### PR TITLE
Make octree evaluation bounds configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,6 +818,7 @@ dependencies = [
  "dynasmrt",
  "getrandom",
  "ieee754",
+ "lazy_static",
  "libc",
  "nalgebra",
  "num-derive",

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -250,6 +250,7 @@ fn run_mesh<S: fidget::eval::Shape>(
             threads: settings.threads,
             min_depth: settings.depth,
             max_depth: settings.max_depth.unwrap_or(settings.depth),
+            bounds: fidget::mesh::CellBounds::default(),
         };
         let octree = fidget::mesh::Octree::build(&shape, settings);
         mesh = octree.walk_dual(settings);

--- a/fidget/Cargo.toml
+++ b/fidget/Cargo.toml
@@ -67,6 +67,7 @@ write-xor-execute = []
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
+lazy_static = "1.4.0"
 
 [[bench]]
 name = "render"

--- a/fidget/benches/mesh.rs
+++ b/fidget/benches/mesh.rs
@@ -18,6 +18,7 @@ pub fn colonnade_octree_thread_sweep(c: &mut Criterion) {
             min_depth: 6,
             max_depth: 6,
             threads,
+            bounds: fidget::mesh::CellBounds::default(),
         };
         #[cfg(feature = "jit")]
         group.bench_function(BenchmarkId::new("jit", threads), move |b| {
@@ -42,6 +43,7 @@ pub fn colonnade_mesh(c: &mut Criterion) {
         min_depth: 8,
         max_depth: 8,
         threads: 8,
+        bounds: fidget::mesh::CellBounds::default(),
     };
     let octree = &fidget::mesh::Octree::build(shape_vm, cfg);
 

--- a/fidget/src/mesh/cell.rs
+++ b/fidget/src/mesh/cell.rs
@@ -152,17 +152,11 @@ pub struct CellIndex {
     pub bounds: CellBounds,
 }
 
-impl Default for CellIndex {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl CellIndex {
-    pub fn new() -> Self {
+    pub fn new(bounds: CellBounds) -> Self {
         CellIndex {
             index: 0,
-            bounds: CellBounds::default(),
+            bounds,
             depth: 0,
         }
     }
@@ -227,15 +221,15 @@ impl std::ops::Index<Axis> for CellBounds {
 
 impl Default for CellBounds {
     fn default() -> Self {
-        Self::new()
+        let x = Interval::new(-1.0, 1.0);
+        let y = Interval::new(-1.0, 1.0);
+        let z = Interval::new(-1.0, 1.0);
+        Self::new(x, y, z)
     }
 }
 
 impl CellBounds {
-    pub fn new() -> Self {
-        let x = Interval::new(-1.0, 1.0);
-        let y = Interval::new(-1.0, 1.0);
-        let z = Interval::new(-1.0, 1.0);
+    pub fn new(x: Interval, y: Interval, z: Interval) -> Self {
         Self { x, y, z }
     }
 

--- a/fidget/src/mesh/mod.rs
+++ b/fidget/src/mesh/mod.rs
@@ -26,7 +26,12 @@
 //!
 //! let (node, ctx) = fidget::rhai::eval("sphere(0, 0, 0, 0.6).call(x, y, z)")?;
 //! let shape = VmShape::new(&ctx, node)?;
-//! let settings = Settings { threads: 8, min_depth: 4, max_depth: 4 };
+//! let settings = Settings {
+//!     threads: 8,
+//!     min_depth: 4,
+//!     max_depth: 4,
+//!     bounds: Default::default(),
+//! };
 //! let o = Octree::build(&shape, settings);
 //! let mesh = o.walk_dual(settings);
 //!
@@ -51,7 +56,8 @@ mod qef;
 #[doc(hidden)]
 pub mod types;
 
-// Re-export the main Octree type as public
+// Re-export CellBounds and the main Octree type as public
+pub use cell::CellBounds;
 pub use octree::Octree;
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -92,4 +98,7 @@ pub struct Settings {
     ///
     /// This is **much slower**.
     pub max_depth: u8,
+
+    /// Bounds to evaluate the octree in
+    pub bounds: CellBounds,
 }

--- a/fidget/src/mesh/mt/dc.rs
+++ b/fidget/src/mesh/mt/dc.rs
@@ -1,7 +1,7 @@
 //! Multithreaded dual contouring
 use super::pool::{QueuePool, ThreadPool};
 use crate::mesh::{
-    cell::{CellIndex, CellVertex},
+    cell::{CellBounds, CellIndex, CellVertex},
     dc::{dc_cell, dc_edge, dc_face, DcBuilder},
     frame::{Frame, XYZ, YZX, ZXY},
     types::{X, Y, Z},
@@ -52,7 +52,7 @@ pub struct DcWorker<'a> {
 }
 
 impl<'a> DcWorker<'a> {
-    pub fn scheduler(octree: &Octree, threads: u8) -> Mesh {
+    pub fn scheduler(octree: &Octree, threads: u8, bounds: CellBounds) -> Mesh {
         let queues = QueuePool::new(threads as usize);
 
         let map = octree
@@ -73,7 +73,7 @@ impl<'a> DcWorker<'a> {
                 verts: vec![],
             })
             .collect::<Vec<_>>();
-        workers[0].queue.push(Task::Cell(CellIndex::default()));
+        workers[0].queue.push(Task::Cell(CellIndex::new(bounds)));
 
         let pool = &ThreadPool::new(threads as usize);
         let out: Vec<_> = std::thread::scope(|s| {


### PR DESCRIPTION
First of all, thank you for this awesome project!

I noticed that the mesh is currently always evaluated in the region [-1, 1] on all axes. This PR extends the mesh settings to make the evaluation bounds configurable.

Please let me know if I should change anything in the current implementation.
