### PR TITLE
Fix meshing edge case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
       change bounds for meshing (by translating + scaling the underlying model).
 - Move `Interval` and `Grad` to `fidget::types` module, instead of
   `fidget::eval::types`.
+- Fix an edge case in meshing where nearly-planar surfaces could produce
+  vertexes far from the desired position.
 
 # 0.2.2
 - Added many transcendental functions: `sin`, `cos`, `tan`, `asin`, `acos`,

--- a/fidget/src/mesh/octree.rs
+++ b/fidget/src/mesh/octree.rs
@@ -1870,4 +1870,23 @@ mod test {
             "bad accumulated QEF in center"
         );
     }
+
+    #[test]
+    fn test_qef_near_planar() {
+        let ctx = BoundContext::new();
+        let shape = sphere(&ctx, [0.0; 3], 0.75);
+
+        let shape: VmShape = shape.convert();
+        let settings = Settings {
+            min_depth: 4,
+            max_depth: 4,
+            threads: 0,
+        };
+
+        let octree = Octree::build(&shape, settings).walk_dual(settings);
+        for v in octree.vertices.iter() {
+            let n = v.norm();
+            assert!(n > 0.7 && n < 0.8, "invalid vertex at {v:?}: {n}");
+        }
+    }
 }


### PR DESCRIPTION
Fixes #53

This adds a relative cutoff for QEF eigenvalues, [same as `libfive`](https://github.com/libfive/libfive/blob/7af5f43684a8a497ac8610d39f7fca935364a9b9/libfive/include/libfive/render/brep/simplex/qef.hpp#L551).