### PR TITLE
Tweaks to thread pool testing

### DIFF
--- a/fidget/src/mesh/mt/pool.rs
+++ b/fidget/src/mesh/mt/pool.rs
@@ -345,8 +345,7 @@ mod test {
             s.spawn(|| {
                 std::thread::sleep(std::time::Duration::from_millis(100));
                 if done.load(Ordering::Acquire) != N {
-                    eprintln!("deadlock in `thread_ctx` test; aborting");
-                    std::process::exit(1);
+                    panic!("deadlock in `thread_ctx` test; aborting");
                 }
             });
             for i in 0..N {

--- a/fidget/src/mesh/mt/pool.rs
+++ b/fidget/src/mesh/mt/pool.rs
@@ -343,7 +343,7 @@ mod test {
 
         std::thread::scope(|s| {
             s.spawn(|| {
-                std::thread::sleep(std::time::Duration::from_millis(100));
+                std::thread::sleep(std::time::Duration::from_millis(500));
                 if done.load(Ordering::Acquire) != N {
                     panic!("deadlock in `thread_ctx` test; aborting");
                 }


### PR DESCRIPTION
- Use a `panic!` instead of `exit(1)` (dunno why I was doing the latter)
- Tweak the timeout to make the test more robust under heavy load