### PR TITLE
Fix x86 abs implementation

### DIFF
--- a/fidget/src/core/eval/test/interval.rs
+++ b/fidget/src/core/eval/test/interval.rs
@@ -88,6 +88,19 @@ where
         );
     }
 
+    pub fn test_i_add_abs() {
+        let mut ctx = Context::new();
+        let x = ctx.x();
+        let v = ctx.add(x, 0.5).unwrap();
+        let out = ctx.abs(v).unwrap();
+
+        let shape = S::new(&ctx, out).unwrap();
+        let tape = shape.ez_interval_tape();
+        let mut eval = S::new_interval_eval();
+
+        assert_eq!(eval.eval_x(&tape, [-1.0, 1.0]), [0.0, 1.5].into());
+    }
+
     pub fn test_i_sqrt() {
         let mut ctx = Context::new();
         let x = ctx.x();
@@ -946,6 +959,7 @@ macro_rules! interval_tests {
     ($t:ty) => {
         $crate::interval_test!(test_interval, $t);
         $crate::interval_test!(test_i_abs, $t);
+        $crate::interval_test!(test_i_add_abs, $t);
         $crate::interval_test!(test_i_sqrt, $t);
         $crate::interval_test!(test_i_square, $t);
         $crate::interval_test!(test_i_sin, $t);

--- a/fidget/src/jit/x86_64/interval.rs
+++ b/fidget/src/jit/x86_64/interval.rs
@@ -223,7 +223,7 @@ impl Assembler for IntervalAssembler {
 
             // Clear the lowest value of the interval, leaving us with [0, ...]
             ; C:
-            ; mov eax, (0f32).to_bits() as i32
+            ; xor eax, eax
             ; vpinsrd Rx(reg(out_reg)), Rx(reg(out_reg)), eax, 0
             // fallthrough to end
 

--- a/fidget/src/jit/x86_64/interval.rs
+++ b/fidget/src/jit/x86_64/interval.rs
@@ -223,7 +223,8 @@ impl Assembler for IntervalAssembler {
 
             // Clear the lowest value of the interval, leaving us with [0, ...]
             ; C:
-            ; vpshufd Rx(reg(out_reg)), Rx(reg(out_reg)), 0b11110111u8 as i8
+            ; mov eax, (0f32).to_bits() as i32
+            ; vpinsrd Rx(reg(out_reg)), Rx(reg(out_reg)), eax, 0
             // fallthrough to end
 
             ; E:


### PR DESCRIPTION
Previously, we got a zero from a high value in the output XMM register, which isn't actually guaranteed to be empty!

Fixes #47