### PR TITLE
Logical ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 - Fix an edge case in meshing where nearly-planar surfaces could produce
   vertexes far from the desired position.
 - Add the `modulo` (Euclidean remainder) operation
+- Add logical operations (`and`, `or`, `not`), which can be used to build
+  pseudo-conditionals which are simplified by the `TracingEvaluator`.
 
 # 0.2.2
 - Added many transcendental functions: `sin`, `cos`, `tan`, `asin`, `acos`,

--- a/fidget/src/core/compiler/alloc.rs
+++ b/fidget/src/core/compiler/alloc.rs
@@ -259,6 +259,7 @@ impl<const N: usize> RegisterAllocator<N> {
             SsaOp::AtanReg(out, arg) => (out, arg, RegOp::AtanReg),
             SsaOp::ExpReg(out, arg) => (out, arg, RegOp::ExpReg),
             SsaOp::LnReg(out, arg) => (out, arg, RegOp::LnReg),
+            SsaOp::NotReg(out, arg) => (out, arg, RegOp::NotReg),
             SsaOp::CopyReg(out, arg) => (out, arg, RegOp::CopyReg),
             _ => panic!("Bad opcode: {op:?}"),
         };
@@ -286,7 +287,8 @@ impl<const N: usize> RegisterAllocator<N> {
             | SsaOp::AcosReg(..)
             | SsaOp::AtanReg(..)
             | SsaOp::ExpReg(..)
-            | SsaOp::LnReg(..) => self.op_reg(op),
+            | SsaOp::LnReg(..)
+            | SsaOp::NotReg(..) => self.op_reg(op),
 
             SsaOp::AddRegImm(..)
             | SsaOp::SubRegImm(..)

--- a/fidget/src/core/compiler/alloc.rs
+++ b/fidget/src/core/compiler/alloc.rs
@@ -299,7 +299,9 @@ impl<const N: usize> RegisterAllocator<N> {
             | SsaOp::CompareRegImm(..)
             | SsaOp::CompareImmReg(..)
             | SsaOp::ModRegImm(..)
-            | SsaOp::ModImmReg(..) => self.op_reg_imm(op),
+            | SsaOp::ModImmReg(..)
+            | SsaOp::AndRegImm(..)
+            | SsaOp::OrRegImm(..) => self.op_reg_imm(op),
 
             SsaOp::AddRegReg(..)
             | SsaOp::SubRegReg(..)
@@ -308,7 +310,9 @@ impl<const N: usize> RegisterAllocator<N> {
             | SsaOp::MinRegReg(..)
             | SsaOp::MaxRegReg(..)
             | SsaOp::CompareRegReg(..)
-            | SsaOp::ModRegReg(..) => self.op_reg_reg(op),
+            | SsaOp::ModRegReg(..)
+            | SsaOp::AndRegReg(..)
+            | SsaOp::OrRegReg(..) => self.op_reg_reg(op),
         }
     }
 
@@ -497,6 +501,10 @@ impl<const N: usize> RegisterAllocator<N> {
             SsaOp::ModRegReg(out, lhs, rhs) => {
                 (out, lhs, rhs, RegOp::ModRegReg)
             }
+            SsaOp::AndRegReg(out, lhs, rhs) => {
+                (out, lhs, rhs, RegOp::AndRegReg)
+            }
+            SsaOp::OrRegReg(out, lhs, rhs) => (out, lhs, rhs, RegOp::OrRegReg),
             _ => panic!("Bad opcode: {op:?}"),
         };
         let r_x = self.get_out_reg(out);
@@ -621,6 +629,10 @@ impl<const N: usize> RegisterAllocator<N> {
             SsaOp::ModImmReg(out, arg, imm) => {
                 (out, arg, imm, RegOp::ModImmReg)
             }
+            SsaOp::AndRegImm(out, arg, imm) => {
+                (out, arg, imm, RegOp::AndRegImm)
+            }
+            SsaOp::OrRegImm(out, arg, imm) => (out, arg, imm, RegOp::OrRegImm),
             _ => panic!("Bad opcode: {op:?}"),
         };
         self.op_reg_fn(out, arg, |out, arg| op(out, arg, imm));

--- a/fidget/src/core/compiler/op.rs
+++ b/fidget/src/core/compiler/op.rs
@@ -91,6 +91,10 @@ macro_rules! opcodes {
             MinRegImm($t, $t, f32),
             #[doc = "Compute the maximum of a register and an immediate"]
             MaxRegImm($t, $t, f32),
+            #[doc = "Multiplies the two values, short-circuiting if either is 0"]
+            AndRegImm($t, $t, f32),
+            #[doc = "Add two values, short-circuiting if either is 0"]
+            OrRegImm($t, $t, f32),
             #[doc = "Compares a register with an immediate"]
             CompareRegImm($t, $t, f32),
             #[doc = "Compares an immediate with a register"]
@@ -108,6 +112,10 @@ macro_rules! opcodes {
             MinRegReg($t, $t, $t),
             #[doc = "Take the maximum of two registers"]
             MaxRegReg($t, $t, $t),
+            #[doc = "Multiply two values, short-circuiting if either is 0"]
+            AndRegReg($t, $t, $t),
+            #[doc = "Add two values, short-circuiting if either is 0"]
+            OrRegReg($t, $t, $t),
             #[doc = "Compares two registers"]
             CompareRegReg($t, $t, $t),
 
@@ -177,7 +185,11 @@ impl SsaOp {
             | SsaOp::CompareImmReg(out, ..)
             | SsaOp::ModRegReg(out, ..)
             | SsaOp::ModRegImm(out, ..)
-            | SsaOp::ModImmReg(out, ..) => *out,
+            | SsaOp::ModImmReg(out, ..)
+            | SsaOp::AndRegImm(out, ..)
+            | SsaOp::AndRegReg(out, ..)
+            | SsaOp::OrRegImm(out, ..)
+            | SsaOp::OrRegReg(out, ..) => *out,
         }
     }
     /// Returns true if the given opcode is associated with a choice
@@ -219,7 +231,11 @@ impl SsaOp {
             SsaOp::MinRegImm(..)
             | SsaOp::MaxRegImm(..)
             | SsaOp::MinRegReg(..)
-            | SsaOp::MaxRegReg(..) => true,
+            | SsaOp::MaxRegReg(..)
+            | SsaOp::AndRegImm(..)
+            | SsaOp::AndRegReg(..)
+            | SsaOp::OrRegImm(..)
+            | SsaOp::OrRegReg(..) => true,
         }
     }
 }

--- a/fidget/src/core/compiler/op.rs
+++ b/fidget/src/core/compiler/op.rs
@@ -66,6 +66,9 @@ macro_rules! opcodes {
             #[doc = "Computes the natural log of the given register"]
             LnReg($t, $t),
 
+            #[doc = "Computes the logical negation of the given register"]
+            NotReg($t, $t),
+
             #[doc = "Copies the given register"]
             CopyReg($t, $t),
 
@@ -166,6 +169,7 @@ impl SsaOp {
             | SsaOp::AtanReg(out, ..)
             | SsaOp::ExpReg(out, ..)
             | SsaOp::LnReg(out, ..)
+            | SsaOp::NotReg(out, ..)
             | SsaOp::AddRegImm(out, ..)
             | SsaOp::MulRegImm(out, ..)
             | SsaOp::DivRegImm(out, ..)
@@ -212,6 +216,7 @@ impl SsaOp {
             | SsaOp::AtanReg(..)
             | SsaOp::ExpReg(..)
             | SsaOp::LnReg(..)
+            | SsaOp::NotReg(..)
             | SsaOp::AddRegImm(..)
             | SsaOp::MulRegImm(..)
             | SsaOp::SubRegImm(..)

--- a/fidget/src/core/compiler/ssa_tape.rs
+++ b/fidget/src/core/compiler/ssa_tape.rs
@@ -161,6 +161,14 @@ impl SsaTape {
                             SsaOp::MaxRegImm,
                             SsaOp::MaxRegImm,
                         ),
+                        BinaryOpcode::And => (
+                            SsaOp::AndRegReg,
+                            SsaOp::AndRegImm,
+                            SsaOp::AndRegImm,
+                        ),
+                        BinaryOpcode::Or => {
+                            (SsaOp::OrRegReg, SsaOp::OrRegImm, SsaOp::OrRegImm)
+                        }
                         BinaryOpcode::Compare => (
                             SsaOp::CompareRegReg,
                             SsaOp::CompareRegImm,
@@ -304,7 +312,9 @@ impl SsaTape {
                 | SsaOp::SubRegReg(out, lhs, rhs)
                 | SsaOp::MinRegReg(out, lhs, rhs)
                 | SsaOp::MaxRegReg(out, lhs, rhs)
-                | SsaOp::ModRegReg(out, lhs, rhs) => {
+                | SsaOp::ModRegReg(out, lhs, rhs)
+                | SsaOp::AndRegReg(out, lhs, rhs)
+                | SsaOp::OrRegReg(out, lhs, rhs) => {
                     let op = match op {
                         SsaOp::AddRegReg(..) => "ADD",
                         SsaOp::MulRegReg(..) => "MUL",
@@ -313,6 +323,8 @@ impl SsaTape {
                         SsaOp::MinRegReg(..) => "MIN",
                         SsaOp::MaxRegReg(..) => "MAX",
                         SsaOp::ModRegReg(..) => "MAX",
+                        SsaOp::AndRegReg(..) => "AND",
+                        SsaOp::OrRegReg(..) => "OR",
                         _ => unreachable!(),
                     };
                     println!("${out} = {op} ${lhs} ${rhs}");
@@ -327,7 +339,9 @@ impl SsaTape {
                 | SsaOp::MinRegImm(out, arg, imm)
                 | SsaOp::MaxRegImm(out, arg, imm)
                 | SsaOp::ModRegImm(out, arg, imm)
-                | SsaOp::ModImmReg(out, arg, imm) => {
+                | SsaOp::ModImmReg(out, arg, imm)
+                | SsaOp::AndRegImm(out, arg, imm)
+                | SsaOp::OrRegImm(out, arg, imm) => {
                     let (op, swap) = match op {
                         SsaOp::AddRegImm(..) => ("ADD", false),
                         SsaOp::MulRegImm(..) => ("MUL", false),
@@ -339,6 +353,8 @@ impl SsaTape {
                         SsaOp::MaxRegImm(..) => ("MAX", false),
                         SsaOp::ModRegImm(..) => ("MOD", false),
                         SsaOp::ModImmReg(..) => ("MOD", true),
+                        SsaOp::AndRegImm(..) => ("AND", true),
+                        SsaOp::OrRegImm(..) => ("OR", true),
                         _ => unreachable!(),
                     };
                     if swap {

--- a/fidget/src/core/compiler/ssa_tape.rs
+++ b/fidget/src/core/compiler/ssa_tape.rs
@@ -181,7 +181,13 @@ impl SsaTape {
                         ),
                     };
 
-                    if matches!(op, BinaryOpcode::Min | BinaryOpcode::Max) {
+                    if matches!(
+                        op,
+                        BinaryOpcode::Min
+                            | BinaryOpcode::Max
+                            | BinaryOpcode::And
+                            | BinaryOpcode::Or
+                    ) {
                         choice_count += 1;
                     }
 
@@ -353,8 +359,8 @@ impl SsaTape {
                         SsaOp::MaxRegImm(..) => ("MAX", false),
                         SsaOp::ModRegImm(..) => ("MOD", false),
                         SsaOp::ModImmReg(..) => ("MOD", true),
-                        SsaOp::AndRegImm(..) => ("AND", true),
-                        SsaOp::OrRegImm(..) => ("OR", true),
+                        SsaOp::AndRegImm(..) => ("AND", false),
+                        SsaOp::OrRegImm(..) => ("OR", false),
                         _ => unreachable!(),
                     };
                     if swap {

--- a/fidget/src/core/compiler/ssa_tape.rs
+++ b/fidget/src/core/compiler/ssa_tape.rs
@@ -164,11 +164,17 @@ impl SsaTape {
                         BinaryOpcode::And => (
                             SsaOp::AndRegReg,
                             SsaOp::AndRegImm,
-                            SsaOp::AndRegImm,
+                            |_out, _lhs, _rhs| {
+                                panic!("AndImmReg must be collapsed")
+                            },
                         ),
-                        BinaryOpcode::Or => {
-                            (SsaOp::OrRegReg, SsaOp::OrRegImm, SsaOp::OrRegImm)
-                        }
+                        BinaryOpcode::Or => (
+                            SsaOp::OrRegReg,
+                            SsaOp::OrRegImm,
+                            |_out, _lhs, _rhs| {
+                                panic!("OrImmReg must be collapsed")
+                            },
+                        ),
                         BinaryOpcode::Compare => (
                             SsaOp::CompareRegReg,
                             SsaOp::CompareRegImm,
@@ -225,6 +231,7 @@ impl SsaTape {
                         UnaryOpcode::Atan => SsaOp::AtanReg,
                         UnaryOpcode::Exp => SsaOp::ExpReg,
                         UnaryOpcode::Ln => SsaOp::LnReg,
+                        UnaryOpcode::Not => SsaOp::NotReg,
                     };
                     op(i, lhs)
                 }
@@ -291,7 +298,8 @@ impl SsaTape {
                 | SsaOp::AcosReg(out, arg)
                 | SsaOp::AtanReg(out, arg)
                 | SsaOp::ExpReg(out, arg)
-                | SsaOp::LnReg(out, arg) => {
+                | SsaOp::LnReg(out, arg)
+                | SsaOp::NotReg(out, arg) => {
                     let op = match op {
                         SsaOp::NegReg(..) => "NEG",
                         SsaOp::AbsReg(..) => "ABS",
@@ -306,6 +314,7 @@ impl SsaTape {
                         SsaOp::AtanReg(..) => "ATAN",
                         SsaOp::ExpReg(..) => "EXP",
                         SsaOp::LnReg(..) => "LN",
+                        SsaOp::NotReg(..) => "NOT",
                         SsaOp::CopyReg(..) => "COPY",
                         _ => unreachable!(),
                     };

--- a/fidget/src/core/context/mod.rs
+++ b/fidget/src/core/context/mod.rs
@@ -420,6 +420,14 @@ impl Context {
         self.op_binary(a, b, BinaryOpcode::Or)
     }
 
+    /// Builds a logical negation node
+    ///
+    /// The output is 1 if the argument is 0, and 0 otherwise.
+    pub fn not<A: IntoNode>(&mut self, a: A) -> Result<Node, Error> {
+        let a = a.into_node(self)?;
+        self.op_unary(a, UnaryOpcode::Not)
+    }
+
     /// Builds a unary negation node
     /// ```
     /// # let mut ctx = fidget::context::Context::new();
@@ -800,6 +808,7 @@ impl Context {
                     UnaryOpcode::Atan => a.atan(),
                     UnaryOpcode::Exp => a.exp(),
                     UnaryOpcode::Ln => a.ln(),
+                    UnaryOpcode::Not => (a == 0.0).into(),
                 }
             }
         };
@@ -864,6 +873,7 @@ impl Context {
                 "acos" => ctx.acos(pop()?)?,
                 "atan" => ctx.atan(pop()?)?,
                 "ln" => ctx.ln(pop()?)?,
+                "not" => ctx.not(pop()?)?,
                 "exp" => ctx.exp(pop()?)?,
                 "add" => ctx.add(pop()?, pop()?)?,
                 "mul" => ctx.mul(pop()?, pop()?)?,
@@ -937,6 +947,7 @@ impl Context {
                 UnaryOpcode::Atan => out += "atan",
                 UnaryOpcode::Exp => out += "exp",
                 UnaryOpcode::Ln => out += "ln",
+                UnaryOpcode::Not => out += "not",
             },
         };
         write!(

--- a/fidget/src/core/context/mod.rs
+++ b/fidget/src/core/context/mod.rs
@@ -684,6 +684,14 @@ impl Context {
                         .map(|i| i as i8 as f64)
                         .unwrap_or(f64::NAN),
                     BinaryOpcode::Mod => a.rem_euclid(b),
+                    BinaryOpcode::And => {
+                        if a == 0.0 || b == 0.0 {
+                            0.0
+                        } else {
+                            a * b
+                        }
+                    }
+                    BinaryOpcode::Or => a + b,
                 }
             }
 
@@ -822,6 +830,8 @@ impl Context {
                 BinaryOpcode::Max => out += "max",
                 BinaryOpcode::Compare => out += "compare",
                 BinaryOpcode::Mod => out += "mod",
+                BinaryOpcode::And => out += "and",
+                BinaryOpcode::Or => out += "or",
             },
             Op::Unary(op, ..) => match op {
                 UnaryOpcode::Neg => out += "neg",

--- a/fidget/src/core/context/op.rs
+++ b/fidget/src/core/context/op.rs
@@ -32,6 +32,8 @@ pub enum BinaryOpcode {
     Max,
     Compare,
     Mod,
+    And,
+    Or,
 }
 
 /// An operation in a math expression.

--- a/fidget/src/core/context/op.rs
+++ b/fidget/src/core/context/op.rs
@@ -18,6 +18,7 @@ pub enum UnaryOpcode {
     Atan,
     Exp,
     Ln,
+    Not,
 }
 
 /// A two-argument math operation

--- a/fidget/src/core/eval/test/grad_slice.rs
+++ b/fidget/src/core/eval/test/grad_slice.rs
@@ -270,6 +270,20 @@ where
         );
     }
 
+    pub fn test_g_not() {
+        let mut ctx = Context::new();
+        let x = ctx.x();
+        let m = ctx.not(x).unwrap();
+        let shape = S::new(&ctx, m).unwrap();
+
+        let mut eval = S::new_grad_slice_eval();
+        let tape = shape.ez_grad_slice_tape();
+        assert_eq!(
+            eval.eval(&tape, &[0.0], &[0.0], &[0.0], &[]).unwrap()[0],
+            Grad::new(1.0, 0.0, 0.0, 0.0)
+        );
+    }
+
     pub fn test_g_circle() {
         let mut ctx = Context::new();
         let x = ctx.x();
@@ -480,7 +494,7 @@ where
                     err = err.min((est_grad as f32 - grad).abs());
                     assert!(
                         err.min(err / grad.abs()) < 1e-3,
-                        "gradient estimate mismatch in '{}' at {a}:
+                        "gradient estimate mismatch in '{}' at {a} => {o:?}:
                         {est_grad} != {grad} ({err})",
                         C::NAME,
                     );
@@ -507,7 +521,8 @@ where
                     || err < 1e-6
                     || err_frac < 1e-6
                     || (v.is_nan() && o.v.is_nan()),
-                "value mismatch in '{name}' at ({a}, {b}): {v} != {o} ({err})"
+                "value mismatch in '{name}' at ({a}, {b}) => {o:?}: \
+                 {v} != {o} ({err})"
             );
 
             if v.is_nan() {
@@ -533,7 +548,7 @@ where
                     assert!(
                         err.min(err / grad.abs()) < 1e-3,
                         "gradient estimate mismatch in '{name}' at \
-                         ({a} + epsilon, {b}): \
+                         ({a} + epsilon, {b}) => {o:?}: \
                          {est_grad} != {grad} ({err})"
                     );
                 }
@@ -553,7 +568,7 @@ where
                         assert!(
                             err.min(err / grad.abs()) < 1e-3,
                             "gradient estimate mismatch in '{name}' at \
-                             ({a} + epsilon, {b}): \
+                             ({a} + epsilon, {b}) => {o:?}: \
                              {est_grad} != {grad} ({err})"
                         );
                     }
@@ -571,7 +586,7 @@ where
                         assert!(
                             err.min(err / grad.abs()) < 1e-3,
                             "gradient estimate mismatch in '{name}' at \
-                             ({a}, {b} + epsilon): \
+                             ({a}, {b} + epsilon) => {o:?}: \
                              {est_grad} != {grad} ({err})"
                         );
                     }
@@ -745,6 +760,7 @@ macro_rules! grad_slice_tests {
         $crate::grad_test!(test_g_min, $t);
         $crate::grad_test!(test_g_max, $t);
         $crate::grad_test!(test_g_min_max, $t);
+        $crate::grad_test!(test_g_not, $t);
         $crate::grad_test!(test_g_div, $t);
         $crate::grad_test!(test_g_recip, $t);
         $crate::grad_test!(test_g_var, $t);

--- a/fidget/src/core/eval/test/interval.rs
+++ b/fidget/src/core/eval/test/interval.rs
@@ -507,6 +507,80 @@ where
         assert_eq!(data.unwrap().as_ref(), &[Choice::Left, Choice::Left]);
     }
 
+    pub fn test_i_and()
+    where
+        <S as Shape>::Trace: AsRef<[Choice]>,
+    {
+        let mut ctx = Context::new();
+        let x = ctx.x();
+        let y = ctx.y();
+        let v = ctx.and(x, y).unwrap();
+
+        let shape = S::new(&ctx, v).unwrap();
+        let tape = shape.ez_interval_tape();
+        let mut eval = S::new_interval_eval();
+        let (r, trace) = eval
+            .eval(&tape, [0.0, 0.0], [-1.0, 3.0], [0.0, 0.0], &[])
+            .unwrap();
+        assert_eq!(r, [0.0, 0.0].into());
+        assert_eq!(trace.unwrap().as_ref(), &[Choice::Left]);
+
+        let (r, trace) = eval
+            .eval(&tape, [-1.0, -0.2], [-1.0, 3.0], [0.0, 0.0], &[])
+            .unwrap();
+        assert_eq!(r, [-1.0, 3.0].into());
+        assert_eq!(trace.unwrap().as_ref(), &[Choice::Right]);
+
+        let (r, trace) = eval
+            .eval(&tape, [0.2, 1.3], [-1.0, 3.0], [0.0, 0.0], &[])
+            .unwrap();
+        assert_eq!(r, [-1.0, 3.0].into());
+        assert_eq!(trace.unwrap().as_ref(), &[Choice::Right]);
+
+        let (r, trace) = eval
+            .eval(&tape, [-0.2, 1.3], [1.0, 3.0], [0.0, 0.0], &[])
+            .unwrap();
+        assert_eq!(r, [0.0, 3.0].into());
+        assert!(trace.is_none()); // can't simplify
+    }
+
+    pub fn test_i_or()
+    where
+        <S as Shape>::Trace: AsRef<[Choice]>,
+    {
+        let mut ctx = Context::new();
+        let x = ctx.x();
+        let y = ctx.y();
+        let v = ctx.or(x, y).unwrap();
+
+        let shape = S::new(&ctx, v).unwrap();
+        let tape = shape.ez_interval_tape();
+        let mut eval = S::new_interval_eval();
+        let (r, trace) = eval
+            .eval(&tape, [0.0, 0.0], [-1.0, 3.0], [0.0, 0.0], &[])
+            .unwrap();
+        assert_eq!(r, [-1.0, 3.0].into());
+        assert_eq!(trace.unwrap().as_ref(), &[Choice::Right]);
+
+        let (r, trace) = eval
+            .eval(&tape, [-1.0, -0.2], [-1.0, 3.0], [0.0, 0.0], &[])
+            .unwrap();
+        assert_eq!(r, [-1.0, -0.2].into());
+        assert_eq!(trace.unwrap().as_ref(), &[Choice::Left]);
+
+        let (r, trace) = eval
+            .eval(&tape, [0.2, 1.3], [-1.0, 3.0], [0.0, 0.0], &[])
+            .unwrap();
+        assert_eq!(r, [0.2, 1.3].into());
+        assert_eq!(trace.unwrap().as_ref(), &[Choice::Left]);
+
+        let (r, trace) = eval
+            .eval(&tape, [-0.2, 1.3], [1.0, 3.0], [0.0, 0.0], &[])
+            .unwrap();
+        assert_eq!(r, [-0.2, 3.0].into());
+        assert!(trace.is_none());
+    }
+
     pub fn test_i_simplify() {
         let mut ctx = Context::new();
         let x = ctx.x();
@@ -974,6 +1048,8 @@ macro_rules! interval_tests {
         $crate::interval_test!(test_i_min_imm, $t);
         $crate::interval_test!(test_i_max, $t);
         $crate::interval_test!(test_i_max_imm, $t);
+        $crate::interval_test!(test_i_and, $t);
+        $crate::interval_test!(test_i_or, $t);
         $crate::interval_test!(test_i_compare, $t);
         $crate::interval_test!(test_i_simplify, $t);
         $crate::interval_test!(test_i_var, $t);

--- a/fidget/src/core/eval/test/interval.rs
+++ b/fidget/src/core/eval/test/interval.rs
@@ -193,6 +193,17 @@ where
         assert!(v.upper().is_nan());
     }
 
+    pub fn test_i_not() {
+        let mut ctx = Context::new();
+        let x = ctx.x();
+        let not_x = ctx.not(x).unwrap();
+
+        let shape = S::new(&ctx, not_x).unwrap();
+        let tape = shape.ez_interval_tape();
+        let mut eval = S::new_interval_eval();
+        assert_eq!(eval.eval_x(&tape, [-5.0, 0.0]), [0.0, 1.0].into());
+    }
+
     pub fn test_i_mul() {
         let mut ctx = Context::new();
         let x = ctx.x();
@@ -1038,6 +1049,7 @@ macro_rules! interval_tests {
         $crate::interval_test!(test_i_square, $t);
         $crate::interval_test!(test_i_sin, $t);
         $crate::interval_test!(test_i_neg, $t);
+        $crate::interval_test!(test_i_not, $t);
         $crate::interval_test!(test_i_mul, $t);
         $crate::interval_test!(test_i_mul_imm, $t);
         $crate::interval_test!(test_i_sub, $t);

--- a/fidget/src/core/eval/test/mod.rs
+++ b/fidget/src/core/eval/test/mod.rs
@@ -234,12 +234,16 @@ pub mod canonical {
             (v.round() - v).abs() < 1e-9
         }
     );
-    declare_canonical_binary!(Context::and, |a, b| if a == 0.0 || b == 0.0 {
-        0.0
-    } else {
-        a * b
-    });
-    declare_canonical_binary!(Context::or, |a, b| a + b);
+    declare_canonical_binary!(
+        Context::and,
+        |a, b| if a == 0.0 { a } else { b },
+        |a, _b| a == 0.0 // discontinuity, because either side snaps to b
+    );
+    declare_canonical_binary!(
+        Context::or,
+        |a, b| if a != 0.0 { a } else { b },
+        |a, _b| a == 0.0 // discontinuity, because either side snaps to a
+    );
 }
 
 #[macro_export]

--- a/fidget/src/core/eval/test/mod.rs
+++ b/fidget/src/core/eval/test/mod.rs
@@ -187,6 +187,7 @@ pub mod canonical {
     declare_canonical_unary!(Context::ln, |a| a.ln());
     declare_canonical_unary!(Context::square, |a| a * a);
     declare_canonical_unary!(Context::sqrt, |a| a.sqrt());
+    declare_canonical_unary!(Context::not, |a| (a == 0.0).into());
 
     declare_canonical_binary!(Context::add, |a, b| a + b);
     declare_canonical_binary!(Context::sub, |a, b| a - b);
@@ -280,6 +281,7 @@ macro_rules! all_unary_tests {
         $crate::one_unary_test!($tester, atan);
         $crate::one_unary_test!($tester, exp);
         $crate::one_unary_test!($tester, ln);
+        $crate::one_unary_test!($tester, not);
         $crate::one_unary_test!($tester, square);
         $crate::one_unary_test!($tester, sqrt);
     };

--- a/fidget/src/core/eval/test/mod.rs
+++ b/fidget/src/core/eval/test/mod.rs
@@ -234,6 +234,12 @@ pub mod canonical {
             (v.round() - v).abs() < 1e-9
         }
     );
+    declare_canonical_binary!(Context::and, |a, b| if a == 0.0 || b == 0.0 {
+        0.0
+    } else {
+        a * b
+    });
+    declare_canonical_binary!(Context::or, |a, b| a + b);
 }
 
 #[macro_export]
@@ -286,5 +292,7 @@ macro_rules! all_binary_tests {
         $crate::one_binary_test!($tester, max);
         $crate::one_binary_test!($tester, compare);
         $crate::one_binary_test!($tester, modulo);
+        $crate::one_binary_test!($tester, and);
+        $crate::one_binary_test!($tester, or);
     };
 }

--- a/fidget/src/core/eval/test/point.rs
+++ b/fidget/src/core/eval/test/point.rs
@@ -128,6 +128,80 @@ where
         assert!(trace.is_none());
     }
 
+    pub fn test_p_and()
+    where
+        <S as Shape>::Trace: AsRef<[Choice]>,
+    {
+        let mut ctx = Context::new();
+        let x = ctx.x();
+        let y = ctx.y();
+        let v = ctx.and(x, y).unwrap();
+
+        let shape = S::new(&ctx, v).unwrap();
+        let tape = shape.ez_point_tape();
+        let mut eval = S::new_point_eval();
+        let (r, trace) = eval.eval(&tape, 0.0, 0.0, 0.0, &[]).unwrap();
+        assert_eq!(r, 0.0);
+        assert_eq!(trace.unwrap().as_ref(), &[Choice::Left]);
+
+        let (r, trace) = eval.eval(&tape, 0.0, 1.0, 0.0, &[]).unwrap();
+        assert_eq!(r, 0.0);
+        assert_eq!(trace.unwrap().as_ref(), &[Choice::Left]);
+
+        let (r, trace) = eval.eval(&tape, 0.0, f32::NAN, 0.0, &[]).unwrap();
+        assert_eq!(r, 0.0);
+        assert_eq!(trace.unwrap().as_ref(), &[Choice::Left]);
+
+        let (r, trace) = eval.eval(&tape, 0.1, 1.0, 0.0, &[]).unwrap();
+        assert_eq!(r, 1.0);
+        assert_eq!(trace.unwrap().as_ref(), &[Choice::Right]);
+
+        let (r, trace) = eval.eval(&tape, 0.1, 0.0, 0.0, &[]).unwrap();
+        assert_eq!(r, 0.0);
+        assert_eq!(trace.unwrap().as_ref(), &[Choice::Right]);
+
+        let (r, trace) = eval.eval(&tape, f32::NAN, 1.2, 0.0, &[]).unwrap();
+        assert_eq!(r, 1.2);
+        assert_eq!(trace.unwrap().as_ref(), &[Choice::Right]);
+    }
+
+    pub fn test_p_or()
+    where
+        <S as Shape>::Trace: AsRef<[Choice]>,
+    {
+        let mut ctx = Context::new();
+        let x = ctx.x();
+        let y = ctx.y();
+        let v = ctx.or(x, y).unwrap();
+
+        let shape = S::new(&ctx, v).unwrap();
+        let tape = shape.ez_point_tape();
+        let mut eval = S::new_point_eval();
+        let (r, trace) = eval.eval(&tape, 0.0, 0.0, 0.0, &[]).unwrap();
+        assert_eq!(r, 0.0);
+        assert_eq!(trace.unwrap().as_ref(), &[Choice::Right]);
+
+        let (r, trace) = eval.eval(&tape, 0.0, 1.0, 0.0, &[]).unwrap();
+        assert_eq!(r, 1.0);
+        assert_eq!(trace.unwrap().as_ref(), &[Choice::Right]);
+
+        let (r, trace) = eval.eval(&tape, 0.0, f32::NAN, 0.0, &[]).unwrap();
+        assert!(r.is_nan());
+        assert_eq!(trace.unwrap().as_ref(), &[Choice::Right]);
+
+        let (r, trace) = eval.eval(&tape, 0.1, 1.0, 0.0, &[]).unwrap();
+        assert_eq!(r, 0.1);
+        assert_eq!(trace.unwrap().as_ref(), &[Choice::Left]);
+
+        let (r, trace) = eval.eval(&tape, 0.1, 0.0, 0.0, &[]).unwrap();
+        assert_eq!(r, 0.1);
+        assert_eq!(trace.unwrap().as_ref(), &[Choice::Left]);
+
+        let (r, trace) = eval.eval(&tape, f32::NAN, 1.2, 0.0, &[]).unwrap();
+        assert!(r.is_nan());
+        assert_eq!(trace.unwrap().as_ref(), &[Choice::Left]);
+    }
+
     pub fn test_p_sin()
     where
         <S as Shape>::Trace: AsRef<[Choice]>,
@@ -580,6 +654,8 @@ macro_rules! point_tests {
         $crate::point_test!(test_p_max, $t);
         $crate::point_test!(test_p_min, $t);
         $crate::point_test!(test_p_sin, $t);
+        $crate::point_test!(test_p_and, $t);
+        $crate::point_test!(test_p_or, $t);
         $crate::point_test!(basic_interpreter, $t);
         $crate::point_test!(test_push, $t);
         $crate::point_test!(test_var, $t);

--- a/fidget/src/core/types/interval.rs
+++ b/fidget/src/core/types/interval.rs
@@ -229,14 +229,11 @@ impl Interval {
         )
     }
 
-    /// Calculates the `AND` of two intervals, treating it as multiplication
-    ///
-    /// Unlike normal multiplication, an unambiguous 0.0 is always selected (in
-    /// normal multiplication, `0.0 × NaA →  NaN`).
+    /// Calculates the short-circuiting `AND` of two intervals
     ///
     /// Returns both the result and a [`Choice`] indicating whether one side is
-    /// always selected.  An unambiguous 0 selects itself; an unambiguous 1
-    /// selects the opposite branch.
+    /// always selected.  An unambiguous 0 in `self` selects itself; an
+    /// unambiguous 1 selects the opposite branch.
     pub fn and_choice(self, rhs: Self) -> (Self, Choice) {
         if self.lower == 0.0 && self.upper == 0.0 {
             (0.0.into(), Choice::Left)
@@ -256,11 +253,11 @@ impl Interval {
         }
     }
 
-    /// Calculates the `OR` of two intervals, treating it as addition
+    /// Calculates the short-circuiting `OR` of two intervals
     ///
     /// Returns both the result and a [`Choice`] indicating whether one side is
-    /// always selected; specifically, an unambiguous 0 selects the opposite
-    /// branch.
+    /// always selected.  An unambiguous 0 in `self` selects the opposite
+    /// branch; an unambiguous 1 selects itself.
     pub fn or_choice(self, rhs: Self) -> (Self, Choice) {
         if !self.contains(0.0) {
             (self, Choice::Left)

--- a/fidget/src/core/vm/data.rs
+++ b/fidget/src/core/vm/data.rs
@@ -184,7 +184,9 @@ impl<const N: usize> VmData<N> {
                     }
                 }
                 SsaOp::MinRegImm(index, arg, imm)
-                | SsaOp::MaxRegImm(index, arg, imm) => {
+                | SsaOp::MaxRegImm(index, arg, imm)
+                | SsaOp::AndRegImm(index, arg, imm)
+                | SsaOp::OrRegImm(index, arg, imm) => {
                     match choice_iter.next().unwrap() {
                         Choice::Left => match workspace.active(*arg) {
                             Some(new_arg) => {
@@ -207,7 +209,9 @@ impl<const N: usize> VmData<N> {
                     }
                 }
                 SsaOp::MinRegReg(index, lhs, rhs)
-                | SsaOp::MaxRegReg(index, lhs, rhs) => {
+                | SsaOp::MaxRegReg(index, lhs, rhs)
+                | SsaOp::AndRegReg(index, lhs, rhs)
+                | SsaOp::OrRegReg(index, lhs, rhs) => {
                     match choice_iter.next().unwrap() {
                         Choice::Left => match workspace.active(*lhs) {
                             Some(new_lhs) => {

--- a/fidget/src/core/vm/data.rs
+++ b/fidget/src/core/vm/data.rs
@@ -162,7 +162,8 @@ impl<const N: usize> VmData<N> {
                 | SsaOp::AcosReg(index, arg)
                 | SsaOp::AtanReg(index, arg)
                 | SsaOp::ExpReg(index, arg)
-                | SsaOp::LnReg(index, arg) => {
+                | SsaOp::LnReg(index, arg)
+                | SsaOp::NotReg(index, arg) => {
                     *index = new_index;
                     *arg = workspace.get_or_insert_active(*arg);
                 }

--- a/fidget/src/core/vm/mod.rs
+++ b/fidget/src/core/vm/mod.rs
@@ -329,6 +329,15 @@ impl<const N: usize> TracingEvaluator for VmIntervalEval<N> {
                 RegOp::LnReg(out, arg) => {
                     v[out] = v[arg].ln();
                 }
+                RegOp::NotReg(out, arg) => {
+                    v[out] = if !v[arg].contains(0.0) {
+                        Interval::new(0.0, 0.0)
+                    } else if v[arg].lower() == 0.0 && v[arg].upper() == 0.0 {
+                        Interval::new(1.0, 1.0)
+                    } else {
+                        Interval::new(0.0, 1.0)
+                    };
+                }
                 RegOp::CopyReg(out, arg) => v[out] = v[arg],
                 RegOp::AddRegImm(out, arg, imm) => {
                     v[out] = v[arg] + imm.into();
@@ -543,6 +552,7 @@ impl<const N: usize> TracingEvaluator for VmPointEval<N> {
                 RegOp::LnReg(out, arg) => {
                     v[out] = v[arg].ln();
                 }
+                RegOp::NotReg(out, arg) => v[out] = (v[arg] == 0.0).into(),
                 RegOp::CopyReg(out, arg) => {
                     v[out] = v[arg];
                 }
@@ -876,6 +886,11 @@ impl<const N: usize> BulkEvaluator for VmFloatSliceEval<N> {
                         v[out][i] = v[arg][i].ln();
                     }
                 }
+                RegOp::NotReg(out, arg) => {
+                    for i in 0..size {
+                        v[out][i] = (v[arg][i] == 0.0).into();
+                    }
+                }
                 RegOp::CopyReg(out, arg) => {
                     for i in 0..size {
                         v[out][i] = v[arg][i];
@@ -1170,6 +1185,11 @@ impl<const N: usize> BulkEvaluator for VmGradSliceEval<N> {
                 RegOp::LnReg(out, arg) => {
                     for i in 0..size {
                         v[out][i] = v[arg][i].ln();
+                    }
+                }
+                RegOp::NotReg(out, arg) => {
+                    for i in 0..size {
+                        v[out][i] = f32::from(v[arg][i].v == 0.0).into();
                     }
                 }
                 RegOp::CopyReg(out, arg) => {

--- a/fidget/src/jit/aarch64/float_slice.rs
+++ b/fidget/src/jit/aarch64/float_slice.rs
@@ -301,7 +301,12 @@ impl Assembler for FloatSliceAssembler {
         )
     }
     fn build_not(&mut self, out_reg: u8, arg_reg: u8) {
-        unimplemented!();
+        dynasm!(self.0.ops
+            ; cmeq v6.s4, V(reg(arg_reg)).s4, 0
+            ; fmov S(reg(out_reg)), 1.0
+            ; dup V(reg(out_reg)).s4, V(reg(out_reg)).s[0]
+            ; and V(reg(out_reg)).b16, V(reg(out_reg)).b16, v6.b16
+        );
     }
     fn build_and(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
         unimplemented!();

--- a/fidget/src/jit/aarch64/float_slice.rs
+++ b/fidget/src/jit/aarch64/float_slice.rs
@@ -309,10 +309,22 @@ impl Assembler for FloatSliceAssembler {
         );
     }
     fn build_and(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
-        unimplemented!();
+        dynasm!(self.0.ops
+            ; cmeq v6.s4, V(reg(lhs_reg)).s4, 0
+            ; mvn v7.b16, v6.b16
+            ; and v6.b16, v6.b16, V(reg(lhs_reg)).b16
+            ; and v7.b16, v7.b16, V(reg(rhs_reg)).b16
+            ; orr V(reg(out_reg)).b16, v6.b16, v7.b16
+        );
     }
     fn build_or(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
-        unimplemented!();
+        dynasm!(self.0.ops
+            ; cmeq v6.s4, V(reg(lhs_reg)).s4, 0
+            ; mvn v7.b16, v6.b16
+            ; and v7.b16, v7.b16, V(reg(lhs_reg)).b16
+            ; and v6.b16, v6.b16, V(reg(rhs_reg)).b16
+            ; orr V(reg(out_reg)).b16, v6.b16, v7.b16
+        );
     }
 
     fn build_compare(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {

--- a/fidget/src/jit/aarch64/float_slice.rs
+++ b/fidget/src/jit/aarch64/float_slice.rs
@@ -300,6 +300,15 @@ impl Assembler for FloatSliceAssembler {
             ; fsub V(reg(out_reg)).s4, V(reg(lhs_reg)).s4, v7.s4
         )
     }
+    fn build_not(&mut self, out_reg: u8, arg_reg: u8) {
+        unimplemented!();
+    }
+    fn build_and(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
+        unimplemented!();
+    }
+    fn build_or(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
+        unimplemented!();
+    }
 
     fn build_compare(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
         dynasm!(self.0.ops

--- a/fidget/src/jit/aarch64/grad_slice.rs
+++ b/fidget/src/jit/aarch64/grad_slice.rs
@@ -411,7 +411,11 @@ impl Assembler for GradSliceAssembler {
     }
 
     fn build_not(&mut self, out_reg: u8, arg_reg: u8) {
-        unimplemented!();
+        dynasm!(self.0.ops
+            ; fcmeq s6, S(reg(arg_reg)), 0.0
+            ; fmov S(reg(out_reg)), 1.0
+            ; and V(reg(out_reg)).b16, V(reg(out_reg)).b16, v6.b16
+        );
     }
     fn build_and(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
         unimplemented!();

--- a/fidget/src/jit/aarch64/grad_slice.rs
+++ b/fidget/src/jit/aarch64/grad_slice.rs
@@ -410,6 +410,16 @@ impl Assembler for GradSliceAssembler {
         self.call_fn_binary(out_reg, lhs_reg, rhs_reg, grad_modulo);
     }
 
+    fn build_not(&mut self, out_reg: u8, arg_reg: u8) {
+        unimplemented!();
+    }
+    fn build_and(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
+        unimplemented!();
+    }
+    fn build_or(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
+        unimplemented!();
+    }
+
     fn build_compare(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
         dynasm!(self.0.ops
             // Check whether either argument is NAN

--- a/fidget/src/jit/aarch64/grad_slice.rs
+++ b/fidget/src/jit/aarch64/grad_slice.rs
@@ -418,10 +418,24 @@ impl Assembler for GradSliceAssembler {
         );
     }
     fn build_and(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
-        unimplemented!();
+        dynasm!(self.0.ops
+            ; fcmeq s6, S(reg(lhs_reg)), 0.0
+            ; dup v6.s4, v6.s[0]
+            ; mvn v7.b16, v6.b16
+            ; and v6.b16, v6.b16, V(reg(lhs_reg)).b16
+            ; and v7.b16, v7.b16, V(reg(rhs_reg)).b16
+            ; orr V(reg(out_reg)).b16, v6.b16, v7.b16
+        );
     }
     fn build_or(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
-        unimplemented!();
+        dynasm!(self.0.ops
+            ; fcmeq s6, S(reg(lhs_reg)), 0.0
+            ; dup v6.s4, v6.s[0]
+            ; mvn v7.b16, v6.b16
+            ; and v7.b16, v7.b16, V(reg(lhs_reg)).b16
+            ; and v6.b16, v6.b16, V(reg(rhs_reg)).b16
+            ; orr V(reg(out_reg)).b16, v6.b16, v7.b16
+        );
     }
 
     fn build_compare(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {

--- a/fidget/src/jit/aarch64/interval.rs
+++ b/fidget/src/jit/aarch64/interval.rs
@@ -492,6 +492,16 @@ impl Assembler for IntervalAssembler {
         self.call_fn_binary(out_reg, lhs_reg, rhs_reg, interval_modulo);
     }
 
+    fn build_not(&mut self, out_reg: u8, arg_reg: u8) {
+        unimplemented!();
+    }
+    fn build_and(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
+        unimplemented!();
+    }
+    fn build_or(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
+        unimplemented!();
+    }
+
     fn build_compare(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
         dynasm!(self.0.ops
             // Very similar to build_min, but without writing choices

--- a/fidget/src/jit/aarch64/interval.rs
+++ b/fidget/src/jit/aarch64/interval.rs
@@ -564,7 +564,7 @@ impl Assembler for IntervalAssembler {
             ; b 24 // -> exit
 
             // s5 = min(rhs.lower, 0.0)
-            // s6 = min(rhs.lower, 0.0)
+            // s6 = max(rhs.upper, 0.0)
             ; movi v6.s2, 0
             ; fmin s5, S(reg(rhs_reg)), s6
             ; mov s7, V(reg(rhs_reg)).s[1]

--- a/fidget/src/jit/aarch64/interval.rs
+++ b/fidget/src/jit/aarch64/interval.rs
@@ -518,7 +518,62 @@ impl Assembler for IntervalAssembler {
         );
     }
     fn build_and(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
-        unimplemented!();
+        dynasm!(self.0.ops
+            // Load the choice bit
+            ; ldrb w14, [x1]
+
+            // v7 = !arg.contains(0.0)
+            ; fcmgt s6, S(reg(lhs_reg)), 0.0 // s6 = lower > 0.0
+            ; mov s5, V(reg(lhs_reg)).s[1]   // s5 = upper
+            ; fcmlt s7, s5, 0.0              // s7 = upper < 0.0
+            ; orr v7.b8, v6.b8, v7.b8 // (lower > 0) || (upper < 0)
+            ; fmov w9, s7
+            ; cmp w9, 0
+            ; b.eq 20 // skip the !arg.contains(0.0) branch
+
+            // !lhs.contains(0.0) -> RHS
+            ; fmov D(reg(out_reg)), D(reg(rhs_reg))
+            ; orr w14, w14, CHOICE_RIGHT
+            ; strb w14, [x2, 0] // write a non-zero value to simplify
+            ; b 96 // -> exit
+
+            // v6 = (lower == 0) && (upper == 0)
+            ; fcmeq s6, S(reg(lhs_reg)), 0.0
+            ; fcmeq s5, s5, 0.0
+            ; and v6.b8, v6.b8, v5.b8 // (lower == 0) && (upper == 0)
+            ; fmov w9, s6
+            ; cmp w9, 0
+            ; b.eq 20 // skip the (lower == 0) && (upper == 0) branch
+
+            // (lhs.lower == 0) && (lhs.upper == 0) -> LHS
+            ; movi V(reg(out_reg)).s2, 0
+            ; orr w14, w14, CHOICE_LEFT
+            ; strb w14, [x2, 0] // write a non-zero value to simplify
+            ; b 56 // -> exit
+
+            // Check whether RHS has a NAN
+            ; orr w14, w14, CHOICE_BOTH
+            ; fcmeq v5.s2, V(reg(rhs_reg)).s2, V(reg(rhs_reg)).s2
+            ; fmov x15, d5
+            ; cmp x15, 0
+            ; b.ne 16 // -> skip over NAN handling into main logic
+
+            // NAN handling
+            ; mov w15, f32::NAN.to_bits().into()
+            ; dup V(reg(out_reg)).s2, w15
+            ; b 24 // -> exit
+
+            // s5 = min(rhs.lower, 0.0)
+            // s6 = min(rhs.lower, 0.0)
+            ; movi v6.s2, 0
+            ; fmin s5, S(reg(rhs_reg)), s6
+            ; mov s7, V(reg(rhs_reg)).s[1]
+            ; fmax s6, s7, s6
+            ; zip1 V(reg(out_reg)).s2, v5.s2, v6.s2
+
+            // exit
+            ; strb w14, [x1], 1 // post-increment
+        )
     }
     fn build_or(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
         unimplemented!();

--- a/fidget/src/jit/aarch64/point.rs
+++ b/fidget/src/jit/aarch64/point.rs
@@ -288,7 +288,11 @@ impl Assembler for PointAssembler {
     }
 
     fn build_not(&mut self, out_reg: u8, arg_reg: u8) {
-        unimplemented!();
+        dynasm!(self.0.ops
+            ; fcmeq s6, S(reg(arg_reg)), 0.0
+            ; fmov S(reg(out_reg)), 1.0
+            ; and V(reg(out_reg)).b8, V(reg(out_reg)).b8, v6.b8
+        );
     }
     fn build_and(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
         unimplemented!();

--- a/fidget/src/jit/aarch64/point.rs
+++ b/fidget/src/jit/aarch64/point.rs
@@ -287,6 +287,16 @@ impl Assembler for PointAssembler {
         )
     }
 
+    fn build_not(&mut self, out_reg: u8, arg_reg: u8) {
+        unimplemented!();
+    }
+    fn build_and(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
+        unimplemented!();
+    }
+    fn build_or(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
+        unimplemented!();
+    }
+
     fn build_compare(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
         // This is using SIMD instructions to avoid branch; dunno if it's faster
         // but it means we can use very similar code to float / grad slice

--- a/fidget/src/jit/mod.rs
+++ b/fidget/src/jit/mod.rs
@@ -185,6 +185,15 @@ trait Assembler {
         self.build_mul(out_reg, lhs_reg, lhs_reg)
     }
 
+    /// Logical not
+    fn build_not(&mut self, out_reg: u8, lhs_reg: u8);
+
+    /// Logical and (short-circuiting)
+    fn build_and(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8);
+
+    /// Logical or (short-circuiting)
+    fn build_or(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8);
+
     /// Addition
     fn build_add(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8);
 
@@ -692,6 +701,9 @@ fn build_asm_fn_with_storage<A: Assembler>(
             RegOp::SquareReg(out, arg) => {
                 asm.build_square(out, arg);
             }
+            RegOp::NotReg(out, arg) => {
+                asm.build_not(out, arg);
+            }
             RegOp::AddRegReg(out, lhs, rhs) => {
                 asm.build_add(out, lhs, rhs);
             }
@@ -748,6 +760,20 @@ fn build_asm_fn_with_storage<A: Assembler>(
             RegOp::ModImmReg(out, arg, imm) => {
                 let reg = asm.load_imm(imm);
                 asm.build_mod(out, reg, arg);
+            }
+            RegOp::AndRegReg(out, lhs, rhs) => {
+                asm.build_and(out, lhs, rhs);
+            }
+            RegOp::AndRegImm(out, arg, imm) => {
+                let reg = asm.load_imm(imm);
+                asm.build_and(out, arg, reg);
+            }
+            RegOp::OrRegReg(out, lhs, rhs) => {
+                asm.build_or(out, lhs, rhs);
+            }
+            RegOp::OrRegImm(out, arg, imm) => {
+                let reg = asm.load_imm(imm);
+                asm.build_or(out, arg, reg);
             }
             RegOp::CopyImm(out, imm) => {
                 let reg = asm.load_imm(imm);

--- a/fidget/src/jit/x86_64/float_slice.rs
+++ b/fidget/src/jit/x86_64/float_slice.rs
@@ -281,6 +281,16 @@ impl Assembler for FloatSliceAssembler {
             ; vsubps Ry(reg(out_reg)), Ry(reg(lhs_reg)), ymm2
         );
     }
+    fn build_not(&mut self, out_reg: u8, arg_reg: u8) {
+        unimplemented!();
+    }
+    fn build_and(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
+        unimplemented!();
+    }
+    fn build_or(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
+        unimplemented!();
+    }
+
     fn build_compare(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
         dynasm!(self.0.ops
             // Build a mask of NANs; conveniently, all 1s is a NAN

--- a/fidget/src/jit/x86_64/float_slice.rs
+++ b/fidget/src/jit/x86_64/float_slice.rs
@@ -282,13 +282,40 @@ impl Assembler for FloatSliceAssembler {
         );
     }
     fn build_not(&mut self, out_reg: u8, arg_reg: u8) {
-        unimplemented!();
+        dynasm!(self.0.ops
+            ; vxorps ymm1, ymm1, ymm1
+            ; vcmpeqps ymm1, ymm1, Ry(reg(arg_reg))
+            ; mov eax, 1f32.to_bits() as i32
+            ; vmovd Rx(reg(out_reg)), eax
+            ; vbroadcastss Ry(reg(out_reg)), Rx(reg(out_reg))
+            ; vandpd Ry(reg(out_reg)), Ry(reg(out_reg)), ymm1
+        );
     }
     fn build_and(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
-        unimplemented!();
+        dynasm!(self.0.ops
+            // Build the (lhs == 0) mask in ymm1 and the opposite in ymm2
+            ; vxorps ymm1, ymm1, ymm1
+            ; vcmpeqps ymm1, ymm1, Ry(reg(lhs_reg))
+            ; vpcmpeqd ymm2, ymm2, ymm2 // All 1s
+            ; vxorpd ymm2, ymm1, ymm2 // 1 ^ b = !b, so this inverts ymm1
+
+            ; vandpd ymm1, ymm1, Ry(reg(lhs_reg))
+            ; vandpd ymm2, ymm2, Ry(reg(rhs_reg))
+            ; vorpd Ry(reg(out_reg)), ymm1, ymm2
+        );
     }
     fn build_or(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
-        unimplemented!();
+        dynasm!(self.0.ops
+            // Build the (lhs == 0) mask in ymm1 and the opposite in ymm2
+            ; vxorps ymm1, ymm1, ymm1
+            ; vcmpeqps ymm1, ymm1, Ry(reg(lhs_reg))
+            ; vpcmpeqd ymm2, ymm2, ymm2 // All 1s
+            ; vxorpd ymm2, ymm1, ymm2 // 1 ^ b = !b, so this inverts ymm1
+
+            ; vandpd ymm1, ymm1, Ry(reg(rhs_reg))
+            ; vandpd ymm2, ymm2, Ry(reg(lhs_reg))
+            ; vorpd Ry(reg(out_reg)), ymm1, ymm2
+        );
     }
 
     fn build_compare(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {

--- a/fidget/src/jit/x86_64/grad_slice.rs
+++ b/fidget/src/jit/x86_64/grad_slice.rs
@@ -394,13 +394,38 @@ impl Assembler for GradSliceAssembler {
         self.call_fn_binary(out_reg, lhs_reg, rhs_reg, grad_modulo);
     }
     fn build_not(&mut self, out_reg: u8, arg_reg: u8) {
-        unimplemented!();
+        let i = self.load_imm(1.0);
+        dynasm!(self.0.ops
+            ; vpxor xmm1, xmm1, xmm1
+            ; vcmpeqss xmm1, Rx(reg(arg_reg)), xmm1
+            ; vandps Rx(reg(out_reg)), xmm1, Rx(reg(i))
+        );
     }
     fn build_and(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
-        unimplemented!();
+        dynasm!(self.0.ops
+            ; vpxor xmm1, xmm1, xmm1
+            ; vcmpeqss xmm1, Rx(reg(lhs_reg)), xmm1
+            ; vbroadcastss xmm1, xmm1
+            ; vpcmpeqd xmm2, xmm2, xmm2
+            ; vxorpd xmm2, xmm1, xmm2 // 1 ^ b = !b, so this inverts xmm1
+
+            ; vandpd xmm1, xmm1, Rx(reg(lhs_reg))
+            ; vandpd xmm2, xmm2, Rx(reg(rhs_reg))
+            ; vorpd Rx(reg(out_reg)), xmm1, xmm2
+        );
     }
     fn build_or(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
-        unimplemented!();
+        dynasm!(self.0.ops
+            ; vpxor xmm1, xmm1, xmm1
+            ; vcmpeqss xmm1, Rx(reg(lhs_reg)), xmm1
+            ; vbroadcastss xmm1, xmm1
+            ; vpcmpeqd xmm2, xmm2, xmm2
+            ; vxorpd xmm2, xmm1, xmm2 // 1 ^ b = !b, so this inverts xmm1
+
+            ; vandpd xmm1, xmm1, Rx(reg(rhs_reg))
+            ; vandpd xmm2, xmm2, Rx(reg(lhs_reg))
+            ; vorpd Rx(reg(out_reg)), xmm1, xmm2
+        );
     }
     fn build_compare(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
         dynasm!(self.0.ops

--- a/fidget/src/jit/x86_64/grad_slice.rs
+++ b/fidget/src/jit/x86_64/grad_slice.rs
@@ -393,6 +393,15 @@ impl Assembler for GradSliceAssembler {
         }
         self.call_fn_binary(out_reg, lhs_reg, rhs_reg, grad_modulo);
     }
+    fn build_not(&mut self, out_reg: u8, arg_reg: u8) {
+        unimplemented!();
+    }
+    fn build_and(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
+        unimplemented!();
+    }
+    fn build_or(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
+        unimplemented!();
+    }
     fn build_compare(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
         dynasm!(self.0.ops
             ; vcomiss Rx(reg(lhs_reg)), Rx(reg(rhs_reg))

--- a/fidget/src/jit/x86_64/interval.rs
+++ b/fidget/src/jit/x86_64/interval.rs
@@ -518,7 +518,7 @@ impl Assembler for IntervalAssembler {
             // xmm2 = !arg.contains(0.0)
             ; vcmpgtss xmm3, Rx(reg(arg_reg)), xmm0 // lower > 0.0
             ; vcmpltss xmm2, xmm1, xmm0 // upper < 0.0
-            ; vandps xmm2, xmm2, xmm3 // (lower > 0) || (upper < 0)
+            ; vorps xmm2, xmm2, xmm3 // (lower > 0) || (upper < 0)
 
             // xmm2 = !!arg.contains(0.0)
             ; vpcmpeqd xmm3, xmm3, xmm3 // all 1s
@@ -545,7 +545,67 @@ impl Assembler for IntervalAssembler {
     }
     fn build_and(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
         assert_ne!(reg(lhs_reg), IMM_REG);
-        unimplemented!();
+        dynasm!(self.0.ops
+            ; mov ax, [rsi] // load the choice flag
+            ; vpxor xmm1, xmm1, xmm1 // xmm1 = 0.0
+
+            // xmm2 = !arg.contains(0.0)
+            ; vcmpgtss xmm3, Rx(reg(lhs_reg)), xmm1 // lower > 0.0
+            ; vpshufd xmm2, Rx(reg(lhs_reg)), 0b11111101u8 as i8 // lhs.upper
+            ; vcmpltss xmm2, xmm2, xmm1 // upper < 0.0
+            ; vorps xmm2, xmm2, xmm3 // (lower > 0) || (upper < 0)
+            ; vcomiss xmm1, xmm2 // compare against 0.0
+            ; jnp >A // skip this branch (jnp because xmm2 will be NAN, all 1s)
+
+            // !lhs.contains(0.0) -> RHS
+            ; vmovq Rx(reg(out_reg)), Rx(reg(rhs_reg))
+            ; or ax, CHOICE_RIGHT as i16
+            ; mov cx, 1 // TODO: why can't we write 1 to [rdx] directly?
+            ; mov [rdx], cx
+            ; jmp >E
+
+            // xmm3 = (lower == 0) && (upper == 0)
+            ; A:
+            ; vcmpeqss xmm3, Rx(reg(lhs_reg)), xmm1
+            ; vpshufd xmm2, Rx(reg(lhs_reg)), 0b11111101u8 as i8 // lhs.upper
+            ; vcmpeqss xmm2, xmm2, xmm1
+            ; vandps xmm3, xmm2, xmm3
+            ; vcomiss xmm1, xmm3
+            ; jnp >B // skip this branch
+
+            // (lower == 0) && (upper == 0) -> LHS
+            ; vmovq Rx(reg(out_reg)), Rx(reg(lhs_reg))
+            ; or ax, CHOICE_LEFT as i16
+            ; mov cx, 1 // TODO: why can't we write 1 to [rdx] directly?
+            ; mov [rdx], cx
+            ; jmp >E
+
+            // We have to combine the outputs
+            ; B:
+            ; or ax, CHOICE_BOTH as i16
+
+            // check for NANs in RHS
+            ; vcomiss Rx(reg(rhs_reg)), Rx(reg(rhs_reg))
+            ; jnp >C
+
+            // Load NAN into out_reg (TODO is this the easiest way?)
+            ; vpcmpeqw Rx(reg(out_reg)), Rx(reg(out_reg)), Rx(reg(out_reg))
+            ; vpslld Rx(reg(out_reg)), Rx(reg(out_reg)), 23
+            ; vpsrld Rx(reg(out_reg)), Rx(reg(out_reg)), 1
+            ; jmp >E
+
+            // Normal case!
+            ; C:
+            ; vpshufd xmm2, Rx(reg(rhs_reg)), 0b11111101u8 as i8 // lhs.upper
+            ; vmaxss xmm2, xmm2, xmm1 // xmm1 = max(rhs.upper, 0.0)
+            ; vminss xmm1, Rx(reg(rhs_reg)), xmm1 // xmm1 = min(rhs.lower, 0.0)
+            ; vunpcklps Rx(reg(out_reg)), xmm1, xmm2
+
+            ; E: // exit
+            ; mov [rsi], ax
+            ; add rsi, 1
+        );
+        self.0.ops.commit_local().unwrap();
     }
     fn build_or(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
         assert_ne!(reg(lhs_reg), IMM_REG);

--- a/fidget/src/jit/x86_64/interval.rs
+++ b/fidget/src/jit/x86_64/interval.rs
@@ -508,6 +508,15 @@ impl Assembler for IntervalAssembler {
         }
         self.call_fn_binary(out_reg, lhs_reg, rhs_reg, interval_modulo);
     }
+    fn build_not(&mut self, out_reg: u8, arg_reg: u8) {
+        unimplemented!();
+    }
+    fn build_and(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
+        unimplemented!();
+    }
+    fn build_or(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
+        unimplemented!();
+    }
     fn build_compare(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
         // TODO: Godbolt uses unpcklps ?
         dynasm!(self.0.ops

--- a/fidget/src/jit/x86_64/interval.rs
+++ b/fidget/src/jit/x86_64/interval.rs
@@ -573,7 +573,7 @@ impl Assembler for IntervalAssembler {
             ; vcomiss xmm1, xmm3
             ; jnp >B // skip this branch
 
-            // (lower == 0) && (upper == 0) -> LHS
+            // (lhs.lower == 0) && (lhs.upper == 0) -> LHS
             ; vmovq Rx(reg(out_reg)), Rx(reg(lhs_reg))
             ; or ax, CHOICE_LEFT as i16
             ; mov cx, 1 // TODO: why can't we write 1 to [rdx] directly?
@@ -609,7 +609,67 @@ impl Assembler for IntervalAssembler {
     }
     fn build_or(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
         assert_ne!(reg(lhs_reg), IMM_REG);
-        unimplemented!();
+        dynasm!(self.0.ops
+            ; mov ax, [rsi] // load the choice flag
+            ; vpxor xmm1, xmm1, xmm1 // xmm1 = 0.0
+
+            // xmm2 = !arg.contains(0.0)
+            ; vcmpgtss xmm3, Rx(reg(lhs_reg)), xmm1 // lower > 0.0
+            ; vpshufd xmm2, Rx(reg(lhs_reg)), 0b11111101u8 as i8 // lhs.upper
+            ; vcmpltss xmm2, xmm2, xmm1 // upper < 0.0
+            ; vorps xmm2, xmm2, xmm3 // (lower > 0) || (upper < 0)
+            ; vcomiss xmm1, xmm2 // compare against 0.0
+            ; jnp >A // skip this branch (jnp because xmm2 will be NAN, all 1s)
+
+            // !lhs.contains(0.0) -> LHS
+            ; vmovq Rx(reg(out_reg)), Rx(reg(lhs_reg))
+            ; or ax, CHOICE_LEFT as i16
+            ; mov cx, 1 // TODO: why can't we write 1 to [rdx] directly?
+            ; mov [rdx], cx
+            ; jmp >E
+
+            // xmm3 = (lower == 0) && (upper == 0)
+            ; A:
+            ; vcmpeqss xmm3, Rx(reg(lhs_reg)), xmm1
+            ; vpshufd xmm2, Rx(reg(lhs_reg)), 0b11111101u8 as i8 // lhs.upper
+            ; vcmpeqss xmm2, xmm2, xmm1
+            ; vandps xmm3, xmm2, xmm3
+            ; vcomiss xmm1, xmm3
+            ; jnp >B // skip this branch
+
+            // (lhs.lower == 0) && (lhs.upper == 0) -> RHS
+            ; vmovq Rx(reg(out_reg)), Rx(reg(rhs_reg))
+            ; or ax, CHOICE_RIGHT as i16
+            ; mov cx, 1 // TODO: why can't we write 1 to [rdx] directly?
+            ; mov [rdx], cx
+            ; jmp >E
+
+            // We have to combine the outputs
+            ; B:
+            ; or ax, CHOICE_BOTH as i16
+
+            // check for NANs in RHS
+            ; vcomiss Rx(reg(rhs_reg)), Rx(reg(rhs_reg))
+            ; jnp >C
+
+            // Load NAN into out_reg (TODO is this the easiest way?)
+            ; vpcmpeqw Rx(reg(out_reg)), Rx(reg(out_reg)), Rx(reg(out_reg))
+            ; vpslld Rx(reg(out_reg)), Rx(reg(out_reg)), 23
+            ; vpsrld Rx(reg(out_reg)), Rx(reg(out_reg)), 1
+            ; jmp >E
+
+            // Normal case!
+            ; C:
+            ; vpshufd xmm2, Rx(reg(lhs_reg)), 0b11111101u8 as i8 // lhs.upper
+            ; vpshufd xmm1, Rx(reg(rhs_reg)), 0b11111101u8 as i8 // rhs.upper
+            ; vmaxss xmm1, xmm1, xmm2 // xmm1 = max(lhs.upper, rhs.upper)
+            ; vminss xmm2, Rx(reg(lhs_reg)), Rx(reg(rhs_reg))
+            ; vunpcklps Rx(reg(out_reg)), xmm2, xmm1
+
+            ; E: // exit
+            ; mov [rsi], ax
+            ; add rsi, 1
+        );
     }
     fn build_compare(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
         // TODO: Godbolt uses unpcklps ?

--- a/fidget/src/jit/x86_64/point.rs
+++ b/fidget/src/jit/x86_64/point.rs
@@ -299,6 +299,15 @@ impl Assembler for PointAssembler {
             ; vsubss Rx(reg(out_reg)), Rx(reg(lhs_reg)), xmm2
         );
     }
+    fn build_not(&mut self, out_reg: u8, arg_reg: u8) {
+        unimplemented!();
+    }
+    fn build_and(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
+        unimplemented!();
+    }
+    fn build_or(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
+        unimplemented!();
+    }
     fn build_compare(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
         dynasm!(self.0.ops
             ; vcomiss Rx(reg(lhs_reg)), Rx(reg(rhs_reg))

--- a/fidget/src/jit/x86_64/point.rs
+++ b/fidget/src/jit/x86_64/point.rs
@@ -309,10 +309,47 @@ impl Assembler for PointAssembler {
         );
     }
     fn build_and(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
-        unimplemented!();
+        dynasm!(self.0.ops
+            // Based on Godbolt, so perhaps less readable than usual
+            ; vmovaps xmm1, Rx(reg(rhs_reg))
+            ; vxorps xmm2, xmm2, xmm2
+            ; vucomiss xmm2, Rx(reg(lhs_reg))
+            ; setnp cl
+            ; sete al
+            ; jne >E
+            ; jp >E
+            ; vmovaps xmm1, Rx(reg(lhs_reg))
+
+            ; E:
+            ; and al, cl
+            ; mov cl, 2
+            ; sub cl, al
+            ; or [rsi], cl // write the choice flag, based on condition flags
+            ; or [rdx], 1 // write the simplify bit
+            ; movaps Rx(reg(out_reg)), xmm1
+        );
+        self.0.ops.commit_local().unwrap()
     }
     fn build_or(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
-        unimplemented!();
+        dynasm!(self.0.ops
+            // Based on Godbolt, so perhaps less readable than usual
+            ; vmovaps xmm1, Rx(reg(lhs_reg))
+            ; vxorps xmm2, xmm2, xmm2
+            ; vucomiss xmm2, Rx(reg(lhs_reg))
+            ; setnp cl
+            ; sete al
+            ; jne >E
+            ; jp >E
+            ; vmovaps xmm1, Rx(reg(rhs_reg))
+
+            ; E:
+            ; and al, cl
+            ; inc al
+            ; or [rsi], al // write the choice flag, based on condition flags
+            ; or [rdx], 1 // write the simplify bit
+            ; movaps Rx(reg(out_reg)), xmm1
+        );
+        self.0.ops.commit_local().unwrap()
     }
     fn build_compare(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
         dynasm!(self.0.ops

--- a/fidget/src/jit/x86_64/point.rs
+++ b/fidget/src/jit/x86_64/point.rs
@@ -300,7 +300,13 @@ impl Assembler for PointAssembler {
         );
     }
     fn build_not(&mut self, out_reg: u8, arg_reg: u8) {
-        unimplemented!();
+        dynasm!(self.0.ops
+            ; vxorps   xmm1, xmm1, xmm1
+            ; vcmpeqss xmm1, xmm1, Rx(reg(arg_reg))
+            ; mov eax, 1f32.to_bits() as i32
+            ; vmovd Rx(reg(out_reg)), eax
+            ; vandpd Rx(reg(out_reg)), Rx(reg(out_reg)), xmm1
+        );
     }
     fn build_and(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
         unimplemented!();


### PR DESCRIPTION
This PR adds `AND`, `OR`, and `NOT` opcodes.

These operations are designed for basically one purpose: making conditionals of the form `(cond && a) || (!cond && b)`.  As such, they have the following semantics:

- `a && b ⇒ if a == 0.0 { a } else { b }`
- `a || b ⇒ if a != 0.0 { a } else { b }`

The operators are also designed to work well with tape simplification (through the `TracingEvaluator`): if `cond` is unambiguously `0.0` or unambiguously non-zero, then the conditional statement can be collapsed into either `a` or `b`.

(marked as a Draft because I still need to turn the crank on JIT implementations)