### PR TITLE
Use vunpcklps instead of unpcklps to avoid penalty

### DIFF
--- a/fidget/src/jit/x86_64/interval.rs
+++ b/fidget/src/jit/x86_64/interval.rs
@@ -378,7 +378,7 @@ impl Assembler for IntervalAssembler {
             ; vmaxss xmm2, xmm2, xmm1 // xmm2[0] is highest value
 
             // Splice the two together
-            ; unpcklps Rx(reg(out_reg)), xmm2
+            ; vunpcklps Rx(reg(out_reg)), xmm2, xmm2
 
             ; E:
         );

--- a/fidget/src/jit/x86_64/interval.rs
+++ b/fidget/src/jit/x86_64/interval.rs
@@ -378,7 +378,7 @@ impl Assembler for IntervalAssembler {
             ; vmaxss xmm2, xmm2, xmm1 // xmm2[0] is highest value
 
             // Splice the two together
-            ; vunpcklps Rx(reg(out_reg)), xmm2, xmm2
+            ; vunpcklps Rx(reg(out_reg)), Rx(reg(out_reg)), xmm2
 
             ; E:
         );


### PR DESCRIPTION
x86 is a Good and Normal instruction set