### PR TITLE
Fix viewer crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
   `Var`-related functions and opcodes).  This was over-engineered; the plan
   going forward will be to support functions with _N_ inputs (currently fixed to
   3, `x`/`y`/`z`).
+- Improved robustness of `viewer` application when editors move files instead of
+  writing to them directly.
 
 # 0.2.3
 - Fix a possible panic during multithreaded 3D rendering of very small images


### PR DESCRIPTION
Some editors will do move / rename shenanigans to write a file atomically, so the watcher thread could crash if it tried to read the file contents while the file was temporarily absent.