### PR TITLE
More Rhai function improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   3, `x`/`y`/`z`).
 - Improved robustness of `viewer` application when editors move files instead of
   writing to them directly.
+- Add Rhai bindings for all new opcodes
 
 # 0.2.3
 - Fix a possible panic during multithreaded 3D rendering of very small images

--- a/fidget/src/core/context/tree.rs
+++ b/fidget/src/core/context/tree.rs
@@ -120,6 +120,18 @@ impl Tree {
     pub fn min<T: Into<Tree>>(&self, other: T) -> Self {
         Self::op_binary(self.clone(), other.into(), BinaryOpcode::Min)
     }
+    pub fn compare<T: Into<Tree>>(&self, other: T) -> Self {
+        Self::op_binary(self.clone(), other.into(), BinaryOpcode::Compare)
+    }
+    pub fn modulo<T: Into<Tree>>(&self, other: T) -> Self {
+        Self::op_binary(self.clone(), other.into(), BinaryOpcode::Mod)
+    }
+    pub fn and<T: Into<Tree>>(&self, other: T) -> Self {
+        Self::op_binary(self.clone(), other.into(), BinaryOpcode::And)
+    }
+    pub fn or<T: Into<Tree>>(&self, other: T) -> Self {
+        Self::op_binary(self.clone(), other.into(), BinaryOpcode::Or)
+    }
     pub fn neg(&self) -> Self {
         Self::op_unary(self.clone(), UnaryOpcode::Neg)
     }
@@ -146,6 +158,12 @@ impl Tree {
     }
     pub fn ln(&self) -> Self {
         Self::op_unary(self.clone(), UnaryOpcode::Ln)
+    }
+    pub fn not(&self) -> Self {
+        Self::op_unary(self.clone(), UnaryOpcode::Not)
+    }
+    pub fn abs(&self) -> Self {
+        Self::op_unary(self.clone(), UnaryOpcode::Abs)
     }
 }
 


### PR DESCRIPTION
- Adds missing opcodes
- Simplifies binary function macros (using `rhai::Dynamic` instead of different functions for `Tree` / `f64` / `i64`)
- Register functions to ban comparisons of `Tree` objects
