### PR TITLE
New type for render bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,15 @@
   with the difference that unordered results are returned as `NAN`)
 - Fix a bug in the x86 JIT evaluator's implementation of interval `abs`
 - Add generic `TransformedShape<S>`, representing a shape transformed by a 4x4
-  homogeneous matrix
-    - This replaces `RenderConfig::mat` as the way to handle rotation / scale /
-      translation / perspective transforms, e.g. for interactive visualization
-      (where you don't want to remap the underlying shape)
-    - It's a more general solution: for example, we can use the same type to
-      change bounds for meshing (by translating + scaling the underlying model).
+  homogeneous matrix.  This replaces `RenderConfig::mat` as the flexible
+  strategy for rotation / scale / translation / perspective transforms, e.g. for
+  interactive visualization (where you don't want to remap the underlying shape)
+- Introduce a new `Bounds` type, representing an X/Y/Z region of interest for
+  rendering or meshing.  This overlaps somewhat with `TransformedShape`, but
+  it's ergonomic to specify render region instead of having to do the matrix
+  math every time.
+    - Replaced `RenderConfig::mat` with a new `bounds` member.
+    - Added a new `bounds` member to `mesh::Settings`, for octree construction
 - Move `Interval` and `Grad` to `fidget::types` module, instead of
   `fidget::eval::types`.
 - Fix an edge case in meshing where nearly-planar surfaces could produce

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -129,6 +129,7 @@ fn run3d<S: fidget::eval::Shape>(
         image_size: settings.size as usize,
         tile_sizes: S::tile_sizes_3d().to_vec(),
         threads: settings.threads,
+        ..Default::default()
     };
     let shape = shape.apply_transform(mat.into());
 
@@ -206,6 +207,7 @@ fn run2d<S: fidget::eval::Shape>(
             image_size: settings.size as usize,
             tile_sizes: S::tile_sizes_2d().to_vec(),
             threads: settings.threads,
+            ..Default::default()
         };
         if sdf {
             let mut image = vec![];
@@ -250,6 +252,7 @@ fn run_mesh<S: fidget::eval::Shape>(
             threads: settings.threads,
             min_depth: settings.depth,
             max_depth: settings.max_depth.unwrap_or(settings.depth),
+            ..Default::default()
         };
         let octree = fidget::mesh::Octree::build(&shape, settings);
         mesh = octree.walk_dual(settings);

--- a/fidget/benches/mesh.rs
+++ b/fidget/benches/mesh.rs
@@ -18,6 +18,7 @@ pub fn colonnade_octree_thread_sweep(c: &mut Criterion) {
             min_depth: 6,
             max_depth: 6,
             threads,
+            ..Default::default()
         };
         #[cfg(feature = "jit")]
         group.bench_function(BenchmarkId::new("jit", threads), move |b| {
@@ -42,6 +43,7 @@ pub fn colonnade_mesh(c: &mut Criterion) {
         min_depth: 8,
         max_depth: 8,
         threads: 8,
+        ..Default::default()
     };
     let octree = &fidget::mesh::Octree::build(shape_vm, cfg);
 

--- a/fidget/benches/render.rs
+++ b/fidget/benches/render.rs
@@ -20,6 +20,7 @@ pub fn prospero_size_sweep(c: &mut Criterion) {
             image_size: size,
             tile_sizes: fidget::vm::VmShape::tile_sizes_2d().to_vec(),
             threads: 8,
+            ..Default::default()
         };
         group.bench_function(BenchmarkId::new("vm", size), move |b| {
             b.iter(|| {
@@ -38,6 +39,7 @@ pub fn prospero_size_sweep(c: &mut Criterion) {
                 image_size: size,
                 tile_sizes: fidget::jit::JitShape::tile_sizes_2d().to_vec(),
                 threads: 8,
+                ..Default::default()
             };
             group.bench_function(BenchmarkId::new("jit", size), move |b| {
                 b.iter(|| {
@@ -67,6 +69,7 @@ pub fn prospero_thread_sweep(c: &mut Criterion) {
             image_size: 1024,
             tile_sizes: fidget::vm::VmShape::tile_sizes_2d().to_vec(),
             threads,
+            ..Default::default()
         };
         group.bench_function(BenchmarkId::new("vm", threads), move |b| {
             b.iter(|| {
@@ -84,6 +87,7 @@ pub fn prospero_thread_sweep(c: &mut Criterion) {
                 image_size: 1024,
                 tile_sizes: fidget::jit::JitShape::tile_sizes_2d().to_vec(),
                 threads,
+                ..Default::default()
             };
             group.bench_function(BenchmarkId::new("jit", threads), move |b| {
                 b.iter(|| {

--- a/fidget/src/core/mod.rs
+++ b/fidget/src/core/mod.rs
@@ -58,6 +58,7 @@ pub use context::Context;
 
 pub mod compiler;
 pub mod eval;
+pub mod shape;
 pub mod types;
 pub mod vm;
 

--- a/fidget/src/core/shape/bound.rs
+++ b/fidget/src/core/shape/bound.rs
@@ -1,8 +1,20 @@
-use crate::eval::types::Interval;
-
 /// A bounded region in space, typically used as a render region
-struct Bounds {
-    x: Interval,
-    y: Interval,
-    z: Interval,
+///
+/// Right now, all spatial operations take place in a cubical region, so we
+/// specify bounds as a lower corner and region size.
+pub struct Bounds {
+    /// Lower corner of the bounds
+    pub corner: nalgebra::Vector3<f32>,
+    /// Size of the bounds (on each axis)
+    pub size: f32,
+}
+
+impl Default for Bounds {
+    /// By default, the bounds are the `[-1, +1]` cube
+    fn default() -> Self {
+        Self {
+            corner: nalgebra::Vector3::new(-1.0, -1.0, -1.0),
+            size: 2.0,
+        }
+    }
 }

--- a/fidget/src/core/shape/bound.rs
+++ b/fidget/src/core/shape/bound.rs
@@ -1,0 +1,8 @@
+use crate::eval::types::Interval;
+
+/// A bounded region in space, typically used as a render region
+struct Bounds {
+    x: Interval,
+    y: Interval,
+    z: Interval,
+}

--- a/fidget/src/core/shape/bound.rs
+++ b/fidget/src/core/shape/bound.rs
@@ -1,20 +1,49 @@
+use nalgebra::{
+    allocator::Allocator, Const, DefaultAllocator, DimNameAdd, DimNameSub,
+    DimNameSum, OVector, Transform, U1,
+};
+
 /// A bounded region in space, typically used as a render region
 ///
 /// Right now, all spatial operations take place in a cubical region, so we
 /// specify bounds as a lower corner and region size.
-pub struct Bounds {
+pub struct Bounds<const N: usize> {
     /// Lower corner of the bounds
-    pub corner: nalgebra::Vector3<f32>,
+    pub corner: OVector<f32, Const<N>>,
     /// Size of the bounds (on each axis)
     pub size: f32,
 }
 
-impl Default for Bounds {
-    /// By default, the bounds are the `[-1, +1]` cube
+impl<const N: usize> Default for Bounds<N> {
+    /// By default, the bounds are the `[-1, +1]` region
     fn default() -> Self {
-        Self {
-            corner: nalgebra::Vector3::new(-1.0, -1.0, -1.0),
-            size: 2.0,
+        let corner = OVector::<f32, Const<N>>::from_element(-1.0);
+        Self { corner, size: 2.0 }
+    }
+}
+
+impl<const N: usize> Bounds<N>
+where
+    Const<N>: DimNameAdd<U1>,
+    DefaultAllocator:
+        Allocator<f32, DimNameSum<Const<N>, U1>, DimNameSum<Const<N>, U1>>,
+    <Const<N> as DimNameAdd<Const<1>>>::Output: DimNameSub<U1>,
+{
+    /// Returns a homogeneous transform matrix for these bounds
+    ///
+    /// When the matrix is applied, the given bounds will be mapped into the
+    /// `[-1, +1]` region (which is used for all rendering operations).
+    pub fn to_transform_matrix(&self) -> Transform<f32, nalgebra::TGeneral, N> {
+        let center = self.corner;
+        let mut t = nalgebra::Translation::<f32, N>::identity();
+        for (t, c) in t.vector.iter_mut().zip(&center) {
+            *t = c + self.size / 2.0;
         }
+
+        let mut out = Transform::<f32, nalgebra::TGeneral, N>::default();
+        out *= t;
+
+        out.matrix_mut().append_scaling_mut(self.size / 2.0);
+        out
     }
 }

--- a/fidget/src/core/shape/bounds.rs
+++ b/fidget/src/core/shape/bounds.rs
@@ -6,19 +6,24 @@ use nalgebra::{
 /// A bounded region in space, typically used as a render region
 ///
 /// Right now, all spatial operations take place in a cubical region, so we
-/// specify bounds as a lower corner and region size.
+/// specify bounds as a center point and region size.
+#[derive(Copy, Clone, Debug)]
 pub struct Bounds<const N: usize> {
-    /// Lower corner of the bounds
-    pub corner: OVector<f32, Const<N>>,
-    /// Size of the bounds (on each axis)
+    /// Center of the bounds
+    pub center: OVector<f32, Const<N>>,
+
+    /// Size of the bounds in each direction
+    ///
+    /// The full bounds are given by `[center - size, center + size]` on each
+    /// axis.
     pub size: f32,
 }
 
 impl<const N: usize> Default for Bounds<N> {
     /// By default, the bounds are the `[-1, +1]` region
     fn default() -> Self {
-        let corner = OVector::<f32, Const<N>>::from_element(-1.0);
-        Self { corner, size: 2.0 }
+        let center = OVector::<f32, Const<N>>::zeros();
+        Self { center, size: 1.0 }
     }
 }
 
@@ -34,16 +39,15 @@ where
     /// When the matrix is applied, the given bounds will be mapped into the
     /// `[-1, +1]` region (which is used for all rendering operations).
     pub fn to_transform_matrix(&self) -> Transform<f32, nalgebra::TGeneral, N> {
-        let center = self.corner;
         let mut t = nalgebra::Translation::<f32, N>::identity();
-        for (t, c) in t.vector.iter_mut().zip(&center) {
-            *t = c + self.size / 2.0;
+        for (t, c) in t.vector.iter_mut().zip(&self.center) {
+            *t = *c;
         }
 
         let mut out = Transform::<f32, nalgebra::TGeneral, N>::default();
         out *= t;
 
-        out.matrix_mut().append_scaling_mut(self.size / 2.0);
+        out.matrix_mut().append_scaling_mut(self.size);
         out
     }
 }

--- a/fidget/src/core/shape/mod.rs
+++ b/fidget/src/core/shape/mod.rs
@@ -1,3 +1,3 @@
 //! Shape-specific data types
 mod bound;
-pub use bound::Bound;
+pub use bound::Bounds;

--- a/fidget/src/core/shape/mod.rs
+++ b/fidget/src/core/shape/mod.rs
@@ -1,3 +1,3 @@
 //! Shape-specific data types
-mod bound;
-pub use bound::Bounds;
+mod bounds;
+pub use bounds::Bounds;

--- a/fidget/src/core/shape/mod.rs
+++ b/fidget/src/core/shape/mod.rs
@@ -1,0 +1,3 @@
+//! Shape-specific data types
+mod bound;
+pub use bound::Bound;

--- a/fidget/src/mesh/mod.rs
+++ b/fidget/src/mesh/mod.rs
@@ -26,7 +26,12 @@
 //!
 //! let (node, ctx) = fidget::rhai::eval("sphere(0, 0, 0, 0.6).call(x, y, z)")?;
 //! let shape = VmShape::new(&ctx, node)?;
-//! let settings = Settings { threads: 8, min_depth: 4, max_depth: 4 };
+//! let settings = Settings {
+//!     threads: 8,
+//!     min_depth: 4,
+//!     max_depth: 4,
+//!     ..Default::default()
+//! };
 //! let o = Octree::build(&shape, settings);
 //! let mesh = o.walk_dual(settings);
 //!
@@ -36,6 +41,8 @@
 //! mesh.write_stl(&mut f)?;
 //! # Ok::<(), fidget::Error>(())
 //! ```
+
+use crate::shape::Bounds;
 
 mod builder;
 mod cell;
@@ -92,4 +99,18 @@ pub struct Settings {
     ///
     /// This is **much slower**.
     pub max_depth: u8,
+
+    /// Bounds for meshing
+    pub bounds: Bounds<3>,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            threads: 4,
+            min_depth: 3,
+            max_depth: 3,
+            bounds: Default::default(),
+        }
+    }
 }

--- a/fidget/src/mesh/octree.rs
+++ b/fidget/src/mesh/octree.rs
@@ -128,6 +128,16 @@ impl Octree {
     ///
     /// The shape is evaluated on the region `[-1, 1]` on all axes
     pub fn build<S: Shape + Clone>(shape: &S, settings: Settings) -> Self {
+        // Transform the shape given our bounds
+        let shape = shape
+            .clone()
+            .apply_transform(settings.bounds.to_transform_matrix().into());
+        let out = Self::build_inner(&shape, settings);
+        // TODO correct for vertex offsets
+        out
+    }
+
+    fn build_inner<S: Shape + Clone>(shape: &S, settings: Settings) -> Self {
         let eval = Arc::new(EvalGroup::new(shape.clone()));
 
         let mut octree = if settings.threads == 0 {
@@ -1347,19 +1357,29 @@ mod test {
         context::bound::{self, BoundContext, BoundNode},
         eval::{EzShape, MathShape},
         mesh::types::{Edge, X, Y, Z},
+        shape::Bounds,
         vm::VmShape,
     };
+    use nalgebra::Vector3;
     use std::collections::BTreeMap;
 
     const DEPTH0_SINGLE_THREAD: Settings = Settings {
         min_depth: 0,
         max_depth: 0,
         threads: 0,
+        bounds: Bounds {
+            center: Vector3::new(0.0, 0.0, 0.0),
+            size: 1.0,
+        },
     };
     const DEPTH1_SINGLE_THREAD: Settings = Settings {
         min_depth: 1,
         max_depth: 1,
         threads: 0,
+        bounds: Bounds {
+            center: Vector3::new(0.0, 0.0, 0.0),
+            size: 1.0,
+        },
     };
 
     fn sphere(
@@ -1536,6 +1556,7 @@ mod test {
                 min_depth: 5,
                 max_depth: 5,
                 threads,
+                ..Default::default()
             };
             let octree = Octree::build(&shape, settings);
             let sphere_mesh = octree.walk_dual(settings);
@@ -1699,6 +1720,7 @@ mod test {
                     min_depth: 2,
                     max_depth: 2,
                     threads,
+                    ..Default::default()
                 };
                 let octree = Octree::build(&shape, settings);
 
@@ -1763,6 +1785,7 @@ mod test {
                 min_depth: 1,
                 max_depth: 1,
                 threads,
+                ..Default::default()
             };
             let octree = Octree::build(&tape, settings);
             assert_eq!(
@@ -1784,6 +1807,7 @@ mod test {
                 min_depth: 5,
                 max_depth: 5,
                 threads,
+                ..Default::default()
             };
             let octree = Octree::build(&tape, settings);
             let mesh = octree.walk_dual(settings);

--- a/fidget/src/mesh/octree.rs
+++ b/fidget/src/mesh/octree.rs
@@ -1905,6 +1905,7 @@ mod test {
             min_depth: 4,
             max_depth: 4,
             threads: 0,
+            ..Default::default()
         };
 
         let octree = Octree::build(&shape, settings).walk_dual(settings);

--- a/fidget/src/mesh/octree.rs
+++ b/fidget/src/mesh/octree.rs
@@ -131,7 +131,7 @@ impl Octree {
         // Transform the shape given our bounds
         let shape = shape
             .clone()
-            .apply_transform(settings.bounds.to_transform_matrix().into());
+            .apply_transform(settings.bounds.transform().into());
         let out = Self::build_inner(&shape, settings);
         // TODO correct for vertex offsets
         out

--- a/fidget/src/render/config.rs
+++ b/fidget/src/render/config.rs
@@ -85,6 +85,8 @@ where
                 U1,
             >>::Buffer,
         >::from_element(-1.0);
+
+        // Build a matrix which transforms from pixel coordinates to [-1, +1]
         let mut mat =
             nalgebra::Transform::<f32, nalgebra::TGeneral, N>::identity()
                 .matrix()
@@ -92,7 +94,8 @@ where
                 .append_scaling(scale)
                 .append_translation(&v);
 
-        mat *= self.bounds.transform().matrix();
+        // The bounds transform matrix goes from [-1, +1] to model coordinates
+        mat = self.bounds.transform().matrix() * mat;
 
         (
             AlignedRenderConfig {

--- a/fidget/src/render/config.rs
+++ b/fidget/src/render/config.rs
@@ -92,7 +92,7 @@ where
                 .append_scaling(scale)
                 .append_translation(&v);
 
-        mat *= self.bounds.to_transform_matrix().matrix();
+        mat *= self.bounds.transform().matrix();
 
         (
             AlignedRenderConfig {

--- a/fidget/src/render/config.rs
+++ b/fidget/src/render/config.rs
@@ -271,4 +271,64 @@ mod test {
             Point2::new(1.0, 1.0)
         );
     }
+
+    #[test]
+    fn test_bounded_config() {
+        // Simple alignment
+        let config: RenderConfig<2> = RenderConfig {
+            image_size: 512,
+            tile_sizes: vec![64, 32],
+            threads: 8,
+            bounds: Bounds {
+                center: nalgebra::Vector2::new(0.5, 0.5),
+                size: 0.5,
+            },
+        };
+        let (aligned, mat) = config.align();
+        assert_eq!(aligned.image_size, config.image_size);
+        assert_eq!(aligned.tile_sizes, config.tile_sizes);
+        assert_eq!(aligned.threads, config.threads);
+        assert_eq!(
+            mat.transform_point(&Point2::new(0.0, 0.0)),
+            Point2::new(0.0, 0.0)
+        );
+        assert_eq!(
+            mat.transform_point(&Point2::new(512.0, 0.0)),
+            Point2::new(1.0, 0.0)
+        );
+        assert_eq!(
+            mat.transform_point(&Point2::new(512.0, 512.0)),
+            Point2::new(1.0, 1.0)
+        );
+
+        let config: RenderConfig<2> = RenderConfig {
+            image_size: 575,
+            tile_sizes: vec![64, 32],
+            threads: 8,
+            bounds: Bounds {
+                center: nalgebra::Vector2::new(0.5, 0.5),
+                size: 0.5,
+            },
+        };
+        let (aligned, mat) = config.align();
+        assert_eq!(aligned.orig_image_size, 575);
+        assert_eq!(aligned.image_size, 576);
+        assert_eq!(aligned.tile_sizes, config.tile_sizes);
+        assert_eq!(aligned.threads, config.threads);
+        assert_eq!(
+            mat.transform_point(&Point2::new(0.0, 0.0)),
+            Point2::new(0.0, 0.0)
+        );
+        assert_eq!(
+            mat.transform_point(&Point2::new(config.image_size as f32, 0.0)),
+            Point2::new(1.0, 0.0)
+        );
+        assert_eq!(
+            mat.transform_point(&Point2::new(
+                config.image_size as f32,
+                config.image_size as f32
+            )),
+            Point2::new(1.0, 1.0)
+        );
+    }
 }

--- a/fidget/src/render/render2d.rs
+++ b/fidget/src/render/render2d.rs
@@ -341,7 +341,6 @@ pub fn render<S: Shape, M: RenderMode + Sync>(
         assert!(config.tile_sizes[i] % config.tile_sizes[i + 1] == 0);
     }
 
-    println!("applying transform\n{mat}");
     // Convert to a 4x4 matrix and apply to the shape
     let mat = mat.insert_row(2, 0.0);
     let mat = mat.insert_column(2, 0.0);

--- a/fidget/src/render/render2d.rs
+++ b/fidget/src/render/render2d.rs
@@ -341,6 +341,7 @@ pub fn render<S: Shape, M: RenderMode + Sync>(
         assert!(config.tile_sizes[i] % config.tile_sizes[i + 1] == 0);
     }
 
+    println!("applying transform\n{mat}");
     // Convert to a 4x4 matrix and apply to the shape
     let mat = mat.insert_row(2, 0.0);
     let mat = mat.insert_column(2, 0.0);

--- a/viewer/src/main.rs
+++ b/viewer/src/main.rs
@@ -5,7 +5,7 @@ use eframe::egui;
 use env_logger::Env;
 use fidget::render::RenderConfig;
 use log::{debug, error, info};
-use nalgebra::{Transform3, Vector3};
+use nalgebra::{Vector2, Vector3};
 use notify::Watcher;
 
 use std::{error::Error, path::Path};
@@ -149,23 +149,15 @@ fn render<S: fidget::eval::Shape>(
 ) {
     match mode {
         RenderMode::TwoD(camera, mode) => {
-            let mat = Transform3::from_matrix_unchecked(
-                Transform3::identity()
-                    .matrix()
-                    .append_scaling(camera.scale)
-                    .append_translation(&Vector3::new(
-                        camera.offset.x,
-                        camera.offset.y,
-                        0.0,
-                    )),
-            );
-
             let config = RenderConfig {
                 image_size,
                 tile_sizes: S::tile_sizes_2d().to_vec(),
                 threads: 8,
+                bounds: fidget::shape::Bounds {
+                    center: Vector2::new(camera.offset.x, camera.offset.y),
+                    size: camera.scale,
+                },
             };
-            let shape = shape.apply_transform(mat.into());
 
             match mode {
                 TwoDMode::Color => {
@@ -212,23 +204,15 @@ fn render<S: fidget::eval::Shape>(
             }
         }
         RenderMode::ThreeD(camera, mode) => {
-            let mat = Transform3::from_matrix_unchecked(
-                Transform3::identity()
-                    .matrix()
-                    .append_scaling(camera.scale)
-                    .append_translation(&Vector3::new(
-                        camera.offset.x,
-                        camera.offset.y,
-                        0.0,
-                    )),
-            );
-
             let config = RenderConfig {
                 image_size,
                 tile_sizes: S::tile_sizes_2d().to_vec(),
                 threads: 8,
+                bounds: fidget::shape::Bounds {
+                    center: Vector3::new(camera.offset.x, camera.offset.y, 0.0),
+                    size: camera.scale,
+                },
             };
-            let shape = shape.apply_transform(mat.into());
             let (depth, color) = fidget::render::render3d(shape, &config);
             match mode {
                 ThreeDMode::Color => {


### PR DESCRIPTION
This replaces #10 as a general strategy for "bounded rendering", using the same `Bounds` type for both meshing and 2D / 3D rendering.

@julianschuler can you take a look and see if this works for your needs?

To do before merging:
- [x] Add test for octree vertex correction