### PR TITLE
Use const generic for register limits

### DIFF
--- a/fidget/src/core/compiler/lru.rs
+++ b/fidget/src/core/compiler/lru.rs
@@ -16,20 +16,21 @@ struct LruNode {
 ///         ^                       oldest       newest     |
 ///         |-----------------------------------------------|
 /// ```
-pub struct Lru {
-    data: [LruNode; u8::MAX as usize],
+pub struct Lru<const N: usize> {
+    data: [LruNode; N],
     head: u8,
 }
 
-impl Lru {
-    pub fn new(size: u8) -> Self {
+impl<const N: usize> Lru<N> {
+    pub fn new() -> Self {
         let mut out = Self {
-            data: [LruNode::default(); u8::MAX as usize],
+            data: [LruNode::default(); N],
             head: 0,
         };
-        for i in 0..size {
-            out.data[i as usize].next = (i + 1) % size;
-            out.data[i as usize].prev = i.checked_sub(1).unwrap_or(size - 1);
+        for i in 0..N {
+            out.data[i as usize].next = ((i + 1) % N) as u8;
+            out.data[i as usize].prev =
+                (i.checked_sub(1).unwrap_or(N - 1)) as u8;
         }
         out
     }
@@ -81,7 +82,7 @@ mod test {
 
     #[test]
     fn test_tiny_lru() {
-        let mut lru: Lru = Lru::new(2);
+        let mut lru: Lru<2> = Lru::new();
         lru.poke(0);
         assert!(lru.pop() == 1);
         assert!(lru.pop() == 0);
@@ -93,7 +94,7 @@ mod test {
 
     #[test]
     fn test_medium_lru() {
-        let mut lru: Lru = Lru::new(10);
+        let mut lru: Lru<10> = Lru::new();
         lru.poke(0);
         for _ in 0..9 {
             assert!(lru.pop() != 0);

--- a/fidget/src/core/compiler/reg_tape.rs
+++ b/fidget/src/core/compiler/reg_tape.rs
@@ -18,8 +18,8 @@ impl RegTape {
     /// to use [`VmData::simplify`](crate::vm::VmData::simplify), which
     /// simultaneously simplifies **and** performs register allocation in a
     /// single pass.
-    pub fn new(ssa: &SsaTape, reg_limit: u8) -> Self {
-        let mut alloc = RegisterAllocator::new(reg_limit, ssa.len());
+    pub fn new<const N: usize>(ssa: &SsaTape) -> Self {
+        let mut alloc = RegisterAllocator::<N>::new(ssa.len());
         for &op in ssa.iter() {
             alloc.op(op)
         }

--- a/fidget/src/jit/aarch64/float_slice.rs
+++ b/fidget/src/jit/aarch64/float_slice.rs
@@ -96,7 +96,7 @@ impl Assembler for FloatSliceAssembler {
 
     /// Reads from `src_mem` to `dst_reg`
     fn build_load(&mut self, dst_reg: u8, src_mem: u32) {
-        assert!(dst_reg < REGISTER_LIMIT);
+        assert!((dst_reg as usize) < REGISTER_LIMIT);
         let sp_offset = self.0.stack_pos(src_mem);
         assert!(sp_offset < 65536);
         dynasm!(self.0.ops
@@ -106,7 +106,7 @@ impl Assembler for FloatSliceAssembler {
 
     /// Writes from `src_reg` to `dst_mem`
     fn build_store(&mut self, dst_mem: u32, src_reg: u8) {
-        assert!(src_reg < REGISTER_LIMIT);
+        assert!((src_reg as usize) < REGISTER_LIMIT);
         let sp_offset = self.0.stack_pos(dst_mem);
         assert!(sp_offset < 65536);
         dynasm!(self.0.ops

--- a/fidget/src/jit/aarch64/grad_slice.rs
+++ b/fidget/src/jit/aarch64/grad_slice.rs
@@ -98,7 +98,7 @@ impl Assembler for GradSliceAssembler {
 
     /// Reads from `src_mem` to `dst_reg`
     fn build_load(&mut self, dst_reg: u8, src_mem: u32) {
-        assert!(dst_reg < REGISTER_LIMIT);
+        assert!((dst_reg as usize) < REGISTER_LIMIT);
         let sp_offset = self.0.stack_pos(src_mem);
         assert!(sp_offset < 65536);
         dynasm!(self.0.ops
@@ -107,7 +107,7 @@ impl Assembler for GradSliceAssembler {
     }
     /// Writes from `src_reg` to `dst_mem`
     fn build_store(&mut self, dst_mem: u32, src_reg: u8) {
-        assert!(src_reg < REGISTER_LIMIT);
+        assert!((src_reg as usize) < REGISTER_LIMIT);
         let sp_offset = self.0.stack_pos(dst_mem);
         assert!(sp_offset < 65536);
         dynasm!(self.0.ops

--- a/fidget/src/jit/aarch64/interval.rs
+++ b/fidget/src/jit/aarch64/interval.rs
@@ -58,14 +58,14 @@ impl Assembler for IntervalAssembler {
 
     /// Reads from `src_mem` to `dst_reg`
     fn build_load(&mut self, dst_reg: u8, src_mem: u32) {
-        assert!(dst_reg < REGISTER_LIMIT);
+        assert!((dst_reg as usize) < REGISTER_LIMIT);
         let sp_offset = self.0.stack_pos(src_mem);
         assert!(sp_offset <= 32768);
         dynasm!(self.0.ops ; ldr D(reg(dst_reg)), [sp, #(sp_offset)])
     }
     /// Writes from `src_reg` to `dst_mem`
     fn build_store(&mut self, dst_mem: u32, src_reg: u8) {
-        assert!(src_reg < REGISTER_LIMIT);
+        assert!((src_reg as usize) < REGISTER_LIMIT);
         let sp_offset = self.0.stack_pos(dst_mem);
         assert!(sp_offset <= 32768);
         dynasm!(self.0.ops ; str D(reg(src_reg)), [sp, #(sp_offset)])

--- a/fidget/src/jit/aarch64/mod.rs
+++ b/fidget/src/jit/aarch64/mod.rs
@@ -19,7 +19,7 @@
 //! choices; they are caller-saved, so we can trash them at will.
 
 /// We can use registers `v8-15` (callee saved) and `v16-31` (caller saved)
-pub const REGISTER_LIMIT: u8 = 24;
+pub const REGISTER_LIMIT: usize = 24;
 /// `v3` is used for immediates, because `v0-2` contain inputs
 pub const IMM_REG: u8 = 3;
 /// `v4-7` are used for as temporary variables:w

--- a/fidget/src/jit/aarch64/point.rs
+++ b/fidget/src/jit/aarch64/point.rs
@@ -47,14 +47,14 @@ impl Assembler for PointAssembler {
 
     /// Reads from `src_mem` to `dst_reg`
     fn build_load(&mut self, dst_reg: u8, src_mem: u32) {
-        assert!(dst_reg < REGISTER_LIMIT);
+        assert!((dst_reg as usize) < REGISTER_LIMIT);
         let sp_offset = self.0.stack_pos(src_mem);
         assert!(sp_offset <= 16384);
         dynasm!(self.0.ops ; ldr S(reg(dst_reg)), [sp, #(sp_offset)])
     }
     /// Writes from `src_reg` to `dst_mem`
     fn build_store(&mut self, dst_mem: u32, src_reg: u8) {
-        assert!(src_reg < REGISTER_LIMIT);
+        assert!((src_reg as usize) < REGISTER_LIMIT);
         let sp_offset = self.0.stack_pos(dst_mem);
         assert!(sp_offset <= 16384);
         dynasm!(self.0.ops ; str S(reg(src_reg)), [sp, #(sp_offset)])

--- a/fidget/src/jit/mod.rs
+++ b/fidget/src/jit/mod.rs
@@ -64,7 +64,7 @@ mod x86_64;
 use x86_64 as arch;
 
 /// Number of registers available when executing natively
-const REGISTER_LIMIT: u8 = arch::REGISTER_LIMIT;
+const REGISTER_LIMIT: usize = arch::REGISTER_LIMIT;
 
 /// Offset before the first useable register
 const OFFSET: u8 = arch::OFFSET;
@@ -725,7 +725,7 @@ impl JitShape {
 impl Shape for JitShape {
     type Trace = VmTrace;
     type Storage = VmData<REGISTER_LIMIT>;
-    type Workspace = VmWorkspace;
+    type Workspace = VmWorkspace<REGISTER_LIMIT>;
 
     type TapeStorage = Mmap;
 

--- a/fidget/src/jit/x86_64/float_slice.rs
+++ b/fidget/src/jit/x86_64/float_slice.rs
@@ -68,14 +68,14 @@ impl Assembler for FloatSliceAssembler {
         Self(out)
     }
     fn build_load(&mut self, dst_reg: u8, src_mem: u32) {
-        assert!(dst_reg < REGISTER_LIMIT);
+        assert!((dst_reg as usize) < REGISTER_LIMIT);
         let sp_offset: i32 = self.0.stack_pos(src_mem).try_into().unwrap();
         dynasm!(self.0.ops
             ; vmovups Ry(reg(dst_reg)), [rsp + sp_offset]
         );
     }
     fn build_store(&mut self, dst_mem: u32, src_reg: u8) {
-        assert!(src_reg < REGISTER_LIMIT);
+        assert!((src_reg as usize) < REGISTER_LIMIT);
         let sp_offset: i32 = self.0.stack_pos(dst_mem).try_into().unwrap();
         dynasm!(self.0.ops
             ; vmovups [rsp + sp_offset], Ry(reg(src_reg))

--- a/fidget/src/jit/x86_64/grad_slice.rs
+++ b/fidget/src/jit/x86_64/grad_slice.rs
@@ -78,14 +78,14 @@ impl Assembler for GradSliceAssembler {
         Self(out)
     }
     fn build_load(&mut self, dst_reg: u8, src_mem: u32) {
-        assert!(dst_reg < REGISTER_LIMIT);
+        assert!((dst_reg as usize) < REGISTER_LIMIT);
         let sp_offset: i32 = self.0.stack_pos(src_mem).try_into().unwrap();
         dynasm!(self.0.ops
             ; vmovups Rx(reg(dst_reg)), [rsp + sp_offset]
         );
     }
     fn build_store(&mut self, dst_mem: u32, src_reg: u8) {
-        assert!(src_reg < REGISTER_LIMIT);
+        assert!((src_reg as usize) < REGISTER_LIMIT);
         let sp_offset: i32 = self.0.stack_pos(dst_mem).try_into().unwrap();
         dynasm!(self.0.ops
             ; vmovups [rsp + sp_offset], Rx(reg(src_reg))

--- a/fidget/src/jit/x86_64/interval.rs
+++ b/fidget/src/jit/x86_64/interval.rs
@@ -41,7 +41,7 @@ impl Assembler for IntervalAssembler {
         Self(out)
     }
     fn build_load(&mut self, dst_reg: u8, src_mem: u32) {
-        assert!(dst_reg < REGISTER_LIMIT);
+        assert!((dst_reg as usize) < REGISTER_LIMIT);
         let sp_offset: i32 = self.0.stack_pos(src_mem).try_into().unwrap();
         dynasm!(self.0.ops
             // Pretend that we're a double
@@ -49,7 +49,7 @@ impl Assembler for IntervalAssembler {
         );
     }
     fn build_store(&mut self, dst_mem: u32, src_reg: u8) {
-        assert!(src_reg < REGISTER_LIMIT);
+        assert!((src_reg as usize) < REGISTER_LIMIT);
         let sp_offset: i32 = self.0.stack_pos(dst_mem).try_into().unwrap();
         dynasm!(self.0.ops
             // Pretend that we're a double

--- a/fidget/src/jit/x86_64/mod.rs
+++ b/fidget/src/jit/x86_64/mod.rs
@@ -12,7 +12,7 @@
 //! available.
 
 /// We use `xmm4-16` (all caller-saved) for graph variables
-pub const REGISTER_LIMIT: u8 = 12;
+pub const REGISTER_LIMIT: usize = 12;
 /// `xmm0` is used for immediates
 pub const IMM_REG: u8 = 0;
 /// `xmm1-3` are available for use as temporaries.

--- a/fidget/src/jit/x86_64/point.rs
+++ b/fidget/src/jit/x86_64/point.rs
@@ -40,14 +40,14 @@ impl Assembler for PointAssembler {
     }
 
     fn build_load(&mut self, dst_reg: u8, src_mem: u32) {
-        assert!(dst_reg < REGISTER_LIMIT);
+        assert!((dst_reg as usize) < REGISTER_LIMIT);
         let sp_offset: i32 = self.0.stack_pos(src_mem).try_into().unwrap();
         dynasm!(self.0.ops
             ; vmovss Rx(reg(dst_reg)), [rsp + sp_offset]
         );
     }
     fn build_store(&mut self, dst_mem: u32, src_reg: u8) {
-        assert!(src_reg < REGISTER_LIMIT);
+        assert!((src_reg as usize) < REGISTER_LIMIT);
         let sp_offset: i32 = self.0.stack_pos(dst_mem).try_into().unwrap();
         dynasm!(self.0.ops
             ; vmovss [rsp + sp_offset], Rx(reg(src_reg))


### PR DESCRIPTION
This is a small speedup for VM-based evaluation, oddly enough!

The diff is mostly `u8` -> `usize` plumbing, because we can't cast const generics from one type to the other.
