### PR TITLE
Add sin operation

### DIFF
--- a/fidget/src/core/compiler/alloc.rs
+++ b/fidget/src/core/compiler/alloc.rs
@@ -251,6 +251,7 @@ impl<const N: usize> RegisterAllocator<N> {
             SsaOp::RecipReg(out, arg) => (out, arg, RegOp::RecipReg),
             SsaOp::SqrtReg(out, arg) => (out, arg, RegOp::SqrtReg),
             SsaOp::SquareReg(out, arg) => (out, arg, RegOp::SquareReg),
+            SsaOp::SinReg(out, arg) => (out, arg, RegOp::SinReg),
             SsaOp::CopyReg(out, arg) => (out, arg, RegOp::CopyReg),
             _ => panic!("Bad opcode: {op:?}"),
         };
@@ -270,7 +271,8 @@ impl<const N: usize> RegisterAllocator<N> {
             | SsaOp::RecipReg(..)
             | SsaOp::SqrtReg(..)
             | SsaOp::SquareReg(..)
-            | SsaOp::CopyReg(..) => self.op_reg(op),
+            | SsaOp::CopyReg(..)
+            | SsaOp::SinReg(..) => self.op_reg(op),
 
             SsaOp::AddRegImm(..)
             | SsaOp::SubRegImm(..)

--- a/fidget/src/core/compiler/op.rs
+++ b/fidget/src/core/compiler/op.rs
@@ -42,6 +42,9 @@ macro_rules! opcodes {
             #[doc = "Square the given register"]
             SquareReg($t, $t),
 
+            #[doc = "Computes the sine of the given register (in radians)"]
+            SinReg($t, $t),
+
             #[doc = "Copies the given register"]
             CopyReg($t, $t),
 
@@ -114,6 +117,7 @@ impl SsaOp {
             | SsaOp::SqrtReg(out, ..)
             | SsaOp::SquareReg(out, ..)
             | SsaOp::CopyReg(out, ..)
+            | SsaOp::SinReg(out, ..)
             | SsaOp::AddRegImm(out, ..)
             | SsaOp::MulRegImm(out, ..)
             | SsaOp::DivRegImm(out, ..)
@@ -142,6 +146,7 @@ impl SsaOp {
             | SsaOp::SqrtReg(..)
             | SsaOp::SquareReg(..)
             | SsaOp::CopyReg(..)
+            | SsaOp::SinReg(..)
             | SsaOp::AddRegImm(..)
             | SsaOp::MulRegImm(..)
             | SsaOp::SubRegImm(..)

--- a/fidget/src/core/compiler/ssa_tape.rs
+++ b/fidget/src/core/compiler/ssa_tape.rs
@@ -193,6 +193,7 @@ impl SsaTape {
                         UnaryOpcode::Recip => SsaOp::RecipReg,
                         UnaryOpcode::Sqrt => SsaOp::SqrtReg,
                         UnaryOpcode::Square => SsaOp::SquareReg,
+                        UnaryOpcode::Sin => SsaOp::SinReg,
                     };
                     op(i, lhs)
                 }
@@ -251,13 +252,15 @@ impl SsaTape {
                 | SsaOp::RecipReg(out, arg)
                 | SsaOp::SqrtReg(out, arg)
                 | SsaOp::CopyReg(out, arg)
-                | SsaOp::SquareReg(out, arg) => {
+                | SsaOp::SquareReg(out, arg)
+                | SsaOp::SinReg(out, arg) => {
                     let op = match op {
                         SsaOp::NegReg(..) => "NEG",
                         SsaOp::AbsReg(..) => "ABS",
                         SsaOp::RecipReg(..) => "RECIP",
                         SsaOp::SqrtReg(..) => "SQRT",
                         SsaOp::SquareReg(..) => "SQUARE",
+                        SsaOp::SinReg(..) => "SIN",
                         SsaOp::CopyReg(..) => "COPY",
                         _ => unreachable!(),
                     };

--- a/fidget/src/core/context/mod.rs
+++ b/fidget/src/core/context/mod.rs
@@ -392,6 +392,19 @@ impl Context {
         self.op_unary(a, UnaryOpcode::Sqrt)
     }
 
+    /// Builds a node which calculates the sine of its input (in radians)
+    /// ```
+    /// # let mut ctx = fidget::context::Context::new();
+    /// let x = ctx.x();
+    /// let op = ctx.sin(x).unwrap();
+    /// let v = ctx.eval_xyz(op, std::f64::consts::PI / 2.0, 0.0, 0.0).unwrap();
+    /// assert_eq!(v, 1.0);
+    /// ```
+    pub fn sin<A: IntoNode>(&mut self, a: A) -> Result<Node, Error> {
+        let a = a.into_node(self)?;
+        self.op_unary(a, UnaryOpcode::Sin)
+    }
+
     ////////////////////////////////////////////////////////////////////////////
     // Derived functions
     /// Builds a node which squares its input
@@ -600,6 +613,7 @@ impl Context {
                     UnaryOpcode::Recip => 1.0 / a,
                     UnaryOpcode::Sqrt => a.sqrt(),
                     UnaryOpcode::Square => a * a,
+                    UnaryOpcode::Sin => a.sin(),
                 }
             }
         };
@@ -713,6 +727,7 @@ impl Context {
                 UnaryOpcode::Recip => out += "recip",
                 UnaryOpcode::Sqrt => out += "sqrt",
                 UnaryOpcode::Square => out += "square",
+                UnaryOpcode::Sin => out += "sin",
             },
         };
         write!(

--- a/fidget/src/core/context/op.rs
+++ b/fidget/src/core/context/op.rs
@@ -10,6 +10,7 @@ pub enum UnaryOpcode {
     Recip,
     Sqrt,
     Square,
+    Sin,
 }
 
 /// A two-argument math operation

--- a/fidget/src/core/eval/test/float_slice.rs
+++ b/fidget/src/core/eval/test/float_slice.rs
@@ -178,6 +178,30 @@ where
             0.5,
         );
     }
+
+    pub fn test_f_sin() {
+        let mut ctx = Context::new();
+        let a = ctx.x();
+        let b = ctx.sin(a).unwrap();
+
+        let shape = S::new(&ctx, b).unwrap();
+        let mut eval = S::new_float_slice_eval();
+        let tape = shape.ez_float_slice_tape();
+        let mut vars = Vars::new(shape.vars());
+
+        let args = [0.0, 1.0, 2.0, std::f32::consts::PI / 2.0];
+        assert_eq!(
+            eval.eval(
+                &tape,
+                &args,
+                &[0.0; 4],
+                &[0.0; 4],
+                vars.bind([("a", 5.0), ("b", 3.0)].into_iter())
+            )
+            .unwrap(),
+            args.map(f32::sin),
+        );
+    }
 }
 
 #[macro_export]
@@ -196,5 +220,6 @@ macro_rules! float_slice_tests {
         $crate::float_slice_test!(test_give_take, $t);
         $crate::float_slice_test!(test_vectorized, $t);
         $crate::float_slice_test!(test_f_var, $t);
+        $crate::float_slice_test!(test_f_sin, $t);
     };
 }

--- a/fidget/src/core/eval/test/float_slice.rs
+++ b/fidget/src/core/eval/test/float_slice.rs
@@ -235,6 +235,27 @@ where
                 depth,
             );
         }
+
+        // Compare against the VmShape evaluator as a baseline.  It's possible
+        // that S is also a VmShape, but this comparison isn't particularly
+        // expensive, so we'll do it regardless.
+        use crate::vm::VmShape;
+        let shape = VmShape::new(&ctx, node).unwrap();
+        let mut eval = VmShape::new_float_slice_eval();
+        let tape = shape.ez_float_slice_tape();
+
+        let cmp = eval.eval(&tape, &x, &y, &z, &[]).unwrap();
+        for (i, (a, b)) in out.iter().zip(cmp.iter()).enumerate() {
+            let err = (a - b).abs();
+            assert!(
+                err < 1e-6,
+                "mismatch at index {i} ({}, {}, {}): {a} != {b} [{err}], {}",
+                x[i],
+                y[i],
+                z[i],
+                depth,
+            );
+        }
     }
 
     pub fn test_f_stress() {

--- a/fidget/src/core/eval/test/float_slice.rs
+++ b/fidget/src/core/eval/test/float_slice.rs
@@ -3,6 +3,7 @@
 //! If the `eval-tests` feature is set, then this exposes a standard test suite
 //! for such evaluators; otherwise, the module has no public exports.
 
+use super::build_stress_fn;
 use crate::{
     context::Context,
     eval::{BulkEvaluator, EzShape, MathShape, Shape, ShapeVars, Vars},
@@ -202,6 +203,45 @@ where
             args.map(f32::sin),
         );
     }
+
+    pub fn test_f_stress_n(depth: usize) {
+        let (ctx, node) = build_stress_fn(depth);
+
+        // Pick an input slice that's guaranteed to be > 1 SIMD register
+        let args = (0..32).map(|i| i as f32 / 32f32).collect::<Vec<f32>>();
+        let x = args.clone();
+        let y: Vec<f32> =
+            args[1..].iter().chain(&args[0..1]).cloned().collect();
+        let z: Vec<f32> =
+            args[2..].iter().chain(&args[0..2]).cloned().collect();
+
+        let shape = S::new(&ctx, node).unwrap();
+        let mut eval = S::new_float_slice_eval();
+        let tape = shape.ez_float_slice_tape();
+
+        let out = eval.eval(&tape, &x, &y, &z, &[]).unwrap();
+
+        for (i, v) in out.iter().cloned().enumerate() {
+            let q = ctx
+                .eval_xyz(node, x[i] as f64, y[i] as f64, z[i] as f64)
+                .unwrap();
+            let err = (v as f64 - q).abs();
+            assert!(
+                err < 1e-2, // generous error bounds, for the 512-op case
+                "mismatch at index {i} ({}, {}, {}): {v} != {q} [{err}], {}",
+                x[i],
+                y[i],
+                z[i],
+                depth,
+            );
+        }
+    }
+
+    pub fn test_f_stress() {
+        for n in [1, 2, 4, 8, 12, 16, 32, 512] {
+            Self::test_f_stress_n(n);
+        }
+    }
 }
 
 #[macro_export]
@@ -221,5 +261,6 @@ macro_rules! float_slice_tests {
         $crate::float_slice_test!(test_vectorized, $t);
         $crate::float_slice_test!(test_f_var, $t);
         $crate::float_slice_test!(test_f_sin, $t);
+        $crate::float_slice_test!(test_f_stress, $t);
     };
 }

--- a/fidget/src/core/eval/test/float_slice.rs
+++ b/fidget/src/core/eval/test/float_slice.rs
@@ -259,7 +259,7 @@ where
     }
 
     pub fn test_f_stress() {
-        for n in [1, 2, 4, 8, 12, 16, 32, 512] {
+        for n in [1, 2, 4, 8, 12, 16, 32] {
             Self::test_f_stress_n(n);
         }
     }

--- a/fidget/src/core/eval/test/grad_slice.rs
+++ b/fidget/src/core/eval/test/grad_slice.rs
@@ -117,6 +117,34 @@ where
         );
     }
 
+    pub fn test_g_sin() {
+        let mut ctx = Context::new();
+        let x = ctx.x();
+        let s = ctx.sin(x).unwrap();
+        let shape = S::new(&ctx, s).unwrap();
+        let tape = shape.ez_grad_slice_tape();
+
+        let mut eval = S::new_grad_slice_eval();
+        let v = eval
+            .eval(&tape, &[1.0, 2.0, 3.0], &[0.0; 3], &[0.0; 3], &[])
+            .unwrap();
+        v[0].compare_eq(Grad::new(1f32.sin(), 1f32.cos(), 0.0, 0.0));
+        v[1].compare_eq(Grad::new(2f32.sin(), 2f32.cos(), 0.0, 0.0));
+        v[2].compare_eq(Grad::new(3f32.sin(), 3f32.cos(), 0.0, 0.0));
+
+        let y = ctx.y();
+        let y = ctx.mul(y, 2.0).unwrap();
+        let s = ctx.sin(y).unwrap();
+        let shape = S::new(&ctx, s).unwrap();
+        let tape = shape.ez_grad_slice_tape();
+        let v = eval
+            .eval(&tape, &[0.0; 3], &[1.0, 2.0, 3.0], &[0.0; 3], &[])
+            .unwrap();
+        v[0].compare_eq(Grad::new(2f32.sin(), 0.0, 2.0 * 2f32.cos(), 0.0));
+        v[1].compare_eq(Grad::new(4f32.sin(), 0.0, 2.0 * 4f32.cos(), 0.0));
+        v[2].compare_eq(Grad::new(6f32.sin(), 0.0, 2.0 * 6f32.cos(), 0.0));
+    }
+
     pub fn test_g_mul() {
         let mut ctx = Context::new();
         let x = ctx.x();
@@ -369,6 +397,7 @@ macro_rules! grad_slice_tests {
         $crate::grad_test!(test_g_abs, $t);
         $crate::grad_test!(test_g_square, $t);
         $crate::grad_test!(test_g_sqrt, $t);
+        $crate::grad_test!(test_g_sin, $t);
         $crate::grad_test!(test_g_mul, $t);
         $crate::grad_test!(test_g_min, $t);
         $crate::grad_test!(test_g_max, $t);

--- a/fidget/src/core/eval/test/grad_slice.rs
+++ b/fidget/src/core/eval/test/grad_slice.rs
@@ -425,7 +425,7 @@ where
     }
 
     pub fn test_g_stress() {
-        for n in [1, 2, 4, 8, 12, 16, 32, 512] {
+        for n in [1, 2, 4, 8, 12, 16, 32] {
             Self::test_g_stress_n(n);
         }
     }

--- a/fidget/src/core/eval/test/interval.rs
+++ b/fidget/src/core/eval/test/interval.rs
@@ -3,9 +3,13 @@
 //! If the `eval-tests` feature is set, then this exposes a standard test suite
 //! for interval evaluators; otherwise, the module has no public exports.
 
+use super::build_stress_fn;
 use crate::{
     context::Context,
-    eval::{EzShape, MathShape, Shape, ShapeVars, TracingEvaluator, Vars},
+    eval::{
+        types::Interval, EzShape, MathShape, Shape, ShapeVars,
+        TracingEvaluator, Vars,
+    },
     vm::Choice,
 };
 
@@ -605,6 +609,52 @@ where
             0.5.into(),
         );
     }
+
+    pub fn test_i_stress_n(depth: usize) {
+        let (ctx, node) = build_stress_fn(depth);
+
+        // Pick an input slice that's guaranteed to be > 1 SIMD register
+        let args = (0..32).map(|i| i as f32 / 32f32).collect::<Vec<f32>>();
+        let x: Vec<_> = args
+            .iter()
+            .zip(args.iter())
+            .map(|(a, b)| Interval::new(*a, *a + *b))
+            .collect();
+        let y: Vec<_> = x[1..].iter().chain(&x[0..1]).cloned().collect();
+        let z: Vec<_> = x[2..].iter().chain(&x[0..2]).cloned().collect();
+
+        let shape = S::new(&ctx, node).unwrap();
+        let mut eval = S::new_interval_eval();
+        let tape = shape.ez_interval_tape();
+
+        let mut out = vec![];
+        for i in 0..args.len() {
+            out.push(eval.eval(&tape, x[i], y[i], z[i], &[]).unwrap().0);
+        }
+
+        // Compare against the VmShape evaluator as a baseline.  It's possible
+        // that S is also a VmShape, but this comparison isn't particularly
+        // expensive, so we'll do it regardless.
+        use crate::vm::VmShape;
+        let shape = VmShape::new(&ctx, node).unwrap();
+        let mut eval = VmShape::new_interval_eval();
+        let tape = shape.ez_interval_tape();
+
+        let mut cmp = vec![];
+        for i in 0..args.len() {
+            cmp.push(eval.eval(&tape, x[i], y[i], z[i], &[]).unwrap().0);
+        }
+
+        for (a, b) in out.iter().zip(cmp.iter()) {
+            a.compare_eq(*b)
+        }
+    }
+
+    pub fn test_i_stress() {
+        for n in [1, 2, 4, 8, 12, 16, 32, 512] {
+            Self::test_i_stress_n(n);
+        }
+    }
 }
 
 #[macro_export]
@@ -638,5 +688,6 @@ macro_rules! interval_tests {
         $crate::interval_test!(test_i_max_imm, $t);
         $crate::interval_test!(test_i_simplify, $t);
         $crate::interval_test!(test_i_var, $t);
+        $crate::interval_test!(test_i_stress, $t);
     };
 }

--- a/fidget/src/core/eval/test/interval.rs
+++ b/fidget/src/core/eval/test/interval.rs
@@ -125,6 +125,26 @@ where
         assert!(v.upper().is_nan());
     }
 
+    pub fn test_i_sin() {
+        let mut ctx = Context::new();
+        let x = ctx.x();
+        let s = ctx.sin(x).unwrap();
+        let shape = S::new(&ctx, s).unwrap();
+        let tape = shape.ez_interval_tape();
+
+        let mut eval = S::new_interval_eval();
+        assert_eq!(eval.eval_x(&tape, [0.0, 1.0]), [-1.0, 1.0].into());
+
+        let y = ctx.y();
+        let y = ctx.mul(y, 2.0).unwrap();
+        let s = ctx.sin(y).unwrap();
+        let s = ctx.add(x, s).unwrap();
+        let shape = S::new(&ctx, s).unwrap();
+        let tape = shape.ez_interval_tape();
+
+        assert_eq!(eval.eval_x(&tape, [0.0, 3.0]), [-1.0, 4.0].into());
+    }
+
     pub fn test_i_neg() {
         let mut ctx = Context::new();
         let x = ctx.x();
@@ -604,6 +624,7 @@ macro_rules! interval_tests {
         $crate::interval_test!(test_i_abs, $t);
         $crate::interval_test!(test_i_sqrt, $t);
         $crate::interval_test!(test_i_square, $t);
+        $crate::interval_test!(test_i_sin, $t);
         $crate::interval_test!(test_i_neg, $t);
         $crate::interval_test!(test_i_mul, $t);
         $crate::interval_test!(test_i_mul_imm, $t);

--- a/fidget/src/core/eval/test/interval.rs
+++ b/fidget/src/core/eval/test/interval.rs
@@ -651,7 +651,7 @@ where
     }
 
     pub fn test_i_stress() {
-        for n in [1, 2, 4, 8, 12, 16, 32, 512] {
+        for n in [1, 2, 4, 8, 12, 16, 32] {
             Self::test_i_stress_n(n);
         }
     }

--- a/fidget/src/core/eval/test/mod.rs
+++ b/fidget/src/core/eval/test/mod.rs
@@ -3,3 +3,33 @@ pub mod float_slice;
 pub mod grad_slice;
 pub mod interval;
 pub mod point;
+
+use crate::context::{Context, Node};
+
+/// Builds a function which stresses the register allocator and function caller
+pub(crate) fn build_stress_fn(n: usize) -> (Context, Node) {
+    let mut inputs = vec![];
+    let mut ctx = Context::new();
+    let mut sum = ctx.constant(0.0);
+    let x = ctx.x();
+    let y = ctx.y();
+    let z = ctx.z();
+
+    // Build up the sum (x * 1) + (y * 2) + (z * 3) + (x * 4) + ...
+    //
+    // We're going to both send these operations into a sin(..) node, then add
+    // them afterwards (in reverse order), meaning their allocations must
+    // persist beyond the sine.
+    for i in 1..=n {
+        let d = ctx.mul(i as f32, [x, y, z][i % 3]).unwrap();
+        inputs.push(d);
+        sum = ctx.add(sum, d).unwrap();
+    }
+
+    sum = ctx.sin(sum).unwrap();
+    for i in inputs.into_iter().rev() {
+        sum = ctx.add(sum, i).unwrap();
+    }
+
+    (ctx, sum)
+}

--- a/fidget/src/core/eval/test/point.rs
+++ b/fidget/src/core/eval/test/point.rs
@@ -379,7 +379,7 @@ where
     }
 
     pub fn test_p_stress() {
-        for n in [1, 2, 4, 8, 12, 16, 32, 512] {
+        for n in [1, 2, 4, 8, 12, 16, 32] {
             Self::test_p_stress_n(n);
         }
     }

--- a/fidget/src/core/eval/test/point.rs
+++ b/fidget/src/core/eval/test/point.rs
@@ -2,6 +2,7 @@
 //!
 //! If the `eval-tests` feature is set, then this exposes a standard test suite
 //! for point evaluators; otherwise, the module has no public exports.
+use super::build_stress_fn;
 use crate::{
     context::Context,
     eval::{EzShape, MathShape, Shape, ShapeVars, TracingEvaluator, Vars},
@@ -325,6 +326,63 @@ where
             0.5
         );
     }
+
+    pub fn test_p_stress_n(depth: usize) {
+        let (ctx, node) = build_stress_fn(depth);
+
+        // Pick an input slice that's guaranteed to be > 1 SIMD register
+        let args = (0..32).map(|i| i as f32 / 32f32).collect::<Vec<f32>>();
+        let x: Vec<_> = args.clone();
+        let y: Vec<_> = x[1..].iter().chain(&x[0..1]).cloned().collect();
+        let z: Vec<_> = x[2..].iter().chain(&x[0..2]).cloned().collect();
+
+        let shape = S::new(&ctx, node).unwrap();
+        let mut eval = S::new_point_eval();
+        let tape = shape.ez_point_tape();
+
+        let mut out = vec![];
+        for i in 0..args.len() {
+            out.push(eval.eval(&tape, x[i], y[i], z[i], &[]).unwrap().0);
+        }
+
+        for (i, v) in out.iter().cloned().enumerate() {
+            let q = ctx
+                .eval_xyz(node, x[i] as f64, y[i] as f64, z[i] as f64)
+                .unwrap();
+            let err = (v as f64 - q).abs();
+            assert!(
+                err < 1e-2, // generous error bounds, for the 512-op case
+                "mismatch at index {i} ({}, {}, {}): {v} != {q} [{err}], {}",
+                x[i],
+                y[i],
+                z[i],
+                depth,
+            );
+        }
+
+        // Compare against the VmShape evaluator as a baseline.  It's possible
+        // that S is also a VmShape, but this comparison isn't particularly
+        // expensive, so we'll do it regardless.
+        use crate::vm::VmShape;
+        let shape = VmShape::new(&ctx, node).unwrap();
+        let mut eval = VmShape::new_point_eval();
+        let tape = shape.ez_point_tape();
+
+        let mut cmp = vec![];
+        for i in 0..args.len() {
+            cmp.push(eval.eval(&tape, x[i], y[i], z[i], &[]).unwrap().0);
+        }
+
+        for (a, b) in out.iter().zip(cmp.iter()) {
+            assert!((a - b).abs() < 1e-6);
+        }
+    }
+
+    pub fn test_p_stress() {
+        for n in [1, 2, 4, 8, 12, 16, 32, 512] {
+            Self::test_p_stress_n(n);
+        }
+    }
 }
 
 #[macro_export]
@@ -350,5 +408,6 @@ macro_rules! point_tests {
         $crate::point_test!(test_push, $t);
         $crate::point_test!(test_var, $t);
         $crate::point_test!(test_basic, $t);
+        $crate::point_test!(test_p_stress, $t);
     };
 }

--- a/fidget/src/core/eval/test/point.rs
+++ b/fidget/src/core/eval/test/point.rs
@@ -127,6 +127,44 @@ where
         assert!(trace.is_none());
     }
 
+    pub fn test_p_sin()
+    where
+        <S as Shape>::Trace: AsRef<[Choice]>,
+    {
+        let mut ctx = Context::new();
+        let x = ctx.x();
+        let s = ctx.sin(x).unwrap();
+
+        let shape = S::new(&ctx, s).unwrap();
+        let tape = shape.ez_point_tape();
+        let mut eval = S::new_point_eval();
+
+        for x in [0.0, 1.0, 2.0] {
+            let (r, trace) = eval.eval(&tape, x, 0.0, 0.0, &[]).unwrap();
+            assert_eq!(r, x.sin());
+            assert!(trace.is_none());
+
+            let (r, trace) = eval.eval(&tape, x, 0.0, 0.0, &[]).unwrap();
+            assert_eq!(r, x.sin());
+            assert!(trace.is_none());
+
+            let (r, trace) = eval.eval(&tape, x, 0.0, 0.0, &[]).unwrap();
+            assert_eq!(r, x.sin());
+            assert!(trace.is_none());
+        }
+
+        let y = ctx.y();
+        let s = ctx.add(s, y).unwrap();
+        let shape = S::new(&ctx, s).unwrap();
+        let tape = shape.ez_point_tape();
+
+        for (x, y) in [(0.0, 1.0), (1.0, 3.0), (2.0, 8.0)] {
+            let (r, trace) = eval.eval(&tape, x, y, 0.0, &[]).unwrap();
+            assert_eq!(r, x.sin() + y);
+            assert!(trace.is_none());
+        }
+    }
+
     pub fn basic_interpreter() {
         let mut ctx = Context::new();
         let x = ctx.x();
@@ -307,6 +345,7 @@ macro_rules! point_tests {
         $crate::point_test!(test_circle, $t);
         $crate::point_test!(test_p_max, $t);
         $crate::point_test!(test_p_min, $t);
+        $crate::point_test!(test_p_sin, $t);
         $crate::point_test!(basic_interpreter, $t);
         $crate::point_test!(test_push, $t);
         $crate::point_test!(test_var, $t);

--- a/fidget/src/core/eval/types.rs
+++ b/fidget/src/core/eval/types.rs
@@ -403,6 +403,17 @@ impl Interval {
     pub fn width(self) -> f32 {
         self.upper - self.lower
     }
+
+    /// Checks that the two values are roughly equal, panicking otherwise
+    #[cfg(test)]
+    pub(crate) fn compare_eq(&self, other: Self) {
+        let d = (self.lower - other.lower)
+            .abs()
+            .max((self.upper - other.upper).abs());
+        if d >= 1e-6 {
+            panic!("lhs != rhs ({self:?} != {other:?})");
+        }
+    }
 }
 
 impl std::fmt::Display for Interval {

--- a/fidget/src/core/eval/types.rs
+++ b/fidget/src/core/eval/types.rs
@@ -61,6 +61,17 @@ impl Grad {
         }
     }
 
+    /// Sine
+    pub fn sin(self) -> Self {
+        let c = self.v.cos();
+        Grad {
+            v: self.v.sin(),
+            dx: self.dx * c,
+            dy: self.dy * c,
+            dz: self.dz * c,
+        }
+    }
+
     /// Reciprocal
     pub fn recip(self) -> Self {
         let v2 = -self.v.powi(2);
@@ -254,6 +265,13 @@ impl Interval {
         } else {
             Interval::new(0.0, self.lower.abs().max(self.upper.abs()).powi(2))
         }
+    }
+    /// Computes the sine of the interval
+    ///
+    /// Right now, this always returns the maximum range of `[-1, 1]`
+    pub fn sin(self) -> Self {
+        // TODO: make this smarter
+        Interval::new(-1.0, 1.0)
     }
     /// Calculates the square root of the interval
     ///

--- a/fidget/src/core/eval/types.rs
+++ b/fidget/src/core/eval/types.rs
@@ -100,6 +100,19 @@ impl Grad {
             rhs
         }
     }
+
+    /// Checks that the two values are roughly equal, panicking otherwise
+    #[cfg(test)]
+    pub(crate) fn compare_eq(&self, other: Self) {
+        let d = (self.v - other.v)
+            .abs()
+            .max((self.dx - other.dx).abs())
+            .max((self.dy - other.dy).abs())
+            .max((self.dz - other.dz).abs());
+        if d >= 1e-6 {
+            panic!("lhs != rhs ({self:?} != {other:?})");
+        }
+    }
 }
 
 impl From<f32> for Grad {

--- a/fidget/src/core/vm/data.rs
+++ b/fidget/src/core/vm/data.rs
@@ -154,7 +154,8 @@ impl<const N: usize> VmData<N> {
                 | SsaOp::AbsReg(index, arg)
                 | SsaOp::RecipReg(index, arg)
                 | SsaOp::SqrtReg(index, arg)
-                | SsaOp::SquareReg(index, arg) => {
+                | SsaOp::SquareReg(index, arg)
+                | SsaOp::SinReg(index, arg) => {
                     *index = new_index;
                     *arg = workspace.get_or_insert_active(*arg);
                 }

--- a/fidget/src/core/vm/mod.rs
+++ b/fidget/src/core/vm/mod.rs
@@ -299,6 +299,9 @@ impl<const N: usize> TracingEvaluator for VmIntervalEval<N> {
                 RegOp::SquareReg(out, arg) => {
                     v[out] = v[arg].square();
                 }
+                RegOp::SinReg(out, arg) => {
+                    v[out] = v[arg].sin();
+                }
                 RegOp::CopyReg(out, arg) => v[out] = v[arg],
                 RegOp::AddRegImm(out, arg, imm) => {
                     v[out] = v[arg] + imm.into();
@@ -422,6 +425,9 @@ impl<const N: usize> TracingEvaluator for VmPointEval<N> {
                 RegOp::SquareReg(out, arg) => {
                     let s = v[arg];
                     v[out] = s * s;
+                }
+                RegOp::SinReg(out, arg) => {
+                    v[out] = v[arg].sin();
                 }
                 RegOp::CopyReg(out, arg) => {
                     v[out] = v[arg];
@@ -643,6 +649,11 @@ impl<const N: usize> BulkEvaluator for VmFloatSliceEval<N> {
                         v[out][i] = s * s;
                     }
                 }
+                RegOp::SinReg(out, arg) => {
+                    for i in 0..size {
+                        v[out][i] = v[arg][i].sin();
+                    }
+                }
                 RegOp::CopyReg(out, arg) => {
                     for i in 0..size {
                         v[out][i] = v[arg][i];
@@ -810,6 +821,11 @@ impl<const N: usize> BulkEvaluator for VmGradSliceEval<N> {
                     for i in 0..size {
                         let s = v[arg][i];
                         v[out][i] = s * s;
+                    }
+                }
+                RegOp::SinReg(out, arg) => {
+                    for i in 0..size {
+                        v[out][i] = v[arg][i].sin();
                     }
                 }
                 RegOp::CopyReg(out, arg) => {

--- a/fidget/src/jit/aarch64/float_slice.rs
+++ b/fidget/src/jit/aarch64/float_slice.rs
@@ -282,20 +282,22 @@ impl FloatSliceAssembler {
             ; mov v4.s[3], v9.s[1]
 
             // Restore register state (lol)
-            ; ldp q30, q31, [sp, #32]!
-            ; ldp q28, q29, [sp, #32]!
-            ; ldp q26, q27, [sp, #32]!
-            ; ldp q24, q25, [sp, #32]!
-            ; ldp q22, q23, [sp, #32]!
-            ; ldp q20, q21, [sp, #32]!
-            ; ldp q18, q19, [sp, #32]!
-            ; ldp q16, q17, [sp, #32]!
-            ; ldp q14, q15, [sp, #32]!
-            ; ldp q12, q13, [sp, #32]!
-            ; ldp q10, q11, [sp, #32]!
-            ; ldp q8, q9, [sp, #32]!
-            ; ldp q2, q3, [sp, #32]!
-            ; ldp q0, q1, [sp, #32]!
+            ; ldp q30, q31, [sp], #32
+            ; ldp q28, q29, [sp], #32
+            ; ldp q26, q27, [sp], #32
+            ; ldp q24, q25, [sp], #32
+            ; ldp q22, q23, [sp], #32
+            ; ldp q20, q21, [sp], #32
+            ; ldp q18, q19, [sp], #32
+            ; ldp q16, q17, [sp], #32
+            ; ldp q14, q15, [sp], #32
+            ; ldp q12, q13, [sp], #32
+            ; ldp q10, q11, [sp], #32
+            ; ldp q8, q9, [sp], #32
+
+            ; ldp q2, q3, [sp], #32
+            ; ldp q0, q1, [sp], #32
+
             ; mov x0, x10
             ; mov x1, x11
             ; mov x2, x12

--- a/fidget/src/jit/aarch64/grad_slice.rs
+++ b/fidget/src/jit/aarch64/grad_slice.rs
@@ -355,20 +355,20 @@ impl GradSliceAssembler {
             ; mov v4.s[3], v3.s[0]
 
             // Restore register state (lol)
-            ; ldp q30, q31, [sp, #32]!
-            ; ldp q28, q29, [sp, #32]!
-            ; ldp q26, q27, [sp, #32]!
-            ; ldp q24, q25, [sp, #32]!
-            ; ldp q22, q23, [sp, #32]!
-            ; ldp q20, q21, [sp, #32]!
-            ; ldp q18, q19, [sp, #32]!
-            ; ldp q16, q17, [sp, #32]!
-            ; ldp q14, q15, [sp, #32]!
-            ; ldp q12, q13, [sp, #32]!
-            ; ldp q10, q11, [sp, #32]!
-            ; ldp q8, q9, [sp, #32]!
-            ; ldp q2, q3, [sp, #32]!
-            ; ldp q0, q1, [sp, #32]!
+            ; ldp q30, q31, [sp], #32
+            ; ldp q28, q29, [sp], #32
+            ; ldp q26, q27, [sp], #32
+            ; ldp q24, q25, [sp], #32
+            ; ldp q22, q23, [sp], #32
+            ; ldp q20, q21, [sp], #32
+            ; ldp q18, q19, [sp], #32
+            ; ldp q16, q17, [sp], #32
+            ; ldp q14, q15, [sp], #32
+            ; ldp q12, q13, [sp], #32
+            ; ldp q10, q11, [sp], #32
+            ; ldp q8, q9, [sp], #32
+            ; ldp q2, q3, [sp], #32
+            ; ldp q0, q1, [sp], #32
             ; mov x0, x10
             ; mov x1, x11
             ; mov x2, x12

--- a/fidget/src/jit/aarch64/grad_slice.rs
+++ b/fidget/src/jit/aarch64/grad_slice.rs
@@ -124,6 +124,12 @@ impl Assembler for GradSliceAssembler {
             ; ldr S(reg(out_reg)), [x3, #(src_arg * 4)]
         );
     }
+    fn build_sin(&mut self, out_reg: u8, lhs_reg: u8) {
+        extern "C" fn grad_sin(v: Grad) -> Grad {
+            v.sin()
+        }
+        self.call_fn_unary(out_reg, lhs_reg, grad_sin);
+    }
     fn build_copy(&mut self, out_reg: u8, lhs_reg: u8) {
         dynasm!(self.0.ops ; mov V(reg(out_reg)).b16, V(reg(lhs_reg)).b16)
     }
@@ -288,5 +294,16 @@ impl Assembler for GradSliceAssembler {
         );
 
         self.0.ops.finalize()
+    }
+}
+
+impl GradSliceAssembler {
+    fn call_fn_unary(
+        &mut self,
+        out_reg: u8,
+        arg_reg: u8,
+        f: extern "C" fn(Grad) -> Grad,
+    ) {
+        unimplemented!()
     }
 }

--- a/fidget/src/jit/aarch64/grad_slice.rs
+++ b/fidget/src/jit/aarch64/grad_slice.rs
@@ -304,6 +304,80 @@ impl GradSliceAssembler {
         arg_reg: u8,
         f: extern "C" fn(Grad) -> Grad,
     ) {
-        unimplemented!()
+        let addr = f as usize;
+        dynasm!(self.0.ops
+            // Back up our current state to caller-saved registers
+            ; mov x10, x0
+            ; mov x11, x1
+            ; mov x12, x2
+            ; mov x13, x3
+            ; mov x14, x4
+            ; mov x15, x5
+
+            // Back up X/Y/Z values
+            ; stp q0, q1, [sp, #-32]!
+            ; stp q2, q3, [sp, #-32]!
+
+            // We use registers v8-v15 (callee saved, but only lower 64 bytes)
+            // and v16-v31 (caller saved)
+            ; stp q8, q9, [sp, #-32]!
+            ; stp q10, q11, [sp, #-32]!
+            ; stp q12, q13, [sp, #-32]!
+            ; stp q14, q15, [sp, #-32]!
+            ; stp q16, q17, [sp, #-32]!
+            ; stp q18, q19, [sp, #-32]!
+            ; stp q20, q21, [sp, #-32]!
+            ; stp q22, q23, [sp, #-32]!
+            ; stp q24, q25, [sp, #-32]!
+            ; stp q26, q27, [sp, #-32]!
+            ; stp q28, q29, [sp, #-32]!
+            ; stp q30, q31, [sp, #-32]!
+
+            // Load the function address, awkwardly, into a caller-saved
+            // register (so we only need to do this once)
+            ; movz x9, #((addr >> 48) as u32), lsl 48
+            ; movk x9, #((addr >> 32) as u32), lsl 32
+            ; movk x9, #((addr >> 16) as u32), lsl 16
+            ; movk x9, #(addr as u32)
+
+            // Prepare to call our stuff!
+            ; mov s0, V(reg(arg_reg)).s[0]
+            ; mov s1, V(reg(arg_reg)).s[1]
+            ; mov s2, V(reg(arg_reg)).s[2]
+            ; mov s3, V(reg(arg_reg)).s[3]
+
+            ; blr x9
+
+            // Copy into v4, because we're about to restore v0/1/2/3
+            ; mov v4.s[0], v0.s[0]
+            ; mov v4.s[1], v1.s[0]
+            ; mov v4.s[2], v2.s[0]
+            ; mov v4.s[3], v3.s[0]
+
+            // Restore register state (lol)
+            ; ldp q30, q31, [sp, #32]!
+            ; ldp q28, q29, [sp, #32]!
+            ; ldp q26, q27, [sp, #32]!
+            ; ldp q24, q25, [sp, #32]!
+            ; ldp q22, q23, [sp, #32]!
+            ; ldp q20, q21, [sp, #32]!
+            ; ldp q18, q19, [sp, #32]!
+            ; ldp q16, q17, [sp, #32]!
+            ; ldp q14, q15, [sp, #32]!
+            ; ldp q12, q13, [sp, #32]!
+            ; ldp q10, q11, [sp, #32]!
+            ; ldp q8, q9, [sp, #32]!
+            ; ldp q2, q3, [sp, #32]!
+            ; ldp q0, q1, [sp, #32]!
+            ; mov x0, x10
+            ; mov x1, x11
+            ; mov x2, x12
+            ; mov x3, x13
+            ; mov x4, x14
+            ; mov x5, x15
+
+            // Set our output value
+            ; mov V(reg(out_reg)).b16, v4.b16
+        );
     }
 }

--- a/fidget/src/jit/aarch64/interval.rs
+++ b/fidget/src/jit/aarch64/interval.rs
@@ -431,6 +431,62 @@ impl IntervalAssembler {
         arg_reg: u8,
         f: extern "C" fn(Interval) -> Interval,
     ) {
-        unimplemented!()
+        let addr = f as usize;
+        dynasm!(self.0.ops
+            // Back up our current state to caller-saved registers
+            ; mov x10, x0
+            ; mov x11, x1
+            ; mov x12, x2
+
+            // Back up X/Y/Z values
+            ; stp d0, d1, [sp, #-16]!
+            ; stp d2, d3, [sp, #-16]!
+
+            // We use registers v8-v15 (callee saved lower 64 bytes, which is
+            // fine for intervals) and v16-v31 (caller saved)
+            ; stp d16, d17, [sp, #-16]!
+            ; stp d18, d19, [sp, #-16]!
+            ; stp d20, d21, [sp, #-16]!
+            ; stp d22, d23, [sp, #-16]!
+            ; stp d24, d25, [sp, #-16]!
+            ; stp d26, d27, [sp, #-16]!
+            ; stp d28, d29, [sp, #-16]!
+            ; stp d30, d31, [sp, #-16]!
+
+            // Load the function address, awkwardly, into a caller-saved
+            // register (so we only need to do this once)
+            ; movz x9, #((addr >> 48) as u32), lsl 48
+            ; movk x9, #((addr >> 32) as u32), lsl 32
+            ; movk x9, #((addr >> 16) as u32), lsl 16
+            ; movk x9, #(addr as u32)
+
+            // Prepare to call our stuff!
+            ; mov s0, V(reg(arg_reg)).s[0]
+            ; mov s1, V(reg(arg_reg)).s[1]
+
+            ; blr x9
+
+            // Copy into v4, because we're about to restore d0/1/2/3
+            ; mov v4.s[0], v0.s[0]
+            ; mov v4.s[1], v1.s[0]
+
+            // Restore register state (lol)
+            ; ldp d30, d31, [sp, #16]!
+            ; ldp d28, d29, [sp, #16]!
+            ; ldp d26, d27, [sp, #16]!
+            ; ldp d24, d25, [sp, #16]!
+            ; ldp d22, d23, [sp, #16]!
+            ; ldp d20, d21, [sp, #16]!
+            ; ldp d18, d19, [sp, #16]!
+            ; ldp d16, d17, [sp, #16]!
+            ; ldp d2, d3, [sp, #16]!
+            ; ldp d0, d1, [sp, #16]!
+            ; mov x0, x10
+            ; mov x1, x11
+            ; mov x2, x12
+
+            // Set our output value
+            ; fmov D(reg(out_reg)), d4
+        );
     }
 }

--- a/fidget/src/jit/aarch64/interval.rs
+++ b/fidget/src/jit/aarch64/interval.rs
@@ -471,16 +471,16 @@ impl IntervalAssembler {
             ; mov v4.s[1], v1.s[0]
 
             // Restore register state (lol)
-            ; ldp d30, d31, [sp, #16]!
-            ; ldp d28, d29, [sp, #16]!
-            ; ldp d26, d27, [sp, #16]!
-            ; ldp d24, d25, [sp, #16]!
-            ; ldp d22, d23, [sp, #16]!
-            ; ldp d20, d21, [sp, #16]!
-            ; ldp d18, d19, [sp, #16]!
-            ; ldp d16, d17, [sp, #16]!
-            ; ldp d2, d3, [sp, #16]!
-            ; ldp d0, d1, [sp, #16]!
+            ; ldp d30, d31, [sp], #16
+            ; ldp d28, d29, [sp], #16
+            ; ldp d26, d27, [sp], #16
+            ; ldp d24, d25, [sp], #16
+            ; ldp d22, d23, [sp], #16
+            ; ldp d20, d21, [sp], #16
+            ; ldp d18, d19, [sp], #16
+            ; ldp d16, d17, [sp], #16
+            ; ldp d2, d3, [sp], #16
+            ; ldp d0, d1, [sp], #16
             ; mov x0, x10
             ; mov x1, x11
             ; mov x2, x12

--- a/fidget/src/jit/aarch64/interval.rs
+++ b/fidget/src/jit/aarch64/interval.rs
@@ -81,6 +81,12 @@ impl Assembler for IntervalAssembler {
             ; dup V(reg(out_reg)).s2, w15
         );
     }
+    fn build_sin(&mut self, out_reg: u8, lhs_reg: u8) {
+        extern "C" fn interval_sin(v: Interval) -> Interval {
+            v.sin()
+        }
+        self.call_fn_unary(out_reg, lhs_reg, interval_sin);
+    }
     fn build_copy(&mut self, out_reg: u8, lhs_reg: u8) {
         dynasm!(self.0.ops ; fmov D(reg(out_reg)), D(reg(lhs_reg)))
     }
@@ -415,5 +421,16 @@ impl Assembler for IntervalAssembler {
         );
 
         self.0.ops.finalize()
+    }
+}
+
+impl IntervalAssembler {
+    fn call_fn_unary(
+        &mut self,
+        out_reg: u8,
+        arg_reg: u8,
+        f: extern "C" fn(Interval) -> Interval,
+    ) {
+        unimplemented!()
     }
 }

--- a/fidget/src/jit/aarch64/point.rs
+++ b/fidget/src/jit/aarch64/point.rs
@@ -219,7 +219,8 @@ impl PointAssembler {
             ; mov x12, x2
 
             // Back up X/Y/Z values
-            ; sub sp, sp, #80 // stack pointer must be 16-byte aligned
+            ; sub sp, sp, #96 // stack pointer must be 16-byte aligned
+            ; stp s8, s9, [sp, #80] // we're overwriting these later
             ; stp s0, s1, [sp, #72]
             ; stp s2, s3, [sp, #64]
 
@@ -249,6 +250,7 @@ impl PointAssembler {
             ; fmov s4, s0
 
             // Restore register state (lol)
+            ; ldp s8, s9, [sp, #80]
             ; ldp s0, s1, [sp, #72]
             ; ldp s2, s3, [sp, #64]
 
@@ -262,7 +264,7 @@ impl PointAssembler {
             ; ldp s26, s27, [sp, #16]
             ; ldp s28, s29, [sp, #8]
             ; ldp s30, s31, [sp, #0]
-            ; add sp, sp, #80
+            ; add sp, sp, #96
 
             ; mov x0, x10
             ; mov x1, x11

--- a/fidget/src/jit/aarch64/point.rs
+++ b/fidget/src/jit/aarch64/point.rs
@@ -72,6 +72,12 @@ impl Assembler for PointAssembler {
     fn build_copy(&mut self, out_reg: u8, lhs_reg: u8) {
         dynasm!(self.0.ops ; fmov S(reg(out_reg)), S(reg(lhs_reg)))
     }
+    fn build_sin(&mut self, out_reg: u8, lhs_reg: u8) {
+        extern "C" fn point_sin(v: f32) -> f32 {
+            v.sin()
+        }
+        self.call_fn_unary(out_reg, lhs_reg, point_sin);
+    }
     fn build_neg(&mut self, out_reg: u8, lhs_reg: u8) {
         dynasm!(self.0.ops ; fneg S(reg(out_reg)), S(reg(lhs_reg)))
     }
@@ -195,5 +201,72 @@ impl Assembler for PointAssembler {
         );
 
         self.0.ops.finalize()
+    }
+}
+
+impl PointAssembler {
+    fn call_fn_unary(
+        &mut self,
+        out_reg: u8,
+        arg_reg: u8,
+        f: extern "C" fn(f32) -> f32,
+    ) {
+        let addr = f as u64;
+        dynasm!(self.0.ops
+            // Back up our current state to caller-saved registers
+            ; mov x10, x0
+            ; mov x11, x1
+            ; mov x12, x2
+
+            // Back up X/Y/Z values
+            ; stp s0, s1, [sp, #-8]!
+            ; stp s2, s3, [sp, #-8]!
+
+            // We use registers v8-v15 (lower 64 bytes are callee saved, so
+            // that's fine) and v16-v31 (caller saved)
+            ; stp s16, s17, [sp, #-8]!
+            ; stp s18, s19, [sp, #-8]!
+            ; stp s20, s21, [sp, #-8]!
+            ; stp s22, s23, [sp, #-8]!
+            ; stp s24, s25, [sp, #-8]!
+            ; stp s26, s27, [sp, #-8]!
+            ; stp s28, s29, [sp, #-8]!
+            ; stp s30, s31, [sp, #-8]!
+
+            // Load the function address, awkwardly, into a caller-saved
+            // register
+            ; movz x9, #((addr >> 48) as u32), lsl 48
+            ; movk x9, #((addr >> 32) as u32), lsl 32
+            ; movk x9, #((addr >> 16) as u32), lsl 16
+            ; movk x9, #(addr as u32)
+
+            // Back up the input argument into s8
+            ; fmov s8, S(reg(arg_reg))
+
+            ; fmov s0, s8
+            ; blr x9
+            ; fmov s4, s0
+
+            // Restore register state (lol)
+            ; ldp s30, s31, [sp, #8]!
+            ; ldp s28, s29, [sp, #8]!
+            ; ldp s26, s27, [sp, #8]!
+            ; ldp s24, s25, [sp, #8]!
+            ; ldp s22, s23, [sp, #8]!
+            ; ldp s20, s21, [sp, #8]!
+            ; ldp s18, s19, [sp, #8]!
+            ; ldp s16, s17, [sp, #8]!
+
+            ; ldp s2, s3, [sp, #8]!
+            ; ldp s0, s1, [sp, #8]!
+
+            ; mov x0, x10
+            ; mov x1, x11
+            ; mov x2, x12
+
+            // Set our output value
+            ; fmov S(reg(out_reg)), s4
+        );
+        unimplemented!()
     }
 }

--- a/fidget/src/jit/mod.rs
+++ b/fidget/src/jit/mod.rs
@@ -147,6 +147,9 @@ trait Assembler {
     /// Square root
     fn build_sqrt(&mut self, out_reg: u8, lhs_reg: u8);
 
+    /// Sine
+    fn build_sin(&mut self, out_reg: u8, lhs_reg: u8);
+
     /// Square
     ///
     /// This has a default implementation, but can be overloaded for efficiency;
@@ -629,6 +632,9 @@ fn build_asm_fn_with_storage<A: Assembler>(
             }
             RegOp::SqrtReg(out, arg) => {
                 asm.build_sqrt(out, arg);
+            }
+            RegOp::SinReg(out, arg) => {
+                asm.build_sin(out, arg);
             }
             RegOp::CopyReg(out, arg) => {
                 asm.build_copy(out, arg);

--- a/fidget/src/jit/mod.rs
+++ b/fidget/src/jit/mod.rs
@@ -306,7 +306,7 @@ struct MmapAssembler {
     global_labels: [Option<AssemblyOffset>; 26],
     local_labels: [Option<AssemblyOffset>; 26],
 
-    global_relocs: arrayvec::ArrayVec<(PatchLoc<Relocation>, u8), 1>,
+    global_relocs: arrayvec::ArrayVec<(PatchLoc<Relocation>, u8), 2>,
     local_relocs: arrayvec::ArrayVec<(PatchLoc<Relocation>, u8), 8>,
 }
 

--- a/fidget/src/jit/x86_64/float_slice.rs
+++ b/fidget/src/jit/x86_64/float_slice.rs
@@ -273,7 +273,7 @@ impl FloatSliceAssembler {
             ; vmovups ymm15, [rsp + 352]
 
             // Get the output value from the stack
-            ; vmovups Rx(reg(out_reg)), [rsp + 416]
+            ; vmovups Ry(reg(out_reg)), [rsp + 416]
             ; add rsp, 456 // oof
 
             // Restore X/Y/Z pointers

--- a/fidget/src/jit/x86_64/float_slice.rs
+++ b/fidget/src/jit/x86_64/float_slice.rs
@@ -233,30 +233,30 @@ impl FloatSliceAssembler {
             // Put the function pointer into a caller-saved register
             ; mov r15, QWORD addr as _
             ; vmovups [rsp + 384], Ry(reg(arg_reg))
-            ; movd Rx(0), [rsp + 384]
+            ; movd xmm0, [rsp + 384]
             ; call r15
-            ; movd [rsp + 416], Rx(0)
-            ; movd Rx(0), [rsp + 388]
+            ; movd [rsp + 416], xmm0
+            ; movd xmm0, [rsp + 388]
             ; call r15
-            ; movd [rsp + 420], Rx(0)
-            ; movd Rx(0), [rsp + 392]
+            ; movd [rsp + 420], xmm0
+            ; movd xmm0, [rsp + 392]
             ; call r15
-            ; movd [rsp + 424], Rx(0)
-            ; movd Rx(0), [rsp + 396]
+            ; movd [rsp + 424], xmm0
+            ; movd xmm0, [rsp + 396]
             ; call r15
-            ; movd [rsp + 428], Rx(0)
-            ; movd Rx(0), [rsp + 400]
+            ; movd [rsp + 428], xmm0
+            ; movd xmm0, [rsp + 400]
             ; call r15
-            ; movd [rsp + 432], Rx(0)
-            ; movd Rx(0), [rsp + 404]
+            ; movd [rsp + 432], xmm0
+            ; movd xmm0, [rsp + 404]
             ; call r15
-            ; movd [rsp + 436], Rx(0)
-            ; movd Rx(0), [rsp + 408]
+            ; movd [rsp + 436], xmm0
+            ; movd xmm0, [rsp + 408]
             ; call r15
-            ; movd [rsp + 440], Rx(0)
-            ; movd Rx(0), [rsp + 412]
+            ; movd [rsp + 440], xmm0
+            ; movd xmm0, [rsp + 412]
             ; call r15
-            ; movd [rsp + 444], Rx(0)
+            ; movd [rsp + 444], xmm0
 
             // Restore float registers
             ; vmovups ymm4, [rsp]

--- a/fidget/src/jit/x86_64/float_slice.rs
+++ b/fidget/src/jit/x86_64/float_slice.rs
@@ -46,20 +46,8 @@ impl Assembler for FloatSliceAssembler {
             ; ->L:
 
             ; test r9, r9
-            ; jnz >B
+            ; jz ->X // jump to the exit if we're done, otherwise fallthrough
 
-            // Finalization code, which happens after all evaluation is complete
-            ; add rsp, out.mem_offset as i32
-            ; pop r15
-            ; pop r14
-            ; pop r13
-            ; pop r12
-            ; pop rbp
-            ; emms
-            ; vzeroall
-            ; ret
-
-            ; B:
             // Copy from the input pointers into the stack right below rbp
             ; vmovups ymm0, [rdi]
             ; vmovups [rbp - 32], ymm0
@@ -191,6 +179,18 @@ impl Assembler for FloatSliceAssembler {
             ; add r8, 32
             ; sub r9, 8
             ; jmp ->L
+
+            // Finalization code, which happens after all evaluation is complete
+            ; ->X:
+            ; add rsp, self.0.mem_offset as i32
+            ; pop r15
+            ; pop r14
+            ; pop r13
+            ; pop r12
+            ; pop rbp
+            ; emms
+            ; vzeroall
+            ; ret
         );
 
         self.0.ops.finalize()

--- a/fidget/src/jit/x86_64/grad_slice.rs
+++ b/fidget/src/jit/x86_64/grad_slice.rs
@@ -39,15 +39,7 @@ impl Assembler for GradSliceAssembler {
             ; ->L:
 
             ; test r9, r9
-            ; jnz >B
-
-            // Finalization code, which happens after all evaluation is complete
-            ; add rsp, out.mem_offset as i32
-            ; pop rbp
-            ; emms
-            ; ret
-
-            ; B: // body of the loop
+            ; jz ->X // jump to the exit if we're done, otherwise fallthrough
 
             // Copy from the input pointers into the stack right below rbp
             ; mov eax, 1.0f32.to_bits() as i32
@@ -312,6 +304,13 @@ impl Assembler for GradSliceAssembler {
             ; add r8, 16 // 4x float
             ; sub r9, 1
             ; jmp ->L
+
+            // Finalization code, which happens after all evaluation is complete
+            ; -> X:
+            ; add rsp, self.0.mem_offset as i32
+            ; pop rbp
+            ; emms
+            ; ret
         );
 
         self.0.ops.finalize()

--- a/fidget/src/jit/x86_64/grad_slice.rs
+++ b/fidget/src/jit/x86_64/grad_slice.rs
@@ -102,6 +102,12 @@ impl Assembler for GradSliceAssembler {
             ; vmovss Rx(reg(out_reg)), [rcx + 4 * (src_arg as i32)]
         );
     }
+    fn build_sin(&mut self, out_reg: u8, lhs_reg: u8) {
+        extern "sysv64" fn grad_sin(v: Grad) -> Grad {
+            v.sin()
+        }
+        self.call_fn_unary(out_reg, lhs_reg, grad_sin);
+    }
     fn build_copy(&mut self, out_reg: u8, lhs_reg: u8) {
         dynasm!(self.0.ops
             ; vmovups Rx(reg(out_reg)), Rx(reg(lhs_reg))
@@ -309,5 +315,16 @@ impl Assembler for GradSliceAssembler {
         );
 
         self.0.ops.finalize()
+    }
+}
+
+impl GradSliceAssembler {
+    fn call_fn_unary(
+        &mut self,
+        out_reg: u8,
+        arg_reg: u8,
+        f: extern "sysv64" fn(Grad) -> Grad,
+    ) {
+        todo!()
     }
 }

--- a/fidget/src/jit/x86_64/interval.rs
+++ b/fidget/src/jit/x86_64/interval.rs
@@ -483,7 +483,7 @@ impl IntervalAssembler {
             ; movsd [rsp + 88], xmm15
 
             // xmm0 = arg.lower
-            ; movss Rx(0), Rx(reg(arg_reg))
+            ; movss xmm0, Rx(reg(arg_reg))
             // xmm1 = arg.upper
             ; vpshufd xmm1, Rx(reg(arg_reg)), 1
             ; mov rdx, QWORD addr as _

--- a/fidget/src/jit/x86_64/interval.rs
+++ b/fidget/src/jit/x86_64/interval.rs
@@ -482,10 +482,8 @@ impl IntervalAssembler {
             ; movsd [rsp + 80], xmm14
             ; movsd [rsp + 88], xmm15
 
-            // xmm0 = arg.lower
-            ; movss xmm0, Rx(reg(arg_reg))
-            // xmm1 = arg.upper
-            ; vpshufd xmm1, Rx(reg(arg_reg)), 1
+            // copy arg to xmm0
+            ; vmovq xmm0, Rx(reg(arg_reg))
             ; mov rdx, QWORD addr as _
             ; call rdx
 
@@ -510,7 +508,7 @@ impl IntervalAssembler {
             ; mov rdx, r14
 
             // Unpack the interval result
-            ; vpunpckldq Rx(reg(out_reg)), xmm0, xmm1
+            ; vmovq Rx(reg(out_reg)), xmm0
         );
     }
 }

--- a/fidget/src/jit/x86_64/point.rs
+++ b/fidget/src/jit/x86_64/point.rs
@@ -20,6 +20,9 @@ use dynasmrt::{dynasm, DynasmApi, DynasmLabelApi};
 /// | `vars`     | `rdi`    | `*const f32` (array)  |
 /// | `choices`  | `rsi`    | `*mut u8` (array)     |
 /// | `simplify` | `rdx`    | `*mut u8` (single)    |
+///
+/// X, Y, and Z are stored on the stack during code execution, to free up those
+/// registers as scratch values.
 impl Assembler for PointAssembler {
     type Data = f32;
 
@@ -236,7 +239,7 @@ impl PointAssembler {
     ) {
         let addr = f as usize;
         dynasm!(self.0.ops
-            // Back up X/Y/Z pointers to registers
+            // Back up X/Y/Z pointers to caller-saved registers
             ; mov r12, rdi
             ; mov r13, rsi
             ; mov r14, rdx
@@ -257,7 +260,7 @@ impl PointAssembler {
             ; movss [rsp + 44], xmm15
 
             // call the function
-            ; movss Rx(0), Rx(reg(arg_reg))
+            ; movss xmm0, Rx(reg(arg_reg))
             ; mov rdx, QWORD addr as _
             ; call rdx
 
@@ -281,7 +284,7 @@ impl PointAssembler {
             ; mov rsi, r13
             ; mov rdx, r14
 
-            ; movss Rx(reg(out_reg)), Rx(0)
+            ; movss Rx(reg(out_reg)), xmm0
         );
     }
 }

--- a/fidget/src/jit/x86_64/point.rs
+++ b/fidget/src/jit/x86_64/point.rs
@@ -27,8 +27,12 @@ impl Assembler for PointAssembler {
         let mut out = AssemblerData::new(mmap);
         dynasm!(out.ops
             ; push rbp
-            ; mov rbp, rsp
+            ; push r12
+            ; push r13
+            ; push r14
+            ; push r15
             ; vzeroupper
+            ; mov rbp, rsp
             // Put X/Y/Z on the stack so we can use those registers
             ; vmovss [rbp - 4], xmm0
             ; vmovss [rbp - 8], xmm1
@@ -67,6 +71,12 @@ impl Assembler for PointAssembler {
         dynasm!(self.0.ops
             ; vmovss Rx(reg(out_reg)), Rx(reg(out_reg)), Rx(reg(lhs_reg))
         );
+    }
+    fn build_sin(&mut self, out_reg: u8, lhs_reg: u8) {
+        extern "sysv64" fn point_sin(v: f32) -> f32 {
+            v.sin()
+        }
+        self.call_fn_unary(out_reg, lhs_reg, point_sin);
     }
     fn build_neg(&mut self, out_reg: u8, lhs_reg: u8) {
         // Flip the sign bit in the float
@@ -205,10 +215,73 @@ impl Assembler for PointAssembler {
             // Prepare our return value
             ; vmovss xmm0, xmm0, Rx(reg(out_reg))
             ; add rsp, self.0.mem_offset as i32
+            ; pop r15
+            ; pop r14
+            ; pop r13
+            ; pop r12
             ; pop rbp
             ; emms
             ; ret
         );
         self.0.ops.finalize()
+    }
+}
+
+impl PointAssembler {
+    fn call_fn_unary(
+        &mut self,
+        out_reg: u8,
+        arg_reg: u8,
+        f: extern "sysv64" fn(f32) -> f32,
+    ) {
+        let addr = f as usize;
+        dynasm!(self.0.ops
+            // Back up X/Y/Z pointers to registers
+            ; mov r12, rdi
+            ; mov r13, rsi
+            ; mov r14, rdx
+
+            // Back up X/Y/Z values to the stack
+            ; sub rsp, 48
+            ; movss [rsp], xmm4
+            ; movss [rsp + 4], xmm5
+            ; movss [rsp + 8], xmm6
+            ; movss [rsp + 12], xmm7
+            ; movss [rsp + 16], xmm8
+            ; movss [rsp + 20], xmm9
+            ; movss [rsp + 24], xmm10
+            ; movss [rsp + 28], xmm11
+            ; movss [rsp + 32], xmm12
+            ; movss [rsp + 36], xmm13
+            ; movss [rsp + 40], xmm14
+            ; movss [rsp + 44], xmm15
+
+            // call the function
+            ; movss Rx(0), Rx(reg(arg_reg))
+            ; mov rdx, QWORD addr as _
+            ; call rdx
+
+            // Restore float registers
+            ; movss xmm4, [rsp]
+            ; movss xmm5, [rsp + 4]
+            ; movss xmm6, [rsp + 8]
+            ; movss xmm7, [rsp + 12]
+            ; movss xmm8, [rsp + 16]
+            ; movss xmm9, [rsp + 20]
+            ; movss xmm10, [rsp + 24]
+            ; movss xmm11, [rsp + 28]
+            ; movss xmm12, [rsp + 32]
+            ; movss xmm13, [rsp + 36]
+            ; movss xmm14, [rsp + 40]
+            ; movss xmm15, [rsp + 44]
+            ; add rsp, 48
+
+            // Restore X/Y/Z pointers
+            ; mov rdi, r12
+            ; mov rsi, r13
+            ; mov rdx, r14
+
+            ; movss Rx(reg(out_reg)), Rx(0)
+        );
     }
 }


### PR DESCRIPTION
This adds the `sin` operation.

More importantly, it adds a generic stub for calling an `extern` function within the JIT assembler, so I don't have to manually hand-write `sinf` in assembly.  This is less efficient (since there's no inlining), but makes adding other trig operations **much** easier.