### PR TITLE
Stack cleanup

### DIFF
--- a/fidget/src/jit/aarch64/float_slice.rs
+++ b/fidget/src/jit/aarch64/float_slice.rs
@@ -32,7 +32,9 @@ pub const SIMD_WIDTH: usize = 4;
 /// | `v3.s4`  | Immediate value (`IMM_REG`)                          |
 /// | `v7.s4`  | Immediate value for recip (1.0)                      |
 /// | `w9`     | Staging for loading immediates                       |
-/// | `w15`    | Staging to load variables
+/// | `w15`    | Staging to load variables                            |
+/// | `x20-25` | Backups for `x0-5` during function calls             |
+/// | `x26`    | Function call address                                |
 ///
 /// The stack is configured as follows
 ///
@@ -112,7 +114,7 @@ impl Assembler for FloatSliceAssembler {
             // calls. We have to use `str` here because we're outside the range
             // for `stp`, sadly
             //
-            // TODO: only do this if we're doing function calls
+            // TODO: only do this if we're doing function calls?
             ; str x20, [sp, 0x200]
             ; str x21, [sp, 0x208]
             ; str x22, [sp, 0x210]
@@ -323,7 +325,8 @@ impl Assembler for FloatSliceAssembler {
             ; ldp   d14, d15, [sp, 0x40]
 
             // Restore callee-saved registers (using `ldr` because we're outside
-            // the range for `ldp`)
+            // the range for `ldp`).  TODO: only do this if the tape contains
+            // function calls?
             ; ldr x20, [sp, 0x200]
             ; ldr x21, [sp, 0x208]
             ; ldr x22, [sp, 0x210]

--- a/fidget/src/jit/aarch64/float_slice.rs
+++ b/fidget/src/jit/aarch64/float_slice.rs
@@ -22,27 +22,105 @@ pub const SIMD_WIDTH: usize = 4;
 /// array contains single `f32` values, which are broadcast into SIMD registers
 /// when they are used.
 ///
-/// During evaluation, X, Y, and Z are stored in `V0-3.S4`
+/// During evaluation, the following registers are used:
+///
+/// | Register | Description                                          |
+/// |----------|------------------------------------------------------|
+/// | `v0.s4`  | X                                                    |
+/// | `v1.s4`  | Y                                                    |
+/// | `v2.s4`  | Z                                                    |
+/// | `v3.s4`  | Immediate value (`IMM_REG`)                          |
+/// | `v7.s4`  | Immediate value for recip (1.0)                      |
+/// | `w9`     | Staging for loading immediates                       |
+/// | `w15`    | Staging to load variables
+///
+/// The stack is configured as follows
+///
+/// ```text
+/// | Position | Value        | Notes                                       |
+/// |----------|--------------|---------------------------------------------|
+/// | 0x238    | ...          | Register spills live up here                |
+/// |----------|--------------|---------------------------------------------|
+/// | 0x230    | `x26`        | Backup for callee-saved register            |
+/// | 0x228    | `x25`        |                                             |
+/// | 0x220    | `x24`        |                                             |
+/// | 0x218    | `x23`        |                                             |
+/// | 0x210    | `x22`        |                                             |
+/// | 0x208    | `x21`        |                                             |
+/// | 0x200    | `x20`        |                                             |
+/// |----------|--------------|---------------------------------------------|
+/// | 0x1f0    | `q2`         | During functions calls, X/Y/Z are saved on  |
+/// | 0x1e0    | `q1`         | the stack                                   |
+/// | 0x1d0    | `q0`         |                                             |
+/// |----------|--------------|---------------------------------------------|
+/// | 0x1c0    | `q31`        | During functions calls, caller-saved tape   |
+/// | 0x1b0    | `q30`        | registers are saved on the stack            |
+/// | 0x1a0    | `q29`        |                                             |
+/// | 0x190    | `q28`        |                                             |
+/// | 0x180    | `q27`        |                                             |
+/// | 0x170    | `q26`        |                                             |
+/// | 0x160    | `q25`        |                                             |
+/// | 0x150    | `q24`        |                                             |
+/// | 0x140    | `q23`        |                                             |
+/// | 0x130    | `q22`        |                                             |
+/// | 0x120    | `q21`        |                                             |
+/// | 0x110    | `q20`        |                                             |
+/// | 0x100    | `q19`        |                                             |
+/// | 0xf0     | `q18`        |                                             |
+/// | 0xe0     | `q17`        |                                             |
+/// | 0xd0     | `q16`        |                                             |
+/// | 0xc0     | `q15`        | We also have to save callee-saved registers |
+/// | 0xb0     | `q14`        | because the callee only saves the lower 64  |
+/// | 0xa0     | `q13`        | bits, and we're using all 128               |
+/// | 0x90     | `q12`        |                                             |
+/// | 0x80     | `q11`        |                                             |
+/// | 0x70     | `q10`        |                                             |
+/// | 0x60     | `q9`         |                                             |
+/// | 0x50     | `q8`         |                                             |
+/// |----------|--------------|---------------------------------------------|
+/// | 0x48     | `d15`        | Callee-saved registers                      |
+/// | 0x40     | `d14`        |                                             |
+/// | 0x38     | `d13`        |                                             |
+/// | 0x30     | `d12`        |                                             |
+/// | 0x28     | `d11`        |                                             |
+/// | 0x20     | `d10`        |                                             |
+/// | 0x18     | `d9`         |                                             |
+/// | 0x10     | `d8`         |                                             |
+/// |----------|--------------|---------------------------------------------|
+/// | 0x8      | `sp` (`x30`) | Stack frame                                 |
+/// | 0x0      | `fp` (`x29`) | [current value for sp]                      |
+/// ```
+const STACK_SIZE: u32 = 0x238;
 impl Assembler for FloatSliceAssembler {
     type Data = f32;
 
     fn init(mmap: Mmap, slot_count: usize) -> Self {
         let mut out = AssemblerData::new(mmap);
+        out.prepare_stack(slot_count, STACK_SIZE as usize);
         dynasm!(out.ops
-            // Preserve frame and link register
-            ; stp   x29, x30, [sp, #-16]!
-            // Preserve sp
+            // Preserve frame and link register, and set up the frame pointer
+            ; stp   x29, x30, [sp, 0x0]
             ; mov   x29, sp
+
             // Preserve callee-saved floating-point registers
-            ; stp   d8, d9, [sp, #-16]!
-            ; stp   d10, d11, [sp, #-16]!
-            ; stp   d12, d13, [sp, #-16]!
-            ; stp   d14, d15, [sp, #-16]!
+            ; stp   d8, d9, [sp, 0x10]
+            ; stp   d10, d11, [sp, 0x20]
+            ; stp   d12, d13, [sp, 0x30]
+            ; stp   d14, d15, [sp, 0x40]
 
-        );
-        out.prepare_stack(slot_count, 0);
+            // Back up a few callee-saved registers that we use for functions
+            // calls. We have to use `str` here because we're outside the range
+            // for `stp`, sadly
+            //
+            // TODO: only do this if we're doing function calls
+            ; str x20, [sp, 0x200]
+            ; str x21, [sp, 0x208]
+            ; str x22, [sp, 0x210]
+            ; str x23, [sp, 0x218]
+            ; str x24, [sp, 0x220]
+            ; str x25, [sp, 0x228]
+            ; str x26, [sp, 0x230]
 
-        dynasm!(out.ops
             // The loop returns here, and we check whether we need to loop
             ; ->L:
             // Remember, at this point we have
@@ -57,22 +135,7 @@ impl Assembler for FloatSliceAssembler {
             // x4 is advanced in finalize().
 
             ; cmp x5, #0
-            ; b.ne #32 // skip to loop body
-
-            // fini:
-            // This is our finalization code, which happens after all evaluation
-            // is complete.
-            //
-            // Restore stack space used for spills
-            ; add   sp, sp, #(out.mem_offset as u32)
-            // Restore callee-saved floating-point registers
-            ; ldp   d14, d15, [sp], #16
-            ; ldp   d12, d13, [sp], #16
-            ; ldp   d10, d11, [sp], #16
-            ; ldp   d8, d9, [sp], #16
-            // Restore frame and link register
-            ; ldp   x29, x30, [sp], #16
-            ; ret
+            ; b.eq ->E
 
             // Loop body:
             //
@@ -96,7 +159,7 @@ impl Assembler for FloatSliceAssembler {
     /// Reads from `src_mem` to `dst_reg`
     fn build_load(&mut self, dst_reg: u8, src_mem: u32) {
         assert!((dst_reg as usize) < REGISTER_LIMIT);
-        let sp_offset = self.0.stack_pos(src_mem);
+        let sp_offset = self.0.stack_pos(src_mem) + STACK_SIZE;
         assert!(sp_offset < 65536);
         dynasm!(self.0.ops
             ; ldr Q(reg(dst_reg)), [sp, #(sp_offset)]
@@ -106,7 +169,7 @@ impl Assembler for FloatSliceAssembler {
     /// Writes from `src_reg` to `dst_mem`
     fn build_store(&mut self, dst_mem: u32, src_reg: u8) {
         assert!((src_reg as usize) < REGISTER_LIMIT);
-        let sp_offset = self.0.stack_pos(dst_mem);
+        let sp_offset = self.0.stack_pos(dst_mem) + STACK_SIZE;
         assert!(sp_offset < 65536);
         dynasm!(self.0.ops
             ; str Q(reg(src_reg)), [sp, #(sp_offset)]
@@ -245,6 +308,33 @@ impl Assembler for FloatSliceAssembler {
             ; mov v0.d[0], V(reg(out_reg)).d[1]
             ; stp D(reg(out_reg)), d0, [x4], #16
             ; b ->L
+
+            ; ->E:
+            // This is our finalization code, which happens after all evaluation
+            // is complete.
+            //
+            // Restore frame and link register
+            ; ldp   x29, x30, [sp, 0x0]
+
+            // Restore callee-saved floating-point registers
+            ; ldp   d8, d9, [sp, 0x10]
+            ; ldp   d10, d11, [sp, 0x20]
+            ; ldp   d12, d13, [sp, 0x30]
+            ; ldp   d14, d15, [sp, 0x40]
+
+            // Restore callee-saved registers (using `ldr` because we're outside
+            // the range for `ldp`)
+            ; ldr x20, [sp, 0x200]
+            ; ldr x21, [sp, 0x208]
+            ; ldr x22, [sp, 0x210]
+            ; ldr x23, [sp, 0x218]
+            ; ldr x24, [sp, 0x220]
+            ; ldr x25, [sp, 0x228]
+            ; ldr x26, [sp, 0x230]
+
+            // Fix up the stack
+            ; add sp, sp, #(self.0.mem_offset as u32)
+            ; ret
         );
 
         self.0.ops.finalize()
@@ -261,89 +351,95 @@ impl FloatSliceAssembler {
         let addr = f as usize;
         dynasm!(self.0.ops
             // Back up our current state
-            // TODO use callee-saved registers instead?
-            ; stp x0, x1, [sp, #-16]!
-            ; stp x2, x3, [sp, #-16]!
-            ; stp x4, x5, [sp, #-16]!
+            ; mov x20, x0
+            ; mov x21, x1
+            ; mov x22, x2
+            ; mov x23, x3
+            ; mov x24, x4
+            ; mov x25, x5
 
             // Back up X/Y/Z values
-            ; stp q0, q1, [sp, #-32]!
-            ; stp q2, q3, [sp, #-32]!
+            ; stp q0, q1, [sp, 0x1d0]
+            ; str q2, [sp, 0x1f0]
 
             // We use registers v8-v15 (callee saved, but only lower 64 bytes)
             // and v16-v31 (caller saved)
-            ; stp q8, q9, [sp, #-32]!
-            ; stp q10, q11, [sp, #-32]!
-            ; stp q12, q13, [sp, #-32]!
-            ; stp q14, q15, [sp, #-32]!
-            ; stp q16, q17, [sp, #-32]!
-            ; stp q18, q19, [sp, #-32]!
-            ; stp q20, q21, [sp, #-32]!
-            ; stp q22, q23, [sp, #-32]!
-            ; stp q24, q25, [sp, #-32]!
-            ; stp q26, q27, [sp, #-32]!
-            ; stp q28, q29, [sp, #-32]!
-            ; stp q30, q31, [sp, #-32]!
+            // TODO: track which registers are actually used?
+            ; stp q8, q9, [sp, 0x50]
+            ; stp q10, q11, [sp, 0x70]
+            ; stp q12, q13, [sp, 0x90]
+            ; stp q14, q15, [sp, 0xb0]
+            ; stp q16, q17, [sp, 0xd0]
+            ; stp q18, q19, [sp, 0xf0]
+            ; stp q20, q21, [sp, 0x110]
+            ; stp q22, q23, [sp, 0x130]
+            ; stp q24, q25, [sp, 0x150]
+            ; stp q26, q27, [sp, 0x170]
+            ; stp q28, q29, [sp, 0x190]
+            ; stp q30, q31, [sp, 0x1b0]
 
-            // Load the function address, awkwardly, into a caller-saved
+            // Load the function address, awkwardly, into a callee-saved
             // register (so we only need to do this once)
-            ; movz x9, #((addr >> 48) as u32), lsl 48
-            ; movk x9, #((addr >> 32) as u32), lsl 32
-            ; movk x9, #((addr >> 16) as u32), lsl 16
-            ; movk x9, #(addr as u32)
+            ; movz x26, #((addr >> 48) as u32), lsl 48
+            ; movk x26, #((addr >> 32) as u32), lsl 32
+            ; movk x26, #((addr >> 16) as u32), lsl 16
+            ; movk x26, #(addr as u32)
 
             // We're going to back up our argument into d8/d9 (since the callee
             // only saves the bottom 64 bits).  Note that d8/d9 may be our input
-            // argument, so we'll move it to v4 first.
-            ; mov v4.b16, V(reg(arg_reg)).b16
-            ; mov d8, v4.d[0]
-            ; mov d9, v4.d[1]
+            // argument, so we'll move it to v0 first.
+            ; mov v0.b16, V(reg(arg_reg)).b16
+            ; mov d8, v0.d[0]
+            ; mov d9, v0.d[1]
 
             ; mov s0, v8.s[0]
-            ; blr x9
+            ; blr x26
             ; mov v8.s[0], v0.s[0]
 
             ; mov s0, v8.s[1]
-            ; blr x9
+            ; blr x26
             ; mov v8.s[1], v0.s[0]
 
             ; mov s0, v9.s[0]
-            ; blr x9
+            ; blr x26
             ; mov v9.s[0], v0.s[0]
 
             ; mov s0, v9.s[1]
-            ; blr x9
+            ; blr x26
             ; mov v9.s[1], v0.s[0]
 
-            // Copy into v4, because we're about to restore v8
-            ; mov v4.s[0], v8.s[0]
-            ; mov v4.s[1], v8.s[1]
-            ; mov v4.s[2], v9.s[0]
-            ; mov v4.s[3], v9.s[1]
+            // Copy into v0, because we're about to restore v8
+            ; mov v0.d[0], v8.d[0]
+            ; mov v0.d[1], v9.d[0]
 
-            // Restore register state (lol)
-            ; ldp q30, q31, [sp], #32
-            ; ldp q28, q29, [sp], #32
-            ; ldp q26, q27, [sp], #32
-            ; ldp q24, q25, [sp], #32
-            ; ldp q22, q23, [sp], #32
-            ; ldp q20, q21, [sp], #32
-            ; ldp q18, q19, [sp], #32
-            ; ldp q16, q17, [sp], #32
-            ; ldp q14, q15, [sp], #32
-            ; ldp q12, q13, [sp], #32
-            ; ldp q10, q11, [sp], #32
-            ; ldp q8, q9, [sp], #32
-
-            ; ldp q2, q3, [sp], #32
-            ; ldp q0, q1, [sp], #32
-
-            ; ldp x4, x5, [sp], #16
-            ; ldp x2, x3, [sp], #16
-            ; ldp x0, x1, [sp], #16
+            // Restore register state
+            ; ldp q8, q9, [sp, 0x50]
+            ; ldp q10, q11, [sp, 0x70]
+            ; ldp q12, q13, [sp, 0x90]
+            ; ldp q14, q15, [sp, 0xb0]
+            ; ldp q16, q17, [sp, 0xd0]
+            ; ldp q18, q19, [sp, 0xf0]
+            ; ldp q20, q21, [sp, 0x110]
+            ; ldp q22, q23, [sp, 0x130]
+            ; ldp q24, q25, [sp, 0x150]
+            ; ldp q26, q27, [sp, 0x170]
+            ; ldp q28, q29, [sp, 0x190]
+            ; ldp q30, q31, [sp, 0x1b0]
 
             // Set our output value
-            ; mov V(reg(out_reg)).b16, v4.b16
+            ; mov V(reg(out_reg)).b16, v0.b16
+
+            // Restore X/Y/Z values
+            ; ldp q0, q1, [sp, 0x1d0]
+            ; ldr q2, [sp, 0x1f0]
+
+            // Restore our current state
+            ; mov x0, x20
+            ; mov x1, x21
+            ; mov x2, x22
+            ; mov x3, x23
+            ; mov x4, x24
+            ; mov x5, x25
         );
     }
 }

--- a/fidget/src/jit/aarch64/float_slice.rs
+++ b/fidget/src/jit/aarch64/float_slice.rs
@@ -93,6 +93,7 @@ pub const SIMD_WIDTH: usize = 4;
 /// | 0x0      | `fp` (`x29`) | [current value for sp]                      |
 /// ```
 const STACK_SIZE: u32 = 0x238;
+
 impl Assembler for FloatSliceAssembler {
     type Data = f32;
 
@@ -136,8 +137,8 @@ impl Assembler for FloatSliceAssembler {
             // We'll be advancing x0, x1, x2 here (and decrementing x5 by 4);
             // x4 is advanced in finalize().
 
-            ; cmp x5, #0
-            ; b.eq ->E
+            ; cmp x5, 0
+            ; b.eq ->E // function exit
 
             // Loop body:
             //
@@ -247,7 +248,7 @@ impl Assembler for FloatSliceAssembler {
     }
     fn build_recip(&mut self, out_reg: u8, lhs_reg: u8) {
         dynasm!(self.0.ops
-            ; fmov s7, #1.0
+            ; fmov s7, 1.0
             ; dup v7.s4, v7.s[0]
             ; fdiv V(reg(out_reg)).s4, v7.s4, V(reg(lhs_reg)).s4
         )

--- a/fidget/src/jit/aarch64/float_slice.rs
+++ b/fidget/src/jit/aarch64/float_slice.rs
@@ -40,7 +40,7 @@ impl Assembler for FloatSliceAssembler {
             ; stp   d14, d15, [sp, #-16]!
 
         );
-        out.prepare_stack(slot_count);
+        out.prepare_stack(slot_count, 0);
 
         dynasm!(out.ops
             // The loop returns here, and we check whether we need to loop

--- a/fidget/src/jit/aarch64/grad_slice.rs
+++ b/fidget/src/jit/aarch64/grad_slice.rs
@@ -23,26 +23,110 @@ use dynasmrt::{dynasm, DynasmApi, DynasmLabelApi};
 ///
 /// During evaluation, X, Y, and Z are stored in `V0-3.S4`.  Each SIMD register
 /// is in the order `[value, dx, dy, dz]`, e.g. the value for X is in `V0.S0`.
+///
+/// In addition to the registers above (`x0-5`), the following extra registers
+/// are used during evaluation:
+///
+/// | Register | Description                                          |
+/// |----------|------------------------------------------------------|
+/// | `v0.s4`  | X                                                    |
+/// | `v1.s4`  | Y                                                    |
+/// | `v2.s4`  | Z                                                    |
+/// | `v3.s4`  | Immediate value (`IMM_REG`)                          |
+/// | `v7.s4`  | Immediate value for recip (1.0)                      |
+/// | `w9`     | Staging for loading immediates                       |
+/// | `w15`    | Staging to load variables                            |
+/// | `x20-25` | Backups for `x0-5` during function calls             |
+/// | `x26`    | Function call address                                |
+///
+/// The stack is configured as follows
+///
+/// ```text
+/// | Position | Value        | Notes                                       |
+/// |----------|--------------|---------------------------------------------|
+/// | 0x238    | ...          | Register spills live up here                |
+/// |----------|--------------|---------------------------------------------|
+/// | 0x230    | `x26`        | Backup for callee-saved register            |
+/// | 0x228    | `x25`        |                                             |
+/// | 0x220    | `x24`        |                                             |
+/// | 0x218    | `x23`        |                                             |
+/// | 0x210    | `x22`        |                                             |
+/// | 0x208    | `x21`        |                                             |
+/// | 0x200    | `x20`        |                                             |
+/// |----------|--------------|---------------------------------------------|
+/// | 0x1f0    | `q2`         | During functions calls, X/Y/Z are saved on  |
+/// | 0x1e0    | `q1`         | the stack                                   |
+/// | 0x1d0    | `q0`         |                                             |
+/// |----------|--------------|---------------------------------------------|
+/// | 0x1c0    | `q31`        | During functions calls, caller-saved tape   |
+/// | 0x1b0    | `q30`        | registers are saved on the stack            |
+/// | 0x1a0    | `q29`        |                                             |
+/// | 0x190    | `q28`        |                                             |
+/// | 0x180    | `q27`        |                                             |
+/// | 0x170    | `q26`        |                                             |
+/// | 0x160    | `q25`        |                                             |
+/// | 0x150    | `q24`        |                                             |
+/// | 0x140    | `q23`        |                                             |
+/// | 0x130    | `q22`        |                                             |
+/// | 0x120    | `q21`        |                                             |
+/// | 0x110    | `q20`        |                                             |
+/// | 0x100    | `q19`        |                                             |
+/// | 0xf0     | `q18`        |                                             |
+/// | 0xe0     | `q17`        |                                             |
+/// | 0xd0     | `q16`        |                                             |
+/// | 0xc0     | `q15`        | We also have to save callee-saved registers |
+/// | 0xb0     | `q14`        | because the callee only saves the lower 64  |
+/// | 0xa0     | `q13`        | bits, and we're using all 128               |
+/// | 0x90     | `q12`        |                                             |
+/// | 0x80     | `q11`        |                                             |
+/// | 0x70     | `q10`        |                                             |
+/// | 0x60     | `q9`         |                                             |
+/// | 0x50     | `q8`         |                                             |
+/// |----------|--------------|---------------------------------------------|
+/// | 0x48     | `d15`        | Callee-saved registers                      |
+/// | 0x40     | `d14`        |                                             |
+/// | 0x38     | `d13`        |                                             |
+/// | 0x30     | `d12`        |                                             |
+/// | 0x28     | `d11`        |                                             |
+/// | 0x20     | `d10`        |                                             |
+/// | 0x18     | `d9`         |                                             |
+/// | 0x10     | `d8`         |                                             |
+/// |----------|--------------|---------------------------------------------|
+/// | 0x8      | `sp` (`x30`) | Stack frame                                 |
+/// | 0x0      | `fp` (`x29`) | [current value for sp]                      |
+/// ```
+const STACK_SIZE: u32 = 0x238;
+
 impl Assembler for GradSliceAssembler {
     type Data = Grad;
 
     fn init(mmap: Mmap, slot_count: usize) -> Self {
         let mut out = AssemblerData::new(mmap);
+        out.prepare_stack(slot_count, STACK_SIZE as usize);
         dynasm!(out.ops
-            // Preserve frame and link register
-            ; stp   x29, x30, [sp, #-16]!
-            // Preserve sp
+            // Preserve frame and link register, and set up the frame pointer
+            ; stp   x29, x30, [sp, 0x0]
             ; mov   x29, sp
 
             // Preserve callee-saved floating-point registers
-            ; stp   d8, d9, [sp, #-16]!
-            ; stp   d10, d11, [sp, #-16]!
-            ; stp   d12, d13, [sp, #-16]!
-            ; stp   d14, d15, [sp, #-16]!
-        );
-        out.prepare_stack(slot_count, 0);
+            ; stp   d8, d9, [sp, 0x10]
+            ; stp   d10, d11, [sp, 0x20]
+            ; stp   d12, d13, [sp, 0x30]
+            ; stp   d14, d15, [sp, 0x40]
 
-        dynasm!(out.ops
+            // Back up a few callee-saved registers that we use for functions
+            // calls. We have to use `str` here because we're outside the range
+            // for `stp`, sadly
+            //
+            // TODO: only do this if we're doing function calls?
+            ; str x20, [sp, 0x200]
+            ; str x21, [sp, 0x208]
+            ; str x22, [sp, 0x210]
+            ; str x23, [sp, 0x218]
+            ; str x24, [sp, 0x220]
+            ; str x25, [sp, 0x228]
+            ; str x26, [sp, 0x230]
+
             // The loop returns here, and we check whether we need to loop
             ; ->L:
             // Remember, at this point we have
@@ -56,38 +140,21 @@ impl Assembler for GradSliceAssembler {
             // We'll be advancing x0, x1, x2 here (and decrementing x5 by 1);
             // x3 is advanced in finalize().
 
-            ; cmp x5, #0
-            ; b.ne #32 // -> jump to loop body
-
-            // fini:
-            // This is our finalization code, which happens after all evaluation
-            // is complete.
-            //
-            // Restore stack space used for spills
-            ; add   sp, sp, #(out.mem_offset as u32)
-
-            // Restore callee-saved floating-point registers
-            ; ldp   d14, d15, [sp], #16
-            ; ldp   d12, d13, [sp], #16
-            ; ldp   d10, d11, [sp], #16
-            ; ldp   d8, d9, [sp], #16
-
-            // Restore frame and link register
-            ; ldp   x29, x30, [sp], #16
-            ; ret
+            ; cmp x5, 0
+            ; b.eq ->E // function exit
 
             // Load V0/1/2.S4 with X/Y/Z values, post-increment
             //
             // We're actually loading two f32s, but we can pretend they're
             // doubles in order to move 64 bits at a time
-            ; fmov s6, #1.0
-            ; ldr s0, [x0], #4
+            ; fmov s6, 1.0
+            ; ldr s0, [x0], 4
             ; mov v0.S[1], v6.S[0]
-            ; ldr s1, [x1], #4
+            ; ldr s1, [x1], 4
             ; mov v1.S[2], v6.S[0]
-            ; ldr s2, [x2], #4
+            ; ldr s2, [x2], 4
             ; mov v2.S[3], v6.S[0]
-            ; sub x5, x5, #1 // We handle 1 item at a time
+            ; sub x5, x5, 1 // We handle 1 item at a time
 
             // Math begins below!
         );
@@ -102,7 +169,7 @@ impl Assembler for GradSliceAssembler {
     /// Reads from `src_mem` to `dst_reg`
     fn build_load(&mut self, dst_reg: u8, src_mem: u32) {
         assert!((dst_reg as usize) < REGISTER_LIMIT);
-        let sp_offset = self.0.stack_pos(src_mem);
+        let sp_offset = self.0.stack_pos(src_mem) + STACK_SIZE;
         assert!(sp_offset < 65536);
         dynasm!(self.0.ops
             ; ldr Q(reg(dst_reg)), [sp, #(sp_offset)]
@@ -111,7 +178,7 @@ impl Assembler for GradSliceAssembler {
     /// Writes from `src_reg` to `dst_mem`
     fn build_store(&mut self, dst_mem: u32, src_reg: u8) {
         assert!((src_reg as usize) < REGISTER_LIMIT);
-        let sp_offset = self.0.stack_pos(dst_mem);
+        let sp_offset = self.0.stack_pos(dst_mem) + STACK_SIZE;
         assert!(sp_offset < 65536);
         dynasm!(self.0.ops
             ; str Q(reg(src_reg)), [sp, #(sp_offset)]
@@ -185,10 +252,10 @@ impl Assembler for GradSliceAssembler {
         // TODO: use two fcsel instead?
         dynasm!(self.0.ops
             ; fcmp S(reg(lhs_reg)), 0.0
-            ; b.lt #12 // -> neg
+            ; b.lt 12 // -> neg
             // Happy path: v >= 0, so we just copy the register
             ; mov V(reg(out_reg)).b16, V(reg(lhs_reg)).b16
-            ; b #8 // -> end
+            ; b 8 // -> end
             // neg:
             ; fneg V(reg(out_reg)).s4, V(reg(lhs_reg)).s4
             // end:
@@ -200,7 +267,7 @@ impl Assembler for GradSliceAssembler {
             ; fneg s6, s6
             ; dup v6.s4, v6.s[0]
             ; fdiv v7.s4, V(reg(lhs_reg)).s4, v6.s4
-            ; fmov s6, #1.0
+            ; fmov s6, 1.0
             ; fdiv s6, s6, S(reg(lhs_reg))
             ; mov V(reg(out_reg)).b16, v7.b16
             ; mov V(reg(out_reg)).s[0], v6.s[0]
@@ -209,7 +276,7 @@ impl Assembler for GradSliceAssembler {
     fn build_sqrt(&mut self, out_reg: u8, lhs_reg: u8) {
         dynasm!(self.0.ops
             ; fsqrt s6, S(reg(lhs_reg))
-            ; fmov s7, #2.0
+            ; fmov s7, 2.0
             ; fmul s7, s6, s7
             ; dup v7.s4, v7.s[0]
             ; fdiv V(reg(out_reg)).s4, V(reg(lhs_reg)).s4, v7.s4
@@ -218,9 +285,9 @@ impl Assembler for GradSliceAssembler {
     }
     fn build_square(&mut self, out_reg: u8, lhs_reg: u8) {
         dynasm!(self.0.ops
-            ; fmov s7, #2.0
+            ; fmov s7, 2.0
             ; dup v7.s4, v7.s[0]
-            ; fmov s6, #1.0
+            ; fmov s6, 1.0
             ; mov v7.S[0], v6.S[0]
             // At this point, v7.s4 is [2.0, 2.0, 2.0, 1.0]
             ; fmov w9, S(reg(lhs_reg))
@@ -298,10 +365,10 @@ impl Assembler for GradSliceAssembler {
     fn build_max(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
         dynasm!(self.0.ops
             ; fcmp S(reg(lhs_reg)), S(reg(rhs_reg))
-            ; b.gt #12 // -> lhs
+            ; b.gt 12 // -> lhs
             // Happy path: v >= 0, so we just copy the register
             ; mov V(reg(out_reg)).b16, V(reg(rhs_reg)).b16
-            ; b #8 // -> end
+            ; b 8 // -> end
             // lhs:
             ; mov V(reg(out_reg)).b16, V(reg(lhs_reg)).b16
             // end:
@@ -310,10 +377,10 @@ impl Assembler for GradSliceAssembler {
     fn build_min(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
         dynasm!(self.0.ops
             ; fcmp S(reg(lhs_reg)), S(reg(rhs_reg))
-            ; b.lt #12 // -> lhs
+            ; b.lt 12 // -> lhs
             // Happy path: v >= 0, so we just copy the register
             ; mov V(reg(out_reg)).b16, V(reg(rhs_reg)).b16
-            ; b #8 // -> end
+            ; b 8 // -> end
             // lhs:
             ; mov V(reg(out_reg)).b16, V(reg(lhs_reg)).b16
             // end:
@@ -334,8 +401,38 @@ impl Assembler for GradSliceAssembler {
     fn finalize(mut self, out_reg: u8) -> Result<Mmap, Error> {
         dynasm!(self.0.ops
             // Prepare our return value, writing to the pointer in x4
-            ; str Q(reg(out_reg)), [x4], #16
+            ; str Q(reg(out_reg)), [x4], 16
             ; b ->L // Jump back to the loop start
+
+            ; ->E:
+            // This is our finalization code, which happens after all evaluation
+            // is complete.
+            //
+            //
+            // Restore frame and link register
+            ; ldp   x29, x30, [sp, 0x0]
+
+            // Restore callee-saved floating-point registers
+            ; ldp   d8, d9, [sp, 0x10]
+            ; ldp   d10, d11, [sp, 0x20]
+            ; ldp   d12, d13, [sp, 0x30]
+            ; ldp   d14, d15, [sp, 0x40]
+
+            // Restore callee-saved registers (using `ldr` because we're outside
+            // the range for `ldp`).  TODO: only do this if the tape contains
+            // function calls?
+            ; ldr x20, [sp, 0x200]
+            ; ldr x21, [sp, 0x208]
+            ; ldr x22, [sp, 0x210]
+            ; ldr x23, [sp, 0x218]
+            ; ldr x24, [sp, 0x220]
+            ; ldr x25, [sp, 0x228]
+            ; ldr x26, [sp, 0x230]
+
+            // Fix up the stack
+            ; add sp, sp, #(self.0.mem_offset as u32)
+            ; ret
+
         );
 
         self.0.ops.finalize()
@@ -352,35 +449,39 @@ impl GradSliceAssembler {
         let addr = f as usize;
         dynasm!(self.0.ops
             // Back up our current state
-            ; stp x0, x1, [sp, #-16]!
-            ; stp x2, x3, [sp, #-16]!
-            ; stp x4, x5, [sp, #-16]!
+            ; mov x20, x0
+            ; mov x21, x1
+            ; mov x22, x2
+            ; mov x23, x3
+            ; mov x24, x4
+            ; mov x25, x5
 
-            // Back up X/Y/Z values
-            ; stp q0, q1, [sp, #-32]!
-            ; stp q2, q3, [sp, #-32]!
+            // Back up X/Y/Z values (TODO use registers here as well?)
+            ; stp q0, q1, [sp, 0x1d0]
+            ; str q2, [sp, 0x1f0]
 
             // We use registers v8-v15 (callee saved, but only lower 64 bytes)
             // and v16-v31 (caller saved)
-            ; stp q8, q9, [sp, #-32]!
-            ; stp q10, q11, [sp, #-32]!
-            ; stp q12, q13, [sp, #-32]!
-            ; stp q14, q15, [sp, #-32]!
-            ; stp q16, q17, [sp, #-32]!
-            ; stp q18, q19, [sp, #-32]!
-            ; stp q20, q21, [sp, #-32]!
-            ; stp q22, q23, [sp, #-32]!
-            ; stp q24, q25, [sp, #-32]!
-            ; stp q26, q27, [sp, #-32]!
-            ; stp q28, q29, [sp, #-32]!
-            ; stp q30, q31, [sp, #-32]!
+            // TODO: track which registers are actually used?
+            ; stp q8, q9, [sp, 0x50]
+            ; stp q10, q11, [sp, 0x70]
+            ; stp q12, q13, [sp, 0x90]
+            ; stp q14, q15, [sp, 0xb0]
+            ; stp q16, q17, [sp, 0xd0]
+            ; stp q18, q19, [sp, 0xf0]
+            ; stp q20, q21, [sp, 0x110]
+            ; stp q22, q23, [sp, 0x130]
+            ; stp q24, q25, [sp, 0x150]
+            ; stp q26, q27, [sp, 0x170]
+            ; stp q28, q29, [sp, 0x190]
+            ; stp q30, q31, [sp, 0x1b0]
 
-            // Load the function address, awkwardly, into a caller-saved
+            // Load the function address, awkwardly, into a callee-saved
             // register (so we only need to do this once)
-            ; movz x9, #((addr >> 48) as u32), lsl 48
-            ; movk x9, #((addr >> 32) as u32), lsl 32
-            ; movk x9, #((addr >> 16) as u32), lsl 16
-            ; movk x9, #(addr as u32)
+            ; movz x26, #((addr >> 48) as u32), lsl 48
+            ; movk x26, #((addr >> 32) as u32), lsl 32
+            ; movk x26, #((addr >> 16) as u32), lsl 16
+            ; movk x26, #(addr as u32)
 
             // Prepare to call our stuff!
             ; mov s0, V(reg(arg_reg)).s[0]
@@ -388,37 +489,39 @@ impl GradSliceAssembler {
             ; mov s2, V(reg(arg_reg)).s[2]
             ; mov s3, V(reg(arg_reg)).s[3]
 
-            ; blr x9
-
-            // Copy into v4, because we're about to restore v0/1/2/3
-            ; mov v4.s[0], v0.s[0]
-            ; mov v4.s[1], v1.s[0]
-            ; mov v4.s[2], v2.s[0]
-            ; mov v4.s[3], v3.s[0]
+            ; blr x26
 
             // Restore register state (lol)
-            ; ldp q30, q31, [sp], #32
-            ; ldp q28, q29, [sp], #32
-            ; ldp q26, q27, [sp], #32
-            ; ldp q24, q25, [sp], #32
-            ; ldp q22, q23, [sp], #32
-            ; ldp q20, q21, [sp], #32
-            ; ldp q18, q19, [sp], #32
-            ; ldp q16, q17, [sp], #32
-            ; ldp q14, q15, [sp], #32
-            ; ldp q12, q13, [sp], #32
-            ; ldp q10, q11, [sp], #32
-            ; ldp q8, q9, [sp], #32
+            ; ldp q8, q9, [sp, 0x50]
+            ; ldp q10, q11, [sp, 0x70]
+            ; ldp q12, q13, [sp, 0x90]
+            ; ldp q14, q15, [sp, 0xb0]
+            ; ldp q16, q17, [sp, 0xd0]
+            ; ldp q18, q19, [sp, 0xf0]
+            ; ldp q20, q21, [sp, 0x110]
+            ; ldp q22, q23, [sp, 0x130]
+            ; ldp q24, q25, [sp, 0x150]
+            ; ldp q26, q27, [sp, 0x170]
+            ; ldp q28, q29, [sp, 0x190]
+            ; ldp q30, q31, [sp, 0x1b0]
 
-            ; ldp q2, q3, [sp], #32
-            ; ldp q0, q1, [sp], #32
+            // Copy into v4, because we're about to restore v0/1/2/3
+            ; mov V(reg(out_reg)).s[0], v0.s[0]
+            ; mov V(reg(out_reg)).s[1], v1.s[0]
+            ; mov V(reg(out_reg)).s[2], v2.s[0]
+            ; mov V(reg(out_reg)).s[3], v3.s[0]
 
-            ; ldp x4, x5, [sp], #16
-            ; ldp x2, x3, [sp], #16
-            ; ldp x0, x1, [sp], #16
+            // Restore X/Y/Z values
+            ; ldp q0, q1, [sp, 0x1d0]
+            ; ldr q2, [sp, 0x1f0]
 
-            // Set our output value
-            ; mov V(reg(out_reg)).b16, v4.b16
+            // Restore our current state
+            ; mov x0, x20
+            ; mov x1, x21
+            ; mov x2, x22
+            ; mov x3, x23
+            ; mov x4, x24
+            ; mov x5, x25
         );
     }
 }

--- a/fidget/src/jit/aarch64/grad_slice.rs
+++ b/fidget/src/jit/aarch64/grad_slice.rs
@@ -40,7 +40,7 @@ impl Assembler for GradSliceAssembler {
             ; stp   d12, d13, [sp, #-16]!
             ; stp   d14, d15, [sp, #-16]!
         );
-        out.prepare_stack(slot_count);
+        out.prepare_stack(slot_count, 0);
 
         dynasm!(out.ops
             // The loop returns here, and we check whether we need to loop

--- a/fidget/src/jit/aarch64/interval.rs
+++ b/fidget/src/jit/aarch64/interval.rs
@@ -99,14 +99,14 @@ impl Assembler for IntervalAssembler {
         out.prepare_stack(slot_count, STACK_SIZE as usize);
         dynasm!(out.ops
             // Preserve frame and link register, and set up the frame pointer
-            ; stp   x29, x30, [sp, #0x0]
+            ; stp   x29, x30, [sp, 0x0]
             ; mov   x29, sp
 
             // Preserve callee-saved floating-point registers
-            ; stp   d8, d9, [sp, #0x10]
-            ; stp   d10, d11, [sp, #0x20]
-            ; stp   d12, d13, [sp, #0x30]
-            ; stp   d14, d15, [sp, #0x40]
+            ; stp   d8, d9, [sp, 0x10]
+            ; stp   d10, d11, [sp, 0x20]
+            ; stp   d12, d13, [sp, 0x30]
+            ; stp   d14, d15, [sp, 0x40]
 
             // Arguments are passed in S0-5; collect them into V0-1
             ; mov v0.s[1], v1.s[0]
@@ -214,11 +214,11 @@ impl Assembler for IntervalAssembler {
             ; fabs V(reg(out_reg)).s2, V(reg(lhs_reg)).s2
 
             // Check whether lhs.upper < 0
-            ; tst x15, #0x1_0000_0000
+            ; tst x15, 0x1_0000_0000
             ; b.ne #24 // -> upper_lz
 
             // Check whether lhs.lower < 0
-            ; tst x15, #0x1
+            ; tst x15, 0x1
 
             // otherwise, we're good; return the original
             ; b.eq #20 // -> end
@@ -273,10 +273,10 @@ impl Assembler for IntervalAssembler {
             ; fmov x15, d4
 
             // Check whether lhs.upper < 0
-            ; tst x15, #0x1_0000_0000
+            ; tst x15, 0x1_0000_0000
             ; b.ne #40 // -> upper_lz
 
-            ; tst x15, #0x1
+            ; tst x15, 0x1
             ; b.ne #12 // -> lower_lz
 
             // Happy path
@@ -306,11 +306,11 @@ impl Assembler for IntervalAssembler {
             ; fmul V(reg(out_reg)).s2, V(reg(lhs_reg)).s2, V(reg(lhs_reg)).s2
 
             // Check whether lhs.upper <= 0.0
-            ; tst x15, #0x1_0000_0000
+            ; tst x15, 0x1_0000_0000
             ; b.ne #28 // -> swap
 
             // Test whether lhs.lower <= 0.0
-            ; tst x15, #0x1
+            ; tst x15, 0x1
             ; b.eq #24 // -> end
 
             // If the input interval straddles 0, then the
@@ -423,10 +423,10 @@ impl Assembler for IntervalAssembler {
             ; fmov x15, d5
             ; ldrb w14, [x1]
 
-            ; tst x15, #0x1_0000_0000
+            ; tst x15, 0x1_0000_0000
             ; b.ne #28 // -> lhs
 
-            ; tst x15, #0x1
+            ; tst x15, 0x1
             ; b.eq #36 // -> both
 
             // LHS < RHS
@@ -472,10 +472,10 @@ impl Assembler for IntervalAssembler {
             ; fmov x15, d5
             ; ldrb w14, [x1]
 
-            ; tst x15, #0x1_0000_0000
+            ; tst x15, 0x1_0000_0000
             ; b.ne #28 // -> rhs
 
-            ; tst x15, #0x1
+            ; tst x15, 0x1
             ; b.eq #36 // -> both
 
             // Fallthrough: LHS < RHS
@@ -515,8 +515,8 @@ impl Assembler for IntervalAssembler {
         if self.0.saved_callee_regs {
             dynasm!(self.0.ops
                 // Restore callee-saved registers
-                ; ldp x20, x21, [sp, #0xe8]
-                ; ldr x22, [sp, #0xf8]
+                ; ldp x20, x21, [sp, 0xe8]
+                ; ldr x22, [sp, 0xf8]
             )
         }
         dynasm!(self.0.ops
@@ -525,13 +525,13 @@ impl Assembler for IntervalAssembler {
             ; mov  s1, V(reg(out_reg)).s[1]
 
             // Restore frame and link register
-            ; ldp   x29, x30, [sp, #0x0]
+            ; ldp   x29, x30, [sp, 0x0]
 
             // Restore callee-saved floating-point registers
-            ; ldp   d8, d9, [sp, #0x10]
-            ; ldp   d10, d11, [sp, #0x20]
-            ; ldp   d12, d13, [sp, #0x30]
-            ; ldp   d14, d15, [sp, #0x40]
+            ; ldp   d8, d9, [sp, 0x10]
+            ; ldp   d10, d11, [sp, 0x20]
+            ; ldp   d12, d13, [sp, 0x30]
+            ; ldp   d14, d15, [sp, 0x40]
 
             // Fix up the stack
             ; add sp, sp, #(self.0.mem_offset as u32)
@@ -553,8 +553,8 @@ impl IntervalAssembler {
         if !self.0.saved_callee_regs {
             dynasm!(self.0.ops
                 // Back up a few callee-saved registers that we're about to use
-                ; stp x20, x21, [sp, #0xe8]
-                ; str x22, [sp, #0xf8]
+                ; stp x20, x21, [sp, 0xe8]
+                ; str x22, [sp, 0xf8]
             );
             self.0.saved_callee_regs = true;
         }
@@ -567,16 +567,16 @@ impl IntervalAssembler {
             ; mov x22, x2
 
             // Back up our state
-            ; stp d16, d17, [sp, #0x50]
-            ; stp d18, d19, [sp, #0x60]
-            ; stp d20, d21, [sp, #0x70]
-            ; stp d22, d23, [sp, #0x80]
-            ; stp d24, d25, [sp, #0x90]
-            ; stp d26, d27, [sp, #0xa0]
-            ; stp d28, d29, [sp, #0xb0]
-            ; stp d30, d31, [sp, #0xc0]
-            ; stp d0, d1, [sp, #0xd0]
-            ; str d2, [sp, #0xe0]
+            ; stp d16, d17, [sp, 0x50]
+            ; stp d18, d19, [sp, 0x60]
+            ; stp d20, d21, [sp, 0x70]
+            ; stp d22, d23, [sp, 0x80]
+            ; stp d24, d25, [sp, 0x90]
+            ; stp d26, d27, [sp, 0xa0]
+            ; stp d28, d29, [sp, 0xb0]
+            ; stp d30, d31, [sp, 0xc0]
+            ; stp d0, d1, [sp, 0xd0]
+            ; str d2, [sp, 0xe0]
 
             // Load the function address, awkwardly, into a caller-saved
             // register (so we only need to do this once)
@@ -592,22 +592,22 @@ impl IntervalAssembler {
             ; blr x0
 
             // Restore floating-point state
-            ; ldp d16, d17, [sp, #0x50]
-            ; ldp d18, d19, [sp, #0x60]
-            ; ldp d20, d21, [sp, #0x70]
-            ; ldp d22, d23, [sp, #0x80]
-            ; ldp d24, d25, [sp, #0x90]
-            ; ldp d26, d27, [sp, #0xa0]
-            ; ldp d28, d29, [sp, #0xb0]
-            ; ldp d30, d31, [sp, #0xc0]
+            ; ldp d16, d17, [sp, 0x50]
+            ; ldp d18, d19, [sp, 0x60]
+            ; ldp d20, d21, [sp, 0x70]
+            ; ldp d22, d23, [sp, 0x80]
+            ; ldp d24, d25, [sp, 0x90]
+            ; ldp d26, d27, [sp, 0xa0]
+            ; ldp d28, d29, [sp, 0xb0]
+            ; ldp d30, d31, [sp, 0xc0]
 
             // Set our output value
             ; mov V(reg(out_reg)).s[0], v0.s[0]
             ; mov V(reg(out_reg)).s[1], v1.s[0]
 
             // Restore X/Y/Z values
-            ; ldp d0, d1, [sp, #0xd0]
-            ; ldr d2, [sp, #0xe0]
+            ; ldp d0, d1, [sp, 0xd0]
+            ; ldr d2, [sp, 0xe0]
 
             // Restore registers
             ; mov x0, x20

--- a/fidget/src/jit/aarch64/point.rs
+++ b/fidget/src/jit/aarch64/point.rs
@@ -91,13 +91,12 @@ impl Assembler for PointAssembler {
 
     fn init(mmap: Mmap, slot_count: usize) -> Self {
         let mut out = AssemblerData::new(mmap);
-        out.prepare_stack(slot_count);
+        out.prepare_stack(slot_count, STACK_SIZE as usize);
         dynasm!(out.ops
-            ; sub sp, sp, #STACK_SIZE
-            // Preserve frame and link register
+            // Preserve frame and link register, and set up the frame pointer
             ; stp   x29, x30, [sp, #0x0]
-            // Set up the frame pointer
             ; mov   x29, sp
+
             // Preserve callee-saved floating-point registers
             ; stp   d8, d9, [sp, #0x10]
             ; stp   d10, d11, [sp, #0x20]
@@ -307,6 +306,7 @@ impl Assembler for PointAssembler {
 
             // Restore frame and link register
             ; ldp   x29, x30, [sp, #0x0]
+
             // Restore callee-saved floating-point registers
             ; ldp   d8, d9, [sp, #0x10]
             ; ldp   d10, d11, [sp, #0x20]
@@ -314,7 +314,7 @@ impl Assembler for PointAssembler {
             ; ldp   d14, d15, [sp, #0x40]
 
             // Fix up the stack
-            ; add sp, sp, #(STACK_SIZE + self.0.mem_offset as u32)
+            ; add sp, sp, #(self.0.mem_offset as u32)
 
             ; ret
         );

--- a/fidget/src/jit/aarch64/point.rs
+++ b/fidget/src/jit/aarch64/point.rs
@@ -190,7 +190,7 @@ impl Assembler for PointAssembler {
     }
     fn build_recip(&mut self, out_reg: u8, lhs_reg: u8) {
         dynasm!(self.0.ops
-            ; fmov s7, #1.0
+            ; fmov s7, 1.0
             ; fdiv S(reg(out_reg)), s7, S(reg(lhs_reg))
         )
     }
@@ -224,56 +224,56 @@ impl Assembler for PointAssembler {
         dynasm!(self.0.ops
             ; ldrb w14, [x1]
             ; fcmp S(reg(lhs_reg)), S(reg(rhs_reg))
-            ; b.mi #20 // -> RHS
-            ; b.gt #32 // -> LHS
+            ; b.mi 20 // -> RHS
+            ; b.gt 32 // -> LHS
 
             // Equal or NaN; do the comparison to collapse NaNs
             ; fmax S(reg(out_reg)), S(reg(lhs_reg)), S(reg(rhs_reg))
             ; orr w14, w14, #CHOICE_BOTH
-            ; b #32 // -> end
+            ; b 32 // -> end
 
             // RHS
             ; fmov S(reg(out_reg)), S(reg(rhs_reg))
             ; orr w14, w14, #CHOICE_RIGHT
-            ; strb w14, [x2, #0] // write a non-zero value to simplify
-            ; b #16
+            ; strb w14, [x2, 0] // write a non-zero value to simplify
+            ; b 16
 
             // LHS
             ; fmov S(reg(out_reg)), S(reg(lhs_reg))
             ; orr w14, w14, #CHOICE_LEFT
-            ; strb w14, [x2, #0] // write a non-zero value to simplify
+            ; strb w14, [x2, 0] // write a non-zero value to simplify
             // fall-through to end
 
             // <- end
-            ; strb w14, [x1], #1 // post-increment
+            ; strb w14, [x1], 1 // post-increment
         )
     }
     fn build_min(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
         dynasm!(self.0.ops
             ; ldrb w14, [x1]
             ; fcmp S(reg(lhs_reg)), S(reg(rhs_reg))
-            ; b.mi #20
-            ; b.gt #32
+            ; b.mi 20
+            ; b.gt 32
 
             // Equal or NaN; do the comparison to collapse NaNs
             ; fmin S(reg(out_reg)), S(reg(lhs_reg)), S(reg(rhs_reg))
             ; orr w14, w14, #CHOICE_BOTH
-            ; b #32 // -> end
+            ; b 32 // -> end
 
             // LHS
             ; fmov S(reg(out_reg)), S(reg(lhs_reg))
             ; orr w14, w14, #CHOICE_LEFT
-            ; strb w14, [x2, #0] // write a non-zero value to simplify
-            ; b #16
+            ; strb w14, [x2, 0] // write a non-zero value to simplify
+            ; b 16
 
             // RHS
             ; fmov S(reg(out_reg)), S(reg(rhs_reg))
             ; orr w14, w14, #CHOICE_RIGHT
-            ; strb w14, [x2, #0]
+            ; strb w14, [x2, 0]
             // fall-through to end
 
             // <- end
-            ; strb w14, [x1], #1 // post-increment
+            ; strb w14, [x1], 1 // post-increment
         )
     }
 

--- a/fidget/src/jit/aarch64/point.rs
+++ b/fidget/src/jit/aarch64/point.rs
@@ -90,14 +90,14 @@ impl Assembler for PointAssembler {
         out.prepare_stack(slot_count, STACK_SIZE as usize);
         dynasm!(out.ops
             // Preserve frame and link register, and set up the frame pointer
-            ; stp   x29, x30, [sp, #0x0]
+            ; stp   x29, x30, [sp, 0x0]
             ; mov   x29, sp
 
             // Preserve callee-saved floating-point registers
-            ; stp   d8, d9, [sp, #0x10]
-            ; stp   d10, d11, [sp, #0x20]
-            ; stp   d12, d13, [sp, #0x30]
-            ; stp   d14, d15, [sp, #0x40]
+            ; stp   d8, d9, [sp, 0x10]
+            ; stp   d10, d11, [sp, 0x20]
+            ; stp   d12, d13, [sp, 0x30]
+            ; stp   d14, d15, [sp, 0x40]
         );
 
         Self(out)
@@ -292,8 +292,8 @@ impl Assembler for PointAssembler {
         if self.0.saved_callee_regs {
             dynasm!(self.0.ops
                 // Restore callee-saved registers
-                ; ldp x20, x21, [sp, #0xa0]
-                ; ldr x22, [sp, #0xb0]
+                ; ldp x20, x21, [sp, 0xa0]
+                ; ldr x22, [sp, 0xb0]
             )
         }
         dynasm!(self.0.ops
@@ -301,13 +301,13 @@ impl Assembler for PointAssembler {
             ; fmov  s0, S(reg(out_reg))
 
             // Restore frame and link register
-            ; ldp   x29, x30, [sp, #0x0]
+            ; ldp   x29, x30, [sp, 0x0]
 
             // Restore callee-saved floating-point registers
-            ; ldp   d8, d9, [sp, #0x10]
-            ; ldp   d10, d11, [sp, #0x20]
-            ; ldp   d12, d13, [sp, #0x30]
-            ; ldp   d14, d15, [sp, #0x40]
+            ; ldp   d8, d9, [sp, 0x10]
+            ; ldp   d10, d11, [sp, 0x20]
+            ; ldp   d12, d13, [sp, 0x30]
+            ; ldp   d14, d15, [sp, 0x40]
 
             // Fix up the stack
             ; add sp, sp, #(self.0.mem_offset as u32)
@@ -329,8 +329,8 @@ impl PointAssembler {
         if !self.0.saved_callee_regs {
             dynasm!(self.0.ops
                 // Back up a few callee-saved registers that we're about to use
-                ; stp x20, x21, [sp, #0xa0]
-                ; str x22, [sp, #0xb0]
+                ; stp x20, x21, [sp, 0xa0]
+                ; str x22, [sp, 0xb0]
             );
             self.0.saved_callee_regs = true;
         }
@@ -343,16 +343,16 @@ impl PointAssembler {
             ; mov x22, x2
 
             // Back up our state
-            ; stp s16, s17, [sp, #0x50]
-            ; stp s18, s19, [sp, #0x58]
-            ; stp s20, s21, [sp, #0x60]
-            ; stp s22, s23, [sp, #0x68]
-            ; stp s24, s25, [sp, #0x70]
-            ; stp s26, s27, [sp, #0x78]
-            ; stp s28, s29, [sp, #0x80]
-            ; stp s30, s31, [sp, #0x88]
-            ; stp s0, s1, [sp, #0x90]
-            ; str s2, [sp, #0x98]
+            ; stp s16, s17, [sp, 0x50]
+            ; stp s18, s19, [sp, 0x58]
+            ; stp s20, s21, [sp, 0x60]
+            ; stp s22, s23, [sp, 0x68]
+            ; stp s24, s25, [sp, 0x70]
+            ; stp s26, s27, [sp, 0x78]
+            ; stp s28, s29, [sp, 0x80]
+            ; stp s30, s31, [sp, 0x88]
+            ; stp s0, s1, [sp, 0x90]
+            ; str s2, [sp, 0x98]
 
             // Load the function address, awkwardly, into x0
             // (since it doesn't matter if it gets trashed)
@@ -365,21 +365,21 @@ impl PointAssembler {
             ; blr x0
 
             // Restore floating-point state
-            ; ldp s16, s17, [sp, #0x50]
-            ; ldp s18, s19, [sp, #0x58]
-            ; ldp s20, s21, [sp, #0x60]
-            ; ldp s22, s23, [sp, #0x68]
-            ; ldp s24, s25, [sp, #0x70]
-            ; ldp s26, s27, [sp, #0x78]
-            ; ldp s28, s29, [sp, #0x80]
-            ; ldp s30, s31, [sp, #0x88]
+            ; ldp s16, s17, [sp, 0x50]
+            ; ldp s18, s19, [sp, 0x58]
+            ; ldp s20, s21, [sp, 0x60]
+            ; ldp s22, s23, [sp, 0x68]
+            ; ldp s24, s25, [sp, 0x70]
+            ; ldp s26, s27, [sp, 0x78]
+            ; ldp s28, s29, [sp, 0x80]
+            ; ldp s30, s31, [sp, 0x88]
 
             // Set our output value
             ; fmov S(reg(out_reg)), s0
 
             // Restore X/Y/Z values
-            ; ldp s0, s1, [sp, #0x90]
-            ; ldr s2, [sp, #0x98]
+            ; ldp s0, s1, [sp, 0x90]
+            ; ldr s2, [sp, 0x98]
 
             // Restore registers
             ; mov x0, x20

--- a/fidget/src/jit/aarch64/point.rs
+++ b/fidget/src/jit/aarch64/point.rs
@@ -41,17 +41,13 @@ use dynasmrt::{dynasm, DynasmApi};
 ///
 /// ```text
 /// | Position | Value        | Notes                                       |
-/// |----------|------------------------------------------------------------|
-/// | 0xc0     | ...          | Register spills live up here                |
 /// |----------|--------------|---------------------------------------------|
-/// | ...      |              | Alignment padding                           |
-/// |----------|------------------------------------------------------------|
 /// | 0xb0     | `x22`        | During functions calls, we use these        |
 /// | 0xa8     | `x21`        | as temporary storage so must preserve their |
 /// | 0xa0     | `x20`        | previous values on the stack                |
 /// |----------|--------------|---------------------------------------------|
 /// | ...      |              | Alignment padding                           |
-/// |----------|------------------------------------------------------------|
+/// |----------|--------------|---------------------------------------------|
 /// | 0x98     | `s2`         | During functions calls, X/Y/Z are saved on  |
 /// | 0x94     | `s1`         | the stack                                   |
 /// | 0x90     | `s0`         |                                             |
@@ -85,7 +81,7 @@ use dynasmrt::{dynasm, DynasmApi};
 /// | 0x8      | `sp` (`x30`) | Stack frame                                 |
 /// | 0x0      | `fp` (`x29`) | [current value for sp]                      |
 /// ```
-const STACK_SIZE: u32 = 0xc0; // nearest multiple of 16 bytes
+const STACK_SIZE: u32 = 0xb8;
 impl Assembler for PointAssembler {
     type Data = f32;
 

--- a/fidget/src/jit/mod.rs
+++ b/fidget/src/jit/mod.rs
@@ -261,6 +261,12 @@ pub(crate) struct AssemblerData<T> {
     /// Current offset of the stack pointer, in bytes
     mem_offset: usize,
 
+    /// Set to true if we have saved certain callee-saved registers
+    ///
+    /// These registers are only modified in function calls, so normally we
+    /// don't save them.
+    saved_callee_regs: bool,
+
     _p: std::marker::PhantomData<*const T>,
 }
 
@@ -269,6 +275,7 @@ impl<T> AssemblerData<T> {
         Self {
             ops: MmapAssembler::from(mmap),
             mem_offset: 0,
+            saved_callee_regs: false,
             _p: std::marker::PhantomData,
         }
     }

--- a/fidget/src/jit/mod.rs
+++ b/fidget/src/jit/mod.rs
@@ -282,12 +282,11 @@ impl<T> AssemblerData<T> {
 
     #[cfg(target_arch = "aarch64")]
     fn prepare_stack(&mut self, slot_count: usize, stack_size: usize) {
-        let mem = if slot_count < REGISTER_LIMIT {
-            stack_size
-        } else {
-            let stack_slots = slot_count - REGISTER_LIMIT;
-            (stack_slots + 1) * std::mem::size_of::<T>() + stack_size
-        };
+        // We always use the stack, if only to store callee-saved registers
+        let mem = slot_count.saturating_sub(REGISTER_LIMIT)
+            * std::mem::size_of::<T>()
+            + stack_size;
+
         // Round up to the nearest multiple of 16 bytes, for alignment
         self.mem_offset = ((mem + 15) / 16) * 16;
         assert!(self.mem_offset < 4096);

--- a/fidget/src/jit/mod.rs
+++ b/fidget/src/jit/mod.rs
@@ -282,16 +282,14 @@ impl<T> AssemblerData<T> {
 
     #[cfg(target_arch = "aarch64")]
     fn prepare_stack(&mut self, slot_count: usize, stack_size: usize) {
-        assert_eq!(stack_size % 16, 0);
-        self.mem_offset = if slot_count < REGISTER_LIMIT {
+        let mem = if slot_count < REGISTER_LIMIT {
             stack_size
         } else {
             let stack_slots = slot_count - REGISTER_LIMIT;
-            let mem = (stack_slots + 1) * std::mem::size_of::<T>();
-
-            // Round up to the nearest multiple of 16 bytes, for alignment
-            ((mem + 15) / 16) * 16 + stack_size
+            (stack_slots + 1) * std::mem::size_of::<T>() + stack_size
         };
+        // Round up to the nearest multiple of 16 bytes, for alignment
+        self.mem_offset = ((mem + 15) / 16) * 16;
         assert!(self.mem_offset < 4096);
         dynasm!(self.ops
             ; sub sp, sp, #(self.mem_offset as u32)

--- a/fidget/src/jit/mod.rs
+++ b/fidget/src/jit/mod.rs
@@ -281,15 +281,17 @@ impl<T> AssemblerData<T> {
     }
 
     #[cfg(target_arch = "aarch64")]
-    fn prepare_stack(&mut self, slot_count: usize) {
-        if slot_count < REGISTER_LIMIT {
-            return;
-        }
-        let stack_slots = slot_count - REGISTER_LIMIT;
-        let mem = (stack_slots + 1) * std::mem::size_of::<T>();
+    fn prepare_stack(&mut self, slot_count: usize, stack_size: usize) {
+        assert_eq!(stack_size % 16, 0);
+        self.mem_offset = if slot_count < REGISTER_LIMIT {
+            stack_size
+        } else {
+            let stack_slots = slot_count - REGISTER_LIMIT;
+            let mem = (stack_slots + 1) * std::mem::size_of::<T>();
 
-        // Round up to the nearest multiple of 16 bytes, for alignment
-        self.mem_offset = ((mem + 15) / 16) * 16;
+            // Round up to the nearest multiple of 16 bytes, for alignment
+            ((mem + 15) / 16) * 16 + stack_size
+        };
         assert!(self.mem_offset < 4096);
         dynasm!(self.ops
             ; sub sp, sp, #(self.mem_offset as u32)

--- a/fidget/src/jit/x86_64/float_slice.rs
+++ b/fidget/src/jit/x86_64/float_slice.rs
@@ -33,14 +33,17 @@ impl Assembler for FloatSliceAssembler {
         let mut out = AssemblerData::new(mmap);
         dynasm!(out.ops
             ; push rbp
-            ; mov rbp, rsp
             ; push r12
             ; push r13
             ; push r14
             ; push r15
+            ; mov rbp, rsp
             ; vzeroupper
         );
-        out.prepare_stack(slot_count, 4);
+        out.prepare_stack(
+            slot_count,
+            4 * std::mem::size_of::<Self::Data>() * SIMD_WIDTH,
+        );
         dynasm!(out.ops
             // The loop returns here, and we check whether to keep looping
             ; ->L:

--- a/fidget/src/jit/x86_64/float_slice.rs
+++ b/fidget/src/jit/x86_64/float_slice.rs
@@ -33,14 +33,14 @@ impl Assembler for FloatSliceAssembler {
         let mut out = AssemblerData::new(mmap);
         dynasm!(out.ops
             ; push rbp
+            ; mov rbp, rsp
             ; push r12
             ; push r13
             ; push r14
             ; push r15
-            ; mov rbp, rsp
             ; vzeroupper
         );
-        out.prepare_stack(slot_count);
+        out.prepare_stack(slot_count, 4);
         dynasm!(out.ops
             // The loop returns here, and we check whether to keep looping
             ; ->L:

--- a/fidget/src/jit/x86_64/grad_slice.rs
+++ b/fidget/src/jit/x86_64/grad_slice.rs
@@ -33,7 +33,7 @@ impl Assembler for GradSliceAssembler {
             ; mov rbp, rsp
             ; vzeroupper
         );
-        out.prepare_stack(slot_count, 4);
+        out.prepare_stack(slot_count, 4 * std::mem::size_of::<Self::Data>());
         dynasm!(out.ops
             // The loop returns here, and we check whether to keep looping
             ; ->L:

--- a/fidget/src/jit/x86_64/grad_slice.rs
+++ b/fidget/src/jit/x86_64/grad_slice.rs
@@ -23,6 +23,43 @@ use dynasmrt::{dynasm, DynasmApi, DynasmLabelApi};
 ///
 /// During evaluation, X, Y, and Z values are stored on the stack to keep
 /// registers unoccupied.
+///
+/// The stack is configured as follows
+///
+/// ```text
+/// | Position | Value        | Notes                                       |
+/// |----------|--------------|---------------------------------------------|
+/// | 0x00     | `rbp`        | Previous value for base pointer             |
+/// |----------|--------------|---------------------------------------------|
+/// | -0x08    | `rdi`        | During functions calls, we use these        |
+/// | -0x10    | `rsi`        | as temporary storage so must preserve their |
+/// | -0x18    | `rdx`        | previous values on the stack                |
+/// | -0x20    | `rcx`        |                                             |
+/// | -0x28    | `r8`         |                                             |
+/// | -0x30    | `r9`         |                                             |
+/// |----------|--------------|---------------------------------------------|
+/// | -0x40    | Z            | Inputs (as 4x floats)                       |
+/// | -0x50    | Y            |                                             |
+/// | -0x60    | X            |                                             |
+/// |----------|--------------|---------------------------------------------|
+/// | ...      | ...          | Register spills live up here                |
+/// |----------|--------------|---------------------------------------------|
+/// | 0xb0     | xmm15        | Caller-saved registers during functions     |
+/// | 0xa0     | xmm14        | calls are placed here, then restored        |
+/// | 0x90     | xmm13        |                                             |
+/// | 0x80     | xmm12        |                                             |
+/// | 0x70     | xmm11        |                                             |
+/// | 0x60     | xmm10        |                                             |
+/// | 0x50     | xmm9         |                                             |
+/// | 0x40     | xmm8         |                                             |
+/// | 0x30     | xmm7         |                                             |
+/// | 0x20     | xmm6         |                                             |
+/// | 0x10     | xmm5         |                                             |
+/// | 0x00     | xmm4         |                                             |
+/// ```
+const STACK_SIZE_UPPER: usize = 0x60; // Positions relative to `rbp`
+const STACK_SIZE_LOWER: usize = 0xc0; // Positions relative to `rsp`
+
 impl Assembler for GradSliceAssembler {
     type Data = Grad;
 
@@ -31,10 +68,24 @@ impl Assembler for GradSliceAssembler {
         dynasm!(out.ops
             ; push rbp
             ; mov rbp, rsp
-            ; vzeroupper
         );
-        out.prepare_stack(slot_count, 4 * std::mem::size_of::<Self::Data>());
+        out.prepare_stack(slot_count, STACK_SIZE_UPPER + STACK_SIZE_LOWER);
+        let input_pos = STACK_SIZE_UPPER as i32;
         dynasm!(out.ops
+            // Preload unchanging gradient values
+            ; mov eax, 1.0f32.to_bits() as i32
+            ; mov [rbp - (input_pos - 0x4)], eax  // d/dx(x) = 1
+            ; mov [rbp - (input_pos - 0x18)], eax // d/dy(y) = 1
+            ; mov [rbp - (input_pos - 0x2c)], eax // d/dz(z) = 1
+
+            ; mov eax, 0.0f32.to_bits() as i32
+            ; mov [rbp - (input_pos - 0x8)], eax // d/dy(x) = 0
+            ; mov [rbp - (input_pos - 0xc)], eax // d/dz(x) = 0
+            ; mov [rbp - (input_pos - 0x14)], eax // d/dx(y) = 0
+            ; mov [rbp - (input_pos - 0x1c)], eax // d/dz(y) = 0
+            ; mov [rbp - (input_pos - 0x24)], eax // d/dz(x) = 0
+            ; mov [rbp - (input_pos - 0x28)], eax // d/dz(y) = 0
+
             // The loop returns here, and we check whether to keep looping
             ; ->L:
 
@@ -42,50 +93,44 @@ impl Assembler for GradSliceAssembler {
             ; jz ->X // jump to the exit if we're done, otherwise fallthrough
 
             // Copy from the input pointers into the stack right below rbp
-            ; mov eax, 1.0f32.to_bits() as i32
-            ; mov [rbp - 12], eax  // 1
-            ; mov [rbp - 24], eax // 1
-            ; mov [rbp - 36], eax // 1
-
             ; mov eax, [rdi]
-            ; mov [rbp - 16], eax  // X
+            ; mov [rbp - input_pos], eax  // X
             ; add rdi, 4
 
             ; mov eax, [rsi]
-            ; mov [rbp - 32], eax // Y
+            ; mov [rbp - (input_pos - 0x10)], eax // Y
             ; add rsi, 4
 
             ; mov eax, [rdx]
-            ; mov [rbp - 48], eax // Z
+            ; mov [rbp - (input_pos - 0x20)], eax // Z
             ; add rdx, 4
-
-            ; mov eax, 0.0f32.to_bits() as i32
-            ; mov [rbp - 8], eax // 0
-            ; mov [rbp - 4], eax // 0
-            ; mov [rbp - 28], eax // 0
-            ; mov [rbp - 20], eax // 0
-            ; mov [rbp - 40], eax // 0
-            ; mov [rbp - 44], eax // 0
         );
         Self(out)
     }
     fn build_load(&mut self, dst_reg: u8, src_mem: u32) {
         assert!((dst_reg as usize) < REGISTER_LIMIT);
-        let sp_offset: i32 = self.0.stack_pos(src_mem).try_into().unwrap();
+        let sp_offset: i32 = (self.0.stack_pos(src_mem)
+            + STACK_SIZE_LOWER as u32)
+            .try_into()
+            .unwrap();
         dynasm!(self.0.ops
             ; vmovups Rx(reg(dst_reg)), [rsp + sp_offset]
         );
     }
     fn build_store(&mut self, dst_mem: u32, src_reg: u8) {
         assert!((src_reg as usize) < REGISTER_LIMIT);
-        let sp_offset: i32 = self.0.stack_pos(dst_mem).try_into().unwrap();
+        let sp_offset: i32 = (self.0.stack_pos(dst_mem)
+            + STACK_SIZE_LOWER as u32)
+            .try_into()
+            .unwrap();
         dynasm!(self.0.ops
             ; vmovups [rsp + sp_offset], Rx(reg(src_reg))
         );
     }
     fn build_input(&mut self, out_reg: u8, src_arg: u8) {
+        let pos = STACK_SIZE_UPPER as i32 - 16 * (src_arg as i32);
         dynasm!(self.0.ops
-            ; vmovups Rx(reg(out_reg)), [rbp - 16 * (src_arg as i32 + 1)]
+            ; vmovups Rx(reg(out_reg)), [rbp - pos]
         );
     }
     fn build_var(&mut self, out_reg: u8, src_arg: u32) {
@@ -368,29 +413,27 @@ impl GradSliceAssembler {
     ) {
         let addr = f as usize;
         dynasm!(self.0.ops
-            // Back up X/Y/Z pointers to caller-saved registers and the stack
-            ; mov r12, rdi
-            ; mov r13, rsi
-            ; mov r14, rdx
-            ; push rcx
-            ; push r8
-            ; push r9
-            ; push r9 // alignment?
+            // Back up X/Y/Z pointers to the stack
+            ; mov [rbp - 0x8], rdi
+            ; mov [rbp - 0x10], rsi
+            ; mov [rbp - 0x18], rdx
+            ; mov [rbp - 0x20], rcx
+            ; mov [rbp - 0x28], r8
+            ; mov [rbp - 0x30], r9
 
-            // Back up register values to the stack
-            ; sub rsp, 192
+            // Back up register values to the stack, saving all 128 bits
             ; vmovups [rsp], xmm4
-            ; vmovups [rsp + 16], xmm5
-            ; vmovups [rsp + 32], xmm6
-            ; vmovups [rsp + 48], xmm7
-            ; vmovups [rsp + 64], xmm8
-            ; vmovups [rsp + 80], xmm9
-            ; vmovups [rsp + 96], xmm10
-            ; vmovups [rsp + 112], xmm11
-            ; vmovups [rsp + 128], xmm12
-            ; vmovups [rsp + 144], xmm13
-            ; vmovups [rsp + 160], xmm14
-            ; vmovups [rsp + 176], xmm15
+            ; vmovups [rsp + 0x10], xmm5
+            ; vmovups [rsp + 0x20], xmm6
+            ; vmovups [rsp + 0x30], xmm7
+            ; vmovups [rsp + 0x40], xmm8
+            ; vmovups [rsp + 0x50], xmm9
+            ; vmovups [rsp + 0x60], xmm10
+            ; vmovups [rsp + 0x70], xmm11
+            ; vmovups [rsp + 0x80], xmm12
+            ; vmovups [rsp + 0x90], xmm13
+            ; vmovups [rsp + 0xa0], xmm14
+            ; vmovups [rsp + 0xb0], xmm15
 
             // call the function, packing the gradient into xmm0 + xmm1
             ; movsd xmm0, Rx(reg(arg_reg))
@@ -400,35 +443,28 @@ impl GradSliceAssembler {
 
             // Restore gradient registers
             ; vmovups xmm4, [rsp]
-            ; vmovups xmm5, [rsp + 16]
-            ; vmovups xmm6, [rsp + 32]
-            ; vmovups xmm7, [rsp + 48]
-            ; vmovups xmm8, [rsp + 64]
-            ; vmovups xmm9, [rsp + 80]
-            ; vmovups xmm10, [rsp + 96]
-            ; vmovups xmm11, [rsp + 112]
-            ; vmovups xmm12, [rsp + 128]
-            ; vmovups xmm13, [rsp + 144]
-            ; vmovups xmm14, [rsp + 160]
-            ; vmovups xmm15, [rsp + 176]
-            ; add rsp, 192
+            ; vmovups xmm5, [rsp + 0x10]
+            ; vmovups xmm6, [rsp + 0x20]
+            ; vmovups xmm7, [rsp + 0x30]
+            ; vmovups xmm8, [rsp + 0x40]
+            ; vmovups xmm9, [rsp + 0x50]
+            ; vmovups xmm10, [rsp + 0x60]
+            ; vmovups xmm11, [rsp + 0x70]
+            ; vmovups xmm12, [rsp + 0x80]
+            ; vmovups xmm13, [rsp + 0x90]
+            ; vmovups xmm14, [rsp + 0xa0]
+            ; vmovups xmm15, [rsp + 0xb0]
 
             // Restore X/Y/Z pointers
-            ; mov rdi, r12
-            ; mov rsi, r13
-            ; mov rdx, r14
+            ; mov rdi, [rbp - 0x8]
+            ; mov rsi, [rbp - 0x10]
+            ; mov rdx, [rbp - 0x18]
+            ; mov rcx, [rbp - 0x20]
+            ; mov r8, [rbp - 0x28]
+            ; mov r9, [rbp - 0x30]
 
             // Collect the 4x floats into the out register
             ; vpunpcklqdq Rx(reg(out_reg)), xmm0, xmm1
-
-            // Restore X/Y/Z pointers
-            ; mov rdi, r12
-            ; mov rsi, r13
-            ; mov rdx, r14
-            ; pop r9 // alignment
-            ; pop r9
-            ; pop r8
-            ; pop rcx
         );
     }
 }

--- a/fidget/src/jit/x86_64/grad_slice.rs
+++ b/fidget/src/jit/x86_64/grad_slice.rs
@@ -33,7 +33,7 @@ impl Assembler for GradSliceAssembler {
             ; mov rbp, rsp
             ; vzeroupper
         );
-        out.prepare_stack(slot_count);
+        out.prepare_stack(slot_count, 4);
         dynasm!(out.ops
             // The loop returns here, and we check whether to keep looping
             ; ->L:

--- a/fidget/src/jit/x86_64/interval.rs
+++ b/fidget/src/jit/x86_64/interval.rs
@@ -33,7 +33,7 @@ use dynasmrt::{dynasm, DynasmApi, DynasmLabelApi};
 /// | -0x10    | `r13`        | as temporary storage so must preserve their |
 /// | -0x18    | `r14`        | previous values on the stack                |
 /// |----------|--------------|---------------------------------------------|
-/// | -0x20    | Z            | Inputs                                      |
+/// | -0x20    | Z            | Inputs (as 2x floats)                       |
 /// | -0x28    | Y            |                                             |
 /// | -0x30    | X            |                                             |
 /// |----------|--------------|---------------------------------------------|

--- a/fidget/src/jit/x86_64/interval.rs
+++ b/fidget/src/jit/x86_64/interval.rs
@@ -28,10 +28,10 @@ impl Assembler for IntervalAssembler {
         let mut out = AssemblerData::new(mmap);
         dynasm!(out.ops
             ; push rbp
-            ; mov rbp, rsp
             ; push r12
             ; push r13
             ; push r14
+            ; mov rbp, rsp
             ; vzeroupper
 
             // Put X/Y/Z on the stack so we can use those registers
@@ -39,7 +39,7 @@ impl Assembler for IntervalAssembler {
             ; movq [rbp - 16], xmm1
             ; movq [rbp - 24], xmm2
         );
-        out.prepare_stack(slot_count, 4);
+        out.prepare_stack(slot_count, 4 * std::mem::size_of::<Self::Data>());
         Self(out)
     }
     fn build_load(&mut self, dst_reg: u8, src_mem: u32) {

--- a/fidget/src/jit/x86_64/interval.rs
+++ b/fidget/src/jit/x86_64/interval.rs
@@ -28,10 +28,10 @@ impl Assembler for IntervalAssembler {
         let mut out = AssemblerData::new(mmap);
         dynasm!(out.ops
             ; push rbp
+            ; mov rbp, rsp
             ; push r12
             ; push r13
             ; push r14
-            ; mov rbp, rsp
             ; vzeroupper
 
             // Put X/Y/Z on the stack so we can use those registers
@@ -39,7 +39,7 @@ impl Assembler for IntervalAssembler {
             ; movq [rbp - 16], xmm1
             ; movq [rbp - 24], xmm2
         );
-        out.prepare_stack(slot_count);
+        out.prepare_stack(slot_count, 4);
         Self(out)
     }
     fn build_load(&mut self, dst_reg: u8, src_mem: u32) {

--- a/fidget/src/jit/x86_64/point.rs
+++ b/fidget/src/jit/x86_64/point.rs
@@ -30,18 +30,18 @@ impl Assembler for PointAssembler {
         let mut out = AssemblerData::new(mmap);
         dynasm!(out.ops
             ; push rbp
+            ; mov rbp, rsp
             ; push r12
             ; push r13
             ; push r14
             ; push r15
             ; vzeroupper
-            ; mov rbp, rsp
             // Put X/Y/Z on the stack so we can use those registers
             ; vmovss [rbp - 4], xmm0
             ; vmovss [rbp - 8], xmm1
             ; vmovss [rbp - 12], xmm2
         );
-        out.prepare_stack(slot_count);
+        out.prepare_stack(slot_count, 4);
         Self(out)
     }
 

--- a/fidget/src/jit/x86_64/point.rs
+++ b/fidget/src/jit/x86_64/point.rs
@@ -30,18 +30,18 @@ impl Assembler for PointAssembler {
         let mut out = AssemblerData::new(mmap);
         dynasm!(out.ops
             ; push rbp
-            ; mov rbp, rsp
             ; push r12
             ; push r13
             ; push r14
             ; push r15
+            ; mov rbp, rsp
             ; vzeroupper
             // Put X/Y/Z on the stack so we can use those registers
             ; vmovss [rbp - 4], xmm0
             ; vmovss [rbp - 8], xmm1
             ; vmovss [rbp - 12], xmm2
         );
-        out.prepare_stack(slot_count, 4);
+        out.prepare_stack(slot_count, 4 * std::mem::size_of::<Self::Data>());
         Self(out)
     }
 

--- a/fidget/src/jit/x86_64/point.rs
+++ b/fidget/src/jit/x86_64/point.rs
@@ -23,6 +23,40 @@ use dynasmrt::{dynasm, DynasmApi, DynasmLabelApi};
 ///
 /// X, Y, and Z are stored on the stack during code execution, to free up those
 /// registers as scratch values.
+///
+/// The stack is configured as follows
+///
+/// ```text
+/// | Position | Value        | Notes                                       |
+/// |----------|--------------|---------------------------------------------|
+/// | 0x00     | `rbp`        | Previous value for base pointer             |
+/// |----------|--------------|---------------------------------------------|
+/// | -0x08    | `r12`        | During functions calls, we use these        |
+/// | -0x10    | `r13`        | as temporary storage so must preserve their |
+/// | -0x18    | `r14`        | previous values on the stack                |
+/// |----------|--------------|---------------------------------------------|
+/// | -0x20    | Z            | Inputs                                      |
+/// | -0x24    | Y            |                                             |
+/// | -0x28    | X            |                                             |
+/// |----------|--------------|---------------------------------------------|
+/// | ...      | ...          | Register spills live up here                |
+/// |----------|--------------|---------------------------------------------|
+/// | 0x2c     | xmm15        | Caller-saved registers during functions     |
+/// | 0x28     | xmm14        | calls are placed here, then restored        |
+/// | 0x24     | xmm13        |                                             |
+/// | 0x20     | xmm12        |                                             |
+/// | 0x1c     | xmm11        |                                             |
+/// | 0x18     | xmm10        |                                             |
+/// | 0x14     | xmm9         |                                             |
+/// | 0x10     | xmm8         |                                             |
+/// | 0x0c     | xmm7         |                                             |
+/// | 0x08     | xmm6         |                                             |
+/// | 0x04     | xmm5         |                                             |
+/// | 0x00     | xmm4         |                                             |
+/// ```
+const STACK_SIZE_UPPER: usize = 0x28; // Positions relative to `rbp`
+const STACK_SIZE_LOWER: usize = 0x30; // Positions relative to `rsp`
+
 impl Assembler for PointAssembler {
     type Data = f32;
 
@@ -30,39 +64,44 @@ impl Assembler for PointAssembler {
         let mut out = AssemblerData::new(mmap);
         dynasm!(out.ops
             ; push rbp
-            ; push r12
-            ; push r13
-            ; push r14
-            ; push r15
             ; mov rbp, rsp
-            ; vzeroupper
-            // Put X/Y/Z on the stack so we can use those registers
-            ; vmovss [rbp - 4], xmm0
-            ; vmovss [rbp - 8], xmm1
-            ; vmovss [rbp - 12], xmm2
         );
-        out.prepare_stack(slot_count, 4 * std::mem::size_of::<Self::Data>());
+        out.prepare_stack(slot_count, STACK_SIZE_UPPER + STACK_SIZE_LOWER);
+        dynasm!(out.ops
+            ; vzeroupper
+            // Put X/Y/Z on the stack to free up those registers
+            ; vmovss [rbp - 0x20], xmm2
+            ; vmovss [rbp - 0x24], xmm1
+            ; vmovss [rbp - 0x28], xmm0
+        );
         Self(out)
     }
 
     fn build_load(&mut self, dst_reg: u8, src_mem: u32) {
         assert!((dst_reg as usize) < REGISTER_LIMIT);
-        let sp_offset: i32 = self.0.stack_pos(src_mem).try_into().unwrap();
+        let sp_offset: i32 = (self.0.stack_pos(src_mem)
+            + STACK_SIZE_LOWER as u32)
+            .try_into()
+            .unwrap();
         dynasm!(self.0.ops
             ; vmovss Rx(reg(dst_reg)), [rsp + sp_offset]
         );
     }
     fn build_store(&mut self, dst_mem: u32, src_reg: u8) {
         assert!((src_reg as usize) < REGISTER_LIMIT);
-        let sp_offset: i32 = self.0.stack_pos(dst_mem).try_into().unwrap();
+        let sp_offset: i32 = (self.0.stack_pos(dst_mem)
+            + STACK_SIZE_LOWER as u32)
+            .try_into()
+            .unwrap();
         dynasm!(self.0.ops
             ; vmovss [rsp + sp_offset], Rx(reg(src_reg))
         );
     }
     fn build_input(&mut self, out_reg: u8, src_arg: u8) {
+        let pos = STACK_SIZE_UPPER as i32 - 4 * (src_arg as i32);
         dynasm!(self.0.ops
             // Pull X/Y/Z from the stack, where they've been placed by init()
-            ; vmovss Rx(reg(out_reg)), [rbp - 4 * (src_arg as i32 + 1)]
+            ; vmovss Rx(reg(out_reg)), [rbp - pos]
         );
     }
     fn build_var(&mut self, out_reg: u8, src_arg: u32) {
@@ -256,14 +295,17 @@ impl Assembler for PointAssembler {
         IMM_REG.wrapping_sub(OFFSET)
     }
     fn finalize(mut self, out_reg: u8) -> Result<Mmap, Error> {
+        if self.0.saved_callee_regs {
+            dynasm!(self.0.ops
+                ; mov r12, [rbp - 0x8]
+                ; mov r13, [rbp - 0x10]
+                ; mov r14, [rbp - 0x18]
+            );
+        }
         dynasm!(self.0.ops
             // Prepare our return value
             ; vmovss xmm0, xmm0, Rx(reg(out_reg))
             ; add rsp, self.0.mem_offset as i32
-            ; pop r15
-            ; pop r14
-            ; pop r13
-            ; pop r12
             ; pop rbp
             ; emms
             ; ret
@@ -279,6 +321,15 @@ impl PointAssembler {
         arg_reg: u8,
         f: extern "sysv64" fn(f32) -> f32,
     ) {
+        // Back up a few callee-saved registers that we're about to use
+        if !self.0.saved_callee_regs {
+            dynasm!(self.0.ops
+                ; mov [rbp - 0x8], r12
+                ; mov [rbp - 0x10], r13
+                ; mov [rbp - 0x18], r14
+            );
+            self.0.saved_callee_regs = true
+        }
         let addr = f as usize;
         dynasm!(self.0.ops
             // Back up X/Y/Z pointers to caller-saved registers
@@ -286,20 +337,19 @@ impl PointAssembler {
             ; mov r13, rsi
             ; mov r14, rdx
 
-            // Back up X/Y/Z values to the stack
-            ; sub rsp, 48
+            // Back up all register values to the stack
             ; movss [rsp], xmm4
-            ; movss [rsp + 4], xmm5
-            ; movss [rsp + 8], xmm6
-            ; movss [rsp + 12], xmm7
-            ; movss [rsp + 16], xmm8
-            ; movss [rsp + 20], xmm9
-            ; movss [rsp + 24], xmm10
-            ; movss [rsp + 28], xmm11
-            ; movss [rsp + 32], xmm12
-            ; movss [rsp + 36], xmm13
-            ; movss [rsp + 40], xmm14
-            ; movss [rsp + 44], xmm15
+            ; movss [rsp + 0x4], xmm5
+            ; movss [rsp + 0x8], xmm6
+            ; movss [rsp + 0xc], xmm7
+            ; movss [rsp + 0x10], xmm8
+            ; movss [rsp + 0x14], xmm9
+            ; movss [rsp + 0x18], xmm10
+            ; movss [rsp + 0x1c], xmm11
+            ; movss [rsp + 0x20], xmm12
+            ; movss [rsp + 0x24], xmm13
+            ; movss [rsp + 0x28], xmm14
+            ; movss [rsp + 0x2c], xmm15
 
             // call the function
             ; movss xmm0, Rx(reg(arg_reg))
@@ -308,18 +358,17 @@ impl PointAssembler {
 
             // Restore float registers
             ; movss xmm4, [rsp]
-            ; movss xmm5, [rsp + 4]
-            ; movss xmm6, [rsp + 8]
-            ; movss xmm7, [rsp + 12]
-            ; movss xmm8, [rsp + 16]
-            ; movss xmm9, [rsp + 20]
-            ; movss xmm10, [rsp + 24]
-            ; movss xmm11, [rsp + 28]
-            ; movss xmm12, [rsp + 32]
-            ; movss xmm13, [rsp + 36]
-            ; movss xmm14, [rsp + 40]
-            ; movss xmm15, [rsp + 44]
-            ; add rsp, 48
+            ; movss xmm5, [rsp + 0x4]
+            ; movss xmm6, [rsp + 0x8]
+            ; movss xmm7, [rsp + 0xc]
+            ; movss xmm8, [rsp + 0x10]
+            ; movss xmm9, [rsp + 0x14]
+            ; movss xmm10, [rsp + 0x18]
+            ; movss xmm11, [rsp + 0x1c]
+            ; movss xmm12, [rsp + 0x20]
+            ; movss xmm13, [rsp + 0x24]
+            ; movss xmm14, [rsp + 0x28]
+            ; movss xmm15, [rsp + 0x2c]
 
             // Restore X/Y/Z pointers
             ; mov rdi, r12


### PR DESCRIPTION
Adds detailed information about registers and stack usage during JIT evaluation.

Switches all stacks to being absolutely addressed, instead of using push/pop, because we know their sizes at JIT compilation time.