### PR TITLE
Add modulo ("euclidean remainder") opcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   `fidget::eval::types`.
 - Fix an edge case in meshing where nearly-planar surfaces could produce
   vertexes far from the desired position.
+- Add the `modulo` (Euclidean remainder) operation
 
 # 0.2.2
 - Added many transcendental functions: `sin`, `cos`, `tan`, `asin`, `acos`,

--- a/fidget/src/core/compiler/alloc.rs
+++ b/fidget/src/core/compiler/alloc.rs
@@ -297,7 +297,8 @@ impl<const N: usize> RegisterAllocator<N> {
             | SsaOp::MinRegImm(..)
             | SsaOp::MaxRegImm(..)
             | SsaOp::CompareRegImm(..)
-            | SsaOp::CompareImmReg(..) => self.op_reg_imm(op),
+            | SsaOp::CompareImmReg(..)
+            | SsaOp::ModRegImm(..) => self.op_reg_imm(op),
 
             SsaOp::AddRegReg(..)
             | SsaOp::SubRegReg(..)
@@ -608,6 +609,9 @@ impl<const N: usize> RegisterAllocator<N> {
             }
             SsaOp::CompareImmReg(out, arg, imm) => {
                 (out, arg, imm, RegOp::CompareImmReg)
+            }
+            SsaOp::ModRegImm(out, arg, imm) => {
+                (out, arg, imm, RegOp::ModRegImm)
             }
             _ => panic!("Bad opcode: {op:?}"),
         };

--- a/fidget/src/core/compiler/alloc.rs
+++ b/fidget/src/core/compiler/alloc.rs
@@ -298,7 +298,8 @@ impl<const N: usize> RegisterAllocator<N> {
             | SsaOp::MaxRegImm(..)
             | SsaOp::CompareRegImm(..)
             | SsaOp::CompareImmReg(..)
-            | SsaOp::ModRegImm(..) => self.op_reg_imm(op),
+            | SsaOp::ModRegImm(..)
+            | SsaOp::ModImmReg(..) => self.op_reg_imm(op),
 
             SsaOp::AddRegReg(..)
             | SsaOp::SubRegReg(..)
@@ -306,7 +307,8 @@ impl<const N: usize> RegisterAllocator<N> {
             | SsaOp::DivRegReg(..)
             | SsaOp::MinRegReg(..)
             | SsaOp::MaxRegReg(..)
-            | SsaOp::CompareRegReg(..) => self.op_reg_reg(op),
+            | SsaOp::CompareRegReg(..)
+            | SsaOp::ModRegReg(..) => self.op_reg_reg(op),
         }
     }
 
@@ -492,6 +494,9 @@ impl<const N: usize> RegisterAllocator<N> {
             SsaOp::CompareRegReg(out, lhs, rhs) => {
                 (out, lhs, rhs, RegOp::CompareRegReg)
             }
+            SsaOp::ModRegReg(out, lhs, rhs) => {
+                (out, lhs, rhs, RegOp::ModRegReg)
+            }
             _ => panic!("Bad opcode: {op:?}"),
         };
         let r_x = self.get_out_reg(out);
@@ -612,6 +617,9 @@ impl<const N: usize> RegisterAllocator<N> {
             }
             SsaOp::ModRegImm(out, arg, imm) => {
                 (out, arg, imm, RegOp::ModRegImm)
+            }
+            SsaOp::ModImmReg(out, arg, imm) => {
+                (out, arg, imm, RegOp::ModImmReg)
             }
             _ => panic!("Bad opcode: {op:?}"),
         };

--- a/fidget/src/core/compiler/op.rs
+++ b/fidget/src/core/compiler/op.rs
@@ -81,8 +81,12 @@ macro_rules! opcodes {
             SubImmReg($t, $t, f32),
             #[doc = "Subtract an immediate from a register"]
             SubRegImm($t, $t, f32),
+            #[doc = "Take the module (least nonnegative remainder) of two registers"]
+            ModRegReg($t, $t, $t),
             #[doc = "Take the module (least nonnegative remainder) of a register and an immediate"]
             ModRegImm($t, $t, f32),
+            #[doc = "Take the module (least nonnegative remainder) of an immediate and a register"]
+            ModImmReg($t, $t, f32),
             #[doc = "Compute the minimum of a register and an immediate"]
             MinRegImm($t, $t, f32),
             #[doc = "Compute the maximum of a register and an immediate"]
@@ -171,7 +175,9 @@ impl SsaOp {
             | SsaOp::CompareRegReg(out, ..)
             | SsaOp::CompareRegImm(out, ..)
             | SsaOp::CompareImmReg(out, ..)
-            | SsaOp::ModRegImm(out, ..) => *out,
+            | SsaOp::ModRegReg(out, ..)
+            | SsaOp::ModRegImm(out, ..)
+            | SsaOp::ModImmReg(out, ..) => *out,
         }
     }
     /// Returns true if the given opcode is associated with a choice
@@ -207,7 +213,9 @@ impl SsaOp {
             | SsaOp::CompareRegReg(..)
             | SsaOp::CompareRegImm(..)
             | SsaOp::CompareImmReg(..)
-            | SsaOp::ModRegImm(..) => false,
+            | SsaOp::ModRegReg(..)
+            | SsaOp::ModRegImm(..)
+            | SsaOp::ModImmReg(..) => false,
             SsaOp::MinRegImm(..)
             | SsaOp::MaxRegImm(..)
             | SsaOp::MinRegReg(..)

--- a/fidget/src/core/compiler/op.rs
+++ b/fidget/src/core/compiler/op.rs
@@ -81,6 +81,8 @@ macro_rules! opcodes {
             SubImmReg($t, $t, f32),
             #[doc = "Subtract an immediate from a register"]
             SubRegImm($t, $t, f32),
+            #[doc = "Take the module (least nonnegative remainder) of a register and an immediate"]
+            ModRegImm($t, $t, f32),
             #[doc = "Compute the minimum of a register and an immediate"]
             MinRegImm($t, $t, f32),
             #[doc = "Compute the maximum of a register and an immediate"]
@@ -168,7 +170,8 @@ impl SsaOp {
             | SsaOp::MaxRegReg(out, ..)
             | SsaOp::CompareRegReg(out, ..)
             | SsaOp::CompareRegImm(out, ..)
-            | SsaOp::CompareImmReg(out, ..) => *out,
+            | SsaOp::CompareImmReg(out, ..)
+            | SsaOp::ModRegImm(out, ..) => *out,
         }
     }
     /// Returns true if the given opcode is associated with a choice
@@ -203,7 +206,8 @@ impl SsaOp {
             | SsaOp::DivImmReg(..)
             | SsaOp::CompareRegReg(..)
             | SsaOp::CompareRegImm(..)
-            | SsaOp::CompareImmReg(..) => false,
+            | SsaOp::CompareImmReg(..)
+            | SsaOp::ModRegImm(..) => false,
             SsaOp::MinRegImm(..)
             | SsaOp::MaxRegImm(..)
             | SsaOp::MinRegReg(..)

--- a/fidget/src/core/compiler/ssa_tape.rs
+++ b/fidget/src/core/compiler/ssa_tape.rs
@@ -167,9 +167,9 @@ impl SsaTape {
                             SsaOp::CompareImmReg,
                         ),
                         BinaryOpcode::Mod => (
-                            |_, _, _| panic!("mod(reg, reg) is invalid"),
-                            |_, _, _| panic!("mod(imm, reg) is invalid"),
+                            SsaOp::ModRegReg,
                             SsaOp::ModRegImm,
+                            SsaOp::ModImmReg,
                         ),
                     };
 
@@ -303,7 +303,8 @@ impl SsaTape {
                 | SsaOp::DivRegReg(out, lhs, rhs)
                 | SsaOp::SubRegReg(out, lhs, rhs)
                 | SsaOp::MinRegReg(out, lhs, rhs)
-                | SsaOp::MaxRegReg(out, lhs, rhs) => {
+                | SsaOp::MaxRegReg(out, lhs, rhs)
+                | SsaOp::ModRegReg(out, lhs, rhs) => {
                     let op = match op {
                         SsaOp::AddRegReg(..) => "ADD",
                         SsaOp::MulRegReg(..) => "MUL",
@@ -311,6 +312,7 @@ impl SsaTape {
                         SsaOp::SubRegReg(..) => "SUB",
                         SsaOp::MinRegReg(..) => "MIN",
                         SsaOp::MaxRegReg(..) => "MAX",
+                        SsaOp::ModRegReg(..) => "MAX",
                         _ => unreachable!(),
                     };
                     println!("${out} = {op} ${lhs} ${rhs}");
@@ -324,7 +326,8 @@ impl SsaTape {
                 | SsaOp::SubRegImm(out, arg, imm)
                 | SsaOp::MinRegImm(out, arg, imm)
                 | SsaOp::MaxRegImm(out, arg, imm)
-                | SsaOp::ModRegImm(out, arg, imm) => {
+                | SsaOp::ModRegImm(out, arg, imm)
+                | SsaOp::ModImmReg(out, arg, imm) => {
                     let (op, swap) = match op {
                         SsaOp::AddRegImm(..) => ("ADD", false),
                         SsaOp::MulRegImm(..) => ("MUL", false),
@@ -335,6 +338,7 @@ impl SsaTape {
                         SsaOp::MinRegImm(..) => ("MIN", false),
                         SsaOp::MaxRegImm(..) => ("MAX", false),
                         SsaOp::ModRegImm(..) => ("MOD", false),
+                        SsaOp::ModImmReg(..) => ("MOD", true),
                         _ => unreachable!(),
                     };
                     if swap {

--- a/fidget/src/core/compiler/ssa_tape.rs
+++ b/fidget/src/core/compiler/ssa_tape.rs
@@ -166,6 +166,11 @@ impl SsaTape {
                             SsaOp::CompareRegImm,
                             SsaOp::CompareImmReg,
                         ),
+                        BinaryOpcode::Mod => (
+                            |_, _, _| panic!("mod(reg, reg) is invalid"),
+                            |_, _, _| panic!("mod(imm, reg) is invalid"),
+                            SsaOp::ModRegImm,
+                        ),
                     };
 
                     if matches!(op, BinaryOpcode::Min | BinaryOpcode::Max) {
@@ -318,7 +323,8 @@ impl SsaTape {
                 | SsaOp::SubImmReg(out, arg, imm)
                 | SsaOp::SubRegImm(out, arg, imm)
                 | SsaOp::MinRegImm(out, arg, imm)
-                | SsaOp::MaxRegImm(out, arg, imm) => {
+                | SsaOp::MaxRegImm(out, arg, imm)
+                | SsaOp::ModRegImm(out, arg, imm) => {
                     let (op, swap) = match op {
                         SsaOp::AddRegImm(..) => ("ADD", false),
                         SsaOp::MulRegImm(..) => ("MUL", false),
@@ -328,6 +334,7 @@ impl SsaTape {
                         SsaOp::SubRegImm(..) => ("SUB", false),
                         SsaOp::MinRegImm(..) => ("MIN", false),
                         SsaOp::MaxRegImm(..) => ("MAX", false),
+                        SsaOp::ModRegImm(..) => ("MOD", false),
                         _ => unreachable!(),
                     };
                     if swap {

--- a/fidget/src/core/context/mod.rs
+++ b/fidget/src/core/context/mod.rs
@@ -536,6 +536,17 @@ impl Context {
         self.op_binary(a, b, BinaryOpcode::Compare)
     }
 
+    /// Builds a node that takes the modulo (least non-negative remainder)
+    pub fn modulo<A: IntoNode, B: IntoNode>(
+        &mut self,
+        a: A,
+        b: B,
+    ) -> Result<Node, Error> {
+        let a = a.into_node(self)?;
+        let b = b.into_node(self)?;
+        self.op_binary(a, b, BinaryOpcode::Mod)
+    }
+
     ////////////////////////////////////////////////////////////////////////////
 
     /// Remaps the X, Y, Z nodes to the given values

--- a/fidget/src/core/context/mod.rs
+++ b/fidget/src/core/context/mod.rs
@@ -672,6 +672,7 @@ impl Context {
                         .partial_cmp(&b)
                         .map(|i| i as i8 as f64)
                         .unwrap_or(f64::NAN),
+                    BinaryOpcode::Mod => a.rem_euclid(b),
                 }
             }
 
@@ -799,6 +800,7 @@ impl Context {
                 BinaryOpcode::Min => out += "min",
                 BinaryOpcode::Max => out += "max",
                 BinaryOpcode::Compare => out += "compare",
+                BinaryOpcode::Mod => out += "mod",
             },
             Op::Unary(op, ..) => match op {
                 UnaryOpcode::Neg => out += "neg",

--- a/fidget/src/core/context/op.rs
+++ b/fidget/src/core/context/op.rs
@@ -31,6 +31,7 @@ pub enum BinaryOpcode {
     Min,
     Max,
     Compare,
+    Mod,
 }
 
 /// An operation in a math expression.

--- a/fidget/src/core/eval/test/float_slice.rs
+++ b/fidget/src/core/eval/test/float_slice.rs
@@ -295,7 +295,7 @@ where
         }
     }
 
-    pub fn compare_float_results(
+    pub fn compare_float_results<C: CanonicalBinaryOp>(
         lhs: &[f32],
         rhs: &[f32],
         out: &[f32],
@@ -306,7 +306,10 @@ where
             let v = g(*a, *b);
             let err = (v - o).abs();
             assert!(
-                (o == v) || err < 1e-6 || (v.is_nan() && o.is_nan()),
+                (o == v)
+                    || C::discontinuous_at(*a, *b)
+                    || err < 1e-6
+                    || (v.is_nan() && o.is_nan()),
                 "mismatch in '{name}' at {a} {b}: {v} != {o} ({err})"
             )
         }
@@ -345,7 +348,7 @@ where
                     .unwrap();
 
                     let rhs = if i == j { &args } else { &rgsa };
-                    Self::compare_float_results(
+                    Self::compare_float_results::<C>(
                         &args,
                         rhs,
                         out,
@@ -386,7 +389,7 @@ where
                     .unwrap();
 
                     let rhs = vec![*rhs; out.len()];
-                    Self::compare_float_results(
+                    Self::compare_float_results::<C>(
                         &args,
                         &rhs,
                         out,
@@ -427,7 +430,7 @@ where
                     .unwrap();
 
                     let lhs = vec![*lhs; out.len()];
-                    Self::compare_float_results(
+                    Self::compare_float_results::<C>(
                         &lhs,
                         &args,
                         out,

--- a/fidget/src/core/eval/test/mod.rs
+++ b/fidget/src/core/eval/test/mod.rs
@@ -231,7 +231,7 @@ pub mod canonical {
         |a, b| a.rem_euclid(b),
         |a, b| {
             let v = a / b;
-            (v.round() - v).abs() < 1e-6
+            (v.round() - v).abs() < 1e-9
         }
     );
 }

--- a/fidget/src/core/eval/test/mod.rs
+++ b/fidget/src/core/eval/test/mod.rs
@@ -190,6 +190,7 @@ pub mod canonical {
 
     declare_canonical_binary!(Context::add, |a, b| a + b);
     declare_canonical_binary!(Context::sub, |a, b| a - b);
+    declare_canonical_binary!(Context::modulo, |a, b| a.rem_euclid(b));
     declare_canonical_binary_full!(
         Context::mul,
         |a, b| a * b,
@@ -277,5 +278,6 @@ macro_rules! all_binary_tests {
         $crate::one_binary_test!($tester, min);
         $crate::one_binary_test!($tester, max);
         $crate::one_binary_test!($tester, compare);
+        $crate::one_binary_test!($tester, modulo);
     };
 }

--- a/fidget/src/core/eval/test/mod.rs
+++ b/fidget/src/core/eval/test/mod.rs
@@ -190,7 +190,6 @@ pub mod canonical {
 
     declare_canonical_binary!(Context::add, |a, b| a + b);
     declare_canonical_binary!(Context::sub, |a, b| a - b);
-    declare_canonical_binary!(Context::modulo, |a, b| a.rem_euclid(b));
     declare_canonical_binary_full!(
         Context::mul,
         |a, b| a * b,
@@ -226,6 +225,14 @@ pub mod canonical {
             Some(v) => (v as i8).into(),
         },
         |a, b| a == b
+    );
+    declare_canonical_binary!(
+        Context::modulo,
+        |a, b| a.rem_euclid(b),
+        |a, b| {
+            let v = a / b;
+            (v.round() - v).abs() < 1e-6
+        }
     );
 }
 

--- a/fidget/src/core/eval/test/point.rs
+++ b/fidget/src/core/eval/test/point.rs
@@ -416,7 +416,7 @@ where
         }
     }
 
-    fn compare_point_results(
+    fn compare_point_results<C: CanonicalBinaryOp>(
         lhs: f32,
         rhs: f32,
         out: f32,
@@ -426,7 +426,10 @@ where
         let value = g(lhs, rhs);
         let err = (value - out).abs();
         assert!(
-            (out == value) || err < 1e-6 || value.is_nan() && out.is_nan(),
+            (out == value)
+                || C::discontinuous_at(lhs, rhs)
+                || err < 1e-6
+                || value.is_nan() && out.is_nan(),
             "mismatch in '{name}' at ({lhs}, {rhs}): \
                             {value} != {out} ({err})"
         )
@@ -464,7 +467,7 @@ where
                         .unwrap();
 
                         let rhs = if i == j { lhs } else { rhs };
-                        Self::compare_point_results(
+                        Self::compare_point_results::<C>(
                             lhs,
                             rhs,
                             out,
@@ -502,7 +505,7 @@ where
                     }
                     .unwrap();
 
-                    Self::compare_point_results(
+                    Self::compare_point_results::<C>(
                         lhs,
                         rhs,
                         out,
@@ -539,7 +542,7 @@ where
                     }
                     .unwrap();
 
-                    Self::compare_point_results(
+                    Self::compare_point_results::<C>(
                         lhs,
                         rhs,
                         out,

--- a/fidget/src/core/types/grad.rs
+++ b/fidget/src/core/types/grad.rs
@@ -186,6 +186,15 @@ impl Grad {
         }
     }
 
+    /// Least non-negative remainder
+    pub fn rem_euclid(&self, i: f32) -> Self {
+        // TODO is this right, or should we have deltas at multiples of i?
+        Grad {
+            v: self.v.rem_euclid(i),
+            ..*self
+        }
+    }
+
     /// Checks that the two values are roughly equal, panicking otherwise
     #[cfg(test)]
     pub(crate) fn compare_eq(&self, other: Self) {

--- a/fidget/src/core/types/grad.rs
+++ b/fidget/src/core/types/grad.rs
@@ -187,11 +187,13 @@ impl Grad {
     }
 
     /// Least non-negative remainder
-    pub fn rem_euclid(&self, i: f32) -> Self {
-        // TODO is this right, or should we have deltas at multiples of i?
+    pub fn rem_euclid(&self, rhs: Grad) -> Self {
+        let e = self.v.div_euclid(rhs.v);
         Grad {
-            v: self.v.rem_euclid(i),
-            ..*self
+            v: self.v.rem_euclid(rhs.v),
+            dx: self.dx - rhs.dx * e,
+            dy: self.dy - rhs.dy * e,
+            dz: self.dz - rhs.dz * e,
         }
     }
 

--- a/fidget/src/core/types/interval.rs
+++ b/fidget/src/core/types/interval.rs
@@ -289,9 +289,9 @@ impl Interval {
     }
 
     /// Least non-negative remainder
-    pub fn rem_euclid(&self, i: f32) -> Self {
+    pub fn rem_euclid(&self, other: Interval) -> Self {
         // TODO optimize this
-        Interval::new(0.0, i)
+        Interval::new(0.0, other.abs().upper())
     }
 }
 

--- a/fidget/src/core/types/interval.rs
+++ b/fidget/src/core/types/interval.rs
@@ -290,8 +290,12 @@ impl Interval {
 
     /// Least non-negative remainder
     pub fn rem_euclid(&self, other: Interval) -> Self {
-        // TODO optimize this
-        Interval::new(0.0, other.abs().upper())
+        if self.has_nan() || other.has_nan() || other.contains(0.0) {
+            f32::NAN.into()
+        } else {
+            // TODO optimize this
+            Interval::new(0.0, other.abs().upper())
+        }
     }
 }
 

--- a/fidget/src/core/types/interval.rs
+++ b/fidget/src/core/types/interval.rs
@@ -287,6 +287,12 @@ impl Interval {
             panic!("lhs != rhs ({self:?} != {other:?})");
         }
     }
+
+    /// Least non-negative remainder
+    pub fn rem_euclid(&self, i: f32) -> Self {
+        // TODO optimize this
+        Interval::new(0.0, i)
+    }
 }
 
 impl std::fmt::Display for Interval {

--- a/fidget/src/core/vm/data.rs
+++ b/fidget/src/core/vm/data.rs
@@ -252,7 +252,8 @@ impl<const N: usize> VmData<N> {
                 | SsaOp::DivRegImm(index, arg, _imm)
                 | SsaOp::DivImmReg(index, arg, _imm)
                 | SsaOp::CompareRegImm(index, arg, _imm)
-                | SsaOp::CompareImmReg(index, arg, _imm) => {
+                | SsaOp::CompareImmReg(index, arg, _imm)
+                | SsaOp::ModRegImm(index, arg, _imm) => {
                     *index = new_index;
                     *arg = workspace.get_or_insert_active(*arg);
                 }

--- a/fidget/src/core/vm/data.rs
+++ b/fidget/src/core/vm/data.rs
@@ -240,7 +240,8 @@ impl<const N: usize> VmData<N> {
                 | SsaOp::MulRegReg(index, lhs, rhs)
                 | SsaOp::SubRegReg(index, lhs, rhs)
                 | SsaOp::DivRegReg(index, lhs, rhs)
-                | SsaOp::CompareRegReg(index, lhs, rhs) => {
+                | SsaOp::CompareRegReg(index, lhs, rhs)
+                | SsaOp::ModRegReg(index, lhs, rhs) => {
                     *index = new_index;
                     *lhs = workspace.get_or_insert_active(*lhs);
                     *rhs = workspace.get_or_insert_active(*rhs);
@@ -253,7 +254,8 @@ impl<const N: usize> VmData<N> {
                 | SsaOp::DivImmReg(index, arg, _imm)
                 | SsaOp::CompareRegImm(index, arg, _imm)
                 | SsaOp::CompareImmReg(index, arg, _imm)
-                | SsaOp::ModRegImm(index, arg, _imm) => {
+                | SsaOp::ModRegImm(index, arg, _imm)
+                | SsaOp::ModImmReg(index, arg, _imm) => {
                     *index = new_index;
                     *arg = workspace.get_or_insert_active(*arg);
                 }

--- a/fidget/src/core/vm/mod.rs
+++ b/fidget/src/core/vm/mod.rs
@@ -361,8 +361,14 @@ impl<const N: usize> TracingEvaluator for VmIntervalEval<N> {
                     *choices.next().unwrap() |= choice;
                     simplify |= choice != Choice::Both;
                 }
+                RegOp::ModRegReg(out, lhs, rhs) => {
+                    v[out] = v[lhs].rem_euclid(v[rhs]);
+                }
                 RegOp::ModRegImm(out, arg, imm) => {
-                    v[out] = v[arg].rem_euclid(imm);
+                    v[out] = v[arg].rem_euclid(imm.into());
+                }
+                RegOp::ModImmReg(out, arg, imm) => {
+                    v[out] = Interval::from(imm).rem_euclid(v[arg]);
                 }
                 RegOp::AddRegReg(out, lhs, rhs) => v[out] = v[lhs] + v[rhs],
                 RegOp::MulRegReg(out, lhs, rhs) => v[out] = v[lhs] * v[rhs],
@@ -574,8 +580,14 @@ impl<const N: usize> TracingEvaluator for VmPointEval<N> {
                     *choices.next().unwrap() |= choice;
                     simplify |= choice != Choice::Both;
                 }
+                RegOp::ModRegReg(out, lhs, rhs) => {
+                    v[out] = v[lhs].rem_euclid(v[rhs]);
+                }
                 RegOp::ModRegImm(out, arg, imm) => {
                     v[out] = v[arg].rem_euclid(imm);
+                }
+                RegOp::ModImmReg(out, arg, imm) => {
+                    v[out] = imm.rem_euclid(v[arg]);
                 }
                 RegOp::AddRegReg(out, lhs, rhs) => {
                     v[out] = v[lhs] + v[rhs];
@@ -863,9 +875,19 @@ impl<const N: usize> BulkEvaluator for VmFloatSliceEval<N> {
                         };
                     }
                 }
+                RegOp::ModRegReg(out, lhs, rhs) => {
+                    for i in 0..size {
+                        v[out][i] = v[lhs][i].rem_euclid(v[rhs][i]);
+                    }
+                }
                 RegOp::ModRegImm(out, arg, imm) => {
                     for i in 0..size {
                         v[out][i] = v[arg][i].rem_euclid(imm);
+                    }
+                }
+                RegOp::ModImmReg(out, arg, imm) => {
+                    for i in 0..size {
+                        v[out][i] = imm.rem_euclid(v[arg][i]);
                     }
                 }
                 RegOp::AddRegReg(out, lhs, rhs) => {
@@ -1127,9 +1149,19 @@ impl<const N: usize> BulkEvaluator for VmGradSliceEval<N> {
                         };
                     }
                 }
+                RegOp::ModRegReg(out, lhs, rhs) => {
+                    for i in 0..size {
+                        v[out][i] = v[lhs][i].rem_euclid(v[rhs][i].v);
+                    }
+                }
                 RegOp::ModRegImm(out, arg, imm) => {
                     for i in 0..size {
                         v[out][i] = v[arg][i].rem_euclid(imm);
+                    }
+                }
+                RegOp::ModImmReg(out, arg, imm) => {
+                    for i in 0..size {
+                        v[out][i] = imm.rem_euclid(v[arg][i].v).into();
                     }
                 }
                 RegOp::AddRegReg(out, lhs, rhs) => {

--- a/fidget/src/core/vm/mod.rs
+++ b/fidget/src/core/vm/mod.rs
@@ -1151,17 +1151,17 @@ impl<const N: usize> BulkEvaluator for VmGradSliceEval<N> {
                 }
                 RegOp::ModRegReg(out, lhs, rhs) => {
                     for i in 0..size {
-                        v[out][i] = v[lhs][i].rem_euclid(v[rhs][i].v);
+                        v[out][i] = v[lhs][i].rem_euclid(v[rhs][i]);
                     }
                 }
                 RegOp::ModRegImm(out, arg, imm) => {
                     for i in 0..size {
-                        v[out][i] = v[arg][i].rem_euclid(imm);
+                        v[out][i] = v[arg][i].rem_euclid(imm.into());
                     }
                 }
                 RegOp::ModImmReg(out, arg, imm) => {
                     for i in 0..size {
-                        v[out][i] = imm.rem_euclid(v[arg][i].v).into();
+                        v[out][i] = Grad::from(imm).rem_euclid(v[arg][i]);
                     }
                 }
                 RegOp::AddRegReg(out, lhs, rhs) => {

--- a/fidget/src/core/vm/mod.rs
+++ b/fidget/src/core/vm/mod.rs
@@ -361,6 +361,9 @@ impl<const N: usize> TracingEvaluator for VmIntervalEval<N> {
                     *choices.next().unwrap() |= choice;
                     simplify |= choice != Choice::Both;
                 }
+                RegOp::ModRegImm(out, arg, imm) => {
+                    v[out] = v[arg].rem_euclid(imm);
+                }
                 RegOp::AddRegReg(out, lhs, rhs) => v[out] = v[lhs] + v[rhs],
                 RegOp::MulRegReg(out, lhs, rhs) => v[out] = v[lhs] * v[rhs],
                 RegOp::DivRegReg(out, lhs, rhs) => v[out] = v[lhs] / v[rhs],
@@ -570,6 +573,9 @@ impl<const N: usize> TracingEvaluator for VmPointEval<N> {
                     v[out] = value;
                     *choices.next().unwrap() |= choice;
                     simplify |= choice != Choice::Both;
+                }
+                RegOp::ModRegImm(out, arg, imm) => {
+                    v[out] = v[arg].rem_euclid(imm);
                 }
                 RegOp::AddRegReg(out, lhs, rhs) => {
                     v[out] = v[lhs] + v[rhs];
@@ -857,6 +863,11 @@ impl<const N: usize> BulkEvaluator for VmFloatSliceEval<N> {
                         };
                     }
                 }
+                RegOp::ModRegImm(out, arg, imm) => {
+                    for i in 0..size {
+                        v[out][i] = v[arg][i].rem_euclid(imm);
+                    }
+                }
                 RegOp::AddRegReg(out, lhs, rhs) => {
                     for i in 0..size {
                         v[out][i] = v[lhs][i] + v[rhs][i];
@@ -1114,6 +1125,11 @@ impl<const N: usize> BulkEvaluator for VmGradSliceEval<N> {
                         } else {
                             v[arg][i].max(imm)
                         };
+                    }
+                }
+                RegOp::ModRegImm(out, arg, imm) => {
+                    for i in 0..size {
+                        v[out][i] = v[arg][i].rem_euclid(imm);
                     }
                 }
                 RegOp::AddRegReg(out, lhs, rhs) => {

--- a/fidget/src/jit/aarch64/float_slice.rs
+++ b/fidget/src/jit/aarch64/float_slice.rs
@@ -291,6 +291,15 @@ impl Assembler for FloatSliceAssembler {
             ; fmin V(reg(out_reg)).s4, V(reg(lhs_reg)).s4, V(reg(rhs_reg)).s4
         )
     }
+    fn build_mod(&mut self, out_reg: u8, arg_reg: u8, imm: f32) {
+        let r = self.load_imm(imm);
+        dynasm!(self.0.ops
+            ; fdiv v7.s4, V(reg(arg_reg)).s4, V(reg(r)).s4
+            ; frintm v7.s4, v7.s4 // round down
+            ; fmul v7.s4, v7.s4, V(reg(r)).s4
+            ; fsub V(reg(out_reg)).s4, V(reg(arg_reg)).s4, v7.s4
+        )
+    }
 
     fn build_compare(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
         dynasm!(self.0.ops

--- a/fidget/src/jit/aarch64/float_slice.rs
+++ b/fidget/src/jit/aarch64/float_slice.rs
@@ -293,9 +293,10 @@ impl Assembler for FloatSliceAssembler {
     }
     fn build_mod(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
         dynasm!(self.0.ops
-            ; fdiv v7.s4, V(reg(lhs_reg)).s4, V(reg(rhs_reg)).s4
+            ; fabs v6.s4, V(reg(rhs_reg)).s4
+            ; fdiv v7.s4, V(reg(lhs_reg)).s4, v6.s4
             ; frintm v7.s4, v7.s4 // round down
-            ; fmul v7.s4, v7.s4, V(reg(rhs_reg)).s4
+            ; fmul v7.s4, v7.s4, v6.s4
             ; fsub V(reg(out_reg)).s4, V(reg(lhs_reg)).s4, v7.s4
         )
     }

--- a/fidget/src/jit/aarch64/float_slice.rs
+++ b/fidget/src/jit/aarch64/float_slice.rs
@@ -291,13 +291,12 @@ impl Assembler for FloatSliceAssembler {
             ; fmin V(reg(out_reg)).s4, V(reg(lhs_reg)).s4, V(reg(rhs_reg)).s4
         )
     }
-    fn build_mod(&mut self, out_reg: u8, arg_reg: u8, imm: f32) {
-        let r = self.load_imm(imm);
+    fn build_mod(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
         dynasm!(self.0.ops
-            ; fdiv v7.s4, V(reg(arg_reg)).s4, V(reg(r)).s4
+            ; fdiv v7.s4, V(reg(lhs_reg)).s4, V(reg(rhs_reg)).s4
             ; frintm v7.s4, v7.s4 // round down
-            ; fmul v7.s4, v7.s4, V(reg(r)).s4
-            ; fsub V(reg(out_reg)).s4, V(reg(arg_reg)).s4, v7.s4
+            ; fmul v7.s4, v7.s4, V(reg(rhs_reg)).s4
+            ; fsub V(reg(out_reg)).s4, V(reg(lhs_reg)).s4, v7.s4
         )
     }
 

--- a/fidget/src/jit/aarch64/grad_slice.rs
+++ b/fidget/src/jit/aarch64/grad_slice.rs
@@ -403,6 +403,10 @@ impl Assembler for GradSliceAssembler {
         )
     }
 
+    fn build_mod(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
+        unimplemented!()
+    }
+
     fn build_compare(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
         dynasm!(self.0.ops
             // Check whether either argument is NAN

--- a/fidget/src/jit/aarch64/interval.rs
+++ b/fidget/src/jit/aarch64/interval.rs
@@ -482,6 +482,10 @@ impl Assembler for IntervalAssembler {
         )
     }
 
+    fn build_mod(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
+        unimplemented!()
+    }
+
     fn build_compare(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
         dynasm!(self.0.ops
             // Very similar to build_min, but without writing choices

--- a/fidget/src/jit/aarch64/interval.rs
+++ b/fidget/src/jit/aarch64/interval.rs
@@ -483,7 +483,13 @@ impl Assembler for IntervalAssembler {
     }
 
     fn build_mod(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
-        unimplemented!()
+        extern "C" fn interval_modulo(
+            lhs: Interval,
+            rhs: Interval,
+        ) -> Interval {
+            lhs.rem_euclid(rhs)
+        }
+        self.call_fn_binary(out_reg, lhs_reg, rhs_reg, interval_modulo);
     }
 
     fn build_compare(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
@@ -631,6 +637,81 @@ impl IntervalAssembler {
             // Prepare to call our stuff!
             ; mov s0, V(reg(arg_reg)).s[0]
             ; mov s1, V(reg(arg_reg)).s[1]
+
+            ; blr x0
+
+            // Restore floating-point state
+            ; ldp d16, d17, [sp, 0x50]
+            ; ldp d18, d19, [sp, 0x60]
+            ; ldp d20, d21, [sp, 0x70]
+            ; ldp d22, d23, [sp, 0x80]
+            ; ldp d24, d25, [sp, 0x90]
+            ; ldp d26, d27, [sp, 0xa0]
+            ; ldp d28, d29, [sp, 0xb0]
+            ; ldp d30, d31, [sp, 0xc0]
+
+            // Set our output value
+            ; mov V(reg(out_reg)).s[0], v0.s[0]
+            ; mov V(reg(out_reg)).s[1], v1.s[0]
+
+            // Restore X/Y/Z values
+            ; ldp d0, d1, [sp, 0xd0]
+            ; ldr d2, [sp, 0xe0]
+
+            // Restore registers
+            ; mov x0, x20
+            ; mov x1, x21
+            ; mov x2, x22
+        );
+    }
+
+    fn call_fn_binary(
+        &mut self,
+        out_reg: u8,
+        lhs_reg: u8,
+        rhs_reg: u8,
+        f: extern "C" fn(Interval, Interval) -> Interval,
+    ) {
+        if !self.0.saved_callee_regs {
+            dynasm!(self.0.ops
+                // Back up a few callee-saved registers that we're about to use
+                ; stp x20, x21, [sp, 0xe8]
+                ; str x22, [sp, 0xf8]
+            );
+            self.0.saved_callee_regs = true;
+        }
+
+        let addr = f as usize;
+        dynasm!(self.0.ops
+            // Back up our current state to callee-saved registers
+            ; mov x20, x0
+            ; mov x21, x1
+            ; mov x22, x2
+
+            // Back up our state
+            ; stp d16, d17, [sp, 0x50]
+            ; stp d18, d19, [sp, 0x60]
+            ; stp d20, d21, [sp, 0x70]
+            ; stp d22, d23, [sp, 0x80]
+            ; stp d24, d25, [sp, 0x90]
+            ; stp d26, d27, [sp, 0xa0]
+            ; stp d28, d29, [sp, 0xb0]
+            ; stp d30, d31, [sp, 0xc0]
+            ; stp d0, d1, [sp, 0xd0]
+            ; str d2, [sp, 0xe0]
+
+            // Load the function address, awkwardly, into a caller-saved
+            // register (so we only need to do this once)
+            ; movz x0, #((addr >> 48) as u32), lsl 48
+            ; movk x0, #((addr >> 32) as u32), lsl 32
+            ; movk x0, #((addr >> 16) as u32), lsl 16
+            ; movk x0, #(addr as u32)
+
+            // Prepare to call our stuff!
+            ; mov s0, V(reg(lhs_reg)).s[0]
+            ; mov s1, V(reg(lhs_reg)).s[1]
+            ; mov s2, V(reg(rhs_reg)).s[0]
+            ; mov s3, V(reg(rhs_reg)).s[1]
 
             ; blr x0
 

--- a/fidget/src/jit/aarch64/point.rs
+++ b/fidget/src/jit/aarch64/point.rs
@@ -277,6 +277,10 @@ impl Assembler for PointAssembler {
         )
     }
 
+    fn build_mod(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
+        unimplemented!()
+    }
+
     fn build_compare(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
         // This is using SIMD instructions to avoid branch; dunno if it's faster
         // but it means we can use very similar code to float / grad slice

--- a/fidget/src/jit/aarch64/point.rs
+++ b/fidget/src/jit/aarch64/point.rs
@@ -278,7 +278,13 @@ impl Assembler for PointAssembler {
     }
 
     fn build_mod(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
-        unimplemented!()
+        dynasm!(self.0.ops
+            ; fabs s6, S(reg(rhs_reg))
+            ; fdiv s7, S(reg(lhs_reg)), s6
+            ; frintm s7, s7 // round down
+            ; fmul s7, s7, s6
+            ; fsub S(reg(out_reg)), S(reg(lhs_reg)), s7
+        )
     }
 
     fn build_compare(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {

--- a/fidget/src/jit/mod.rs
+++ b/fidget/src/jit/mod.rs
@@ -210,7 +210,7 @@ trait Assembler {
     fn build_min(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8);
 
     /// Modulo of two values (least non-negative remainder)
-    fn build_mod(&mut self, out_reg: u8, arg_reg: u8, imm: f32);
+    fn build_mod(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8);
 
     // Special-case functions for immediates.  In some cases, you can be more
     // efficient if you know that an argument is an immediate (for example, both
@@ -738,8 +738,16 @@ fn build_asm_fn_with_storage<A: Assembler>(
                 let reg = asm.load_imm(imm);
                 asm.build_max(out, arg, reg);
             }
+            RegOp::ModRegReg(out, lhs, rhs) => {
+                asm.build_mod(out, lhs, rhs);
+            }
             RegOp::ModRegImm(out, arg, imm) => {
-                asm.build_mod(out, arg, imm);
+                let reg = asm.load_imm(imm);
+                asm.build_mod(out, arg, reg);
+            }
+            RegOp::ModImmReg(out, arg, imm) => {
+                let reg = asm.load_imm(imm);
+                asm.build_mod(out, reg, arg);
             }
             RegOp::CopyImm(out, imm) => {
                 let reg = asm.load_imm(imm);

--- a/fidget/src/jit/mod.rs
+++ b/fidget/src/jit/mod.rs
@@ -205,9 +205,12 @@ trait Assembler {
 
     /// Minimum of two values
     ///
-    /// In a tracing evaluator, this function must also write to the `choices`
+    /// In a tracing evaluator, this function muld also write to the `choices`
     /// array and may set `simplify` if one branch is always taken.
     fn build_min(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8);
+
+    /// Modulo of two values (least non-negative remainder)
+    fn build_mod(&mut self, out_reg: u8, arg_reg: u8, imm: f32);
 
     // Special-case functions for immediates.  In some cases, you can be more
     // efficient if you know that an argument is an immediate (for example, both
@@ -734,6 +737,9 @@ fn build_asm_fn_with_storage<A: Assembler>(
             RegOp::MaxRegImm(out, arg, imm) => {
                 let reg = asm.load_imm(imm);
                 asm.build_max(out, arg, reg);
+            }
+            RegOp::ModRegImm(out, arg, imm) => {
+                asm.build_mod(out, arg, imm);
             }
             RegOp::CopyImm(out, imm) => {
                 let reg = asm.load_imm(imm);

--- a/fidget/src/jit/x86_64/float_slice.rs
+++ b/fidget/src/jit/x86_64/float_slice.rs
@@ -268,6 +268,19 @@ impl Assembler for FloatSliceAssembler {
             ; vorps Ry(reg(out_reg)), Ry(reg(out_reg)), ymm1
         );
     }
+    fn build_mod(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
+        dynasm!(self.0.ops
+            // Take abs(rhs_reg)
+            ; vpcmpeqw ymm2, ymm2, ymm2
+            ; vpsrld ymm2, ymm2, 1 // everything but the sign bit
+            ; vpand ymm1, ymm2, Ry(reg(rhs_reg))
+
+            ; vdivps ymm2, Ry(reg(lhs_reg)), ymm1
+            ; vroundps ymm2, ymm2, 0b1 // floor
+            ; vmulps ymm2, ymm2, ymm1
+            ; vsubps Ry(reg(out_reg)), Ry(reg(lhs_reg)), ymm2
+        );
+    }
     fn build_compare(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
         dynasm!(self.0.ops
             // Build a mask of NANs; conveniently, all 1s is a NAN

--- a/fidget/src/jit/x86_64/grad_slice.rs
+++ b/fidget/src/jit/x86_64/grad_slice.rs
@@ -387,6 +387,9 @@ impl Assembler for GradSliceAssembler {
         );
         self.0.ops.commit_local().unwrap();
     }
+    fn build_mod(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
+        unimplemented!()
+    }
     fn build_compare(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
         dynasm!(self.0.ops
             ; vcomiss Rx(reg(lhs_reg)), Rx(reg(rhs_reg))

--- a/fidget/src/jit/x86_64/interval.rs
+++ b/fidget/src/jit/x86_64/interval.rs
@@ -499,6 +499,9 @@ impl Assembler for IntervalAssembler {
         );
         self.0.ops.commit_local().unwrap();
     }
+    fn build_mod(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
+        unimplemented!()
+    }
     fn build_compare(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
         // TODO: Godbolt uses unpcklps ?
         dynasm!(self.0.ops

--- a/fidget/src/jit/x86_64/point.rs
+++ b/fidget/src/jit/x86_64/point.rs
@@ -287,7 +287,17 @@ impl Assembler for PointAssembler {
         self.0.ops.commit_local().unwrap()
     }
     fn build_mod(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
-        unimplemented!()
+        dynasm!(self.0.ops
+            // Take abs(rhs_reg)
+            ; mov eax, 0x7fffffffu32 as i32
+            ; vmovd xmm2, eax
+            ; vandps xmm1, xmm2, Rx(reg(rhs_reg))
+
+            ; vdivss xmm2, Rx(reg(lhs_reg)), xmm1
+            ; vroundss xmm2, xmm2, xmm2, 0b1 // floor
+            ; vmulss xmm2, xmm2, xmm1
+            ; vsubss Rx(reg(out_reg)), Rx(reg(lhs_reg)), xmm2
+        );
     }
     fn build_compare(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
         dynasm!(self.0.ops

--- a/fidget/src/jit/x86_64/point.rs
+++ b/fidget/src/jit/x86_64/point.rs
@@ -286,6 +286,9 @@ impl Assembler for PointAssembler {
         );
         self.0.ops.commit_local().unwrap()
     }
+    fn build_mod(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
+        unimplemented!()
+    }
     fn build_compare(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
         dynasm!(self.0.ops
             ; vcomiss Rx(reg(lhs_reg)), Rx(reg(rhs_reg))


### PR DESCRIPTION
We're punting on assembly-level implementation for the interval and gradient JITs, because it's tedious.