### PR TITLE
New JIT calling convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 - Improved robustness of `viewer` application when editors move files instead of
   writing to them directly.
 - Add Rhai bindings for all new opcodes
+- Tweak JIT calling convention to take an array of inputs instead of X, Y, Z
+  arguments.
 
 # 0.2.3
 - Fix a possible panic during multithreaded 3D rendering of very small images

--- a/fidget/src/core/compiler/alloc.rs
+++ b/fidget/src/core/compiler/alloc.rs
@@ -656,6 +656,8 @@ impl<const N: usize> RegisterAllocator<N> {
     /// Pushes an [`Input`](crate::compiler::RegOp::Input) operation to the tape
     #[inline(always)]
     fn op_input(&mut self, out: u32, i: u8) {
+        // TODO: tightly pack variables (which may be sparse) into slots
+        self.out.var_count = self.out.var_count.max(i as u32 + 1);
         self.op_out_only(out, |out| RegOp::Input(out, i));
     }
 }

--- a/fidget/src/core/compiler/reg_tape.rs
+++ b/fidget/src/core/compiler/reg_tape.rs
@@ -9,6 +9,9 @@ pub struct RegTape {
 
     /// Total allocated slots
     pub(super) slot_count: u32,
+
+    /// Number of variables
+    pub(super) var_count: u32,
 }
 
 impl RegTape {
@@ -31,6 +34,7 @@ impl RegTape {
         Self {
             tape: vec![],
             slot_count: 1,
+            var_count: 0,
         }
     }
 
@@ -44,6 +48,11 @@ impl RegTape {
     #[inline]
     pub fn slot_count(&self) -> usize {
         self.slot_count as usize
+    }
+    /// Returns the number of variables (inputs) used in this tape
+    #[inline]
+    pub fn var_count(&self) -> usize {
+        self.var_count as usize
     }
     /// Returns the number of elements in the tape
     #[inline]

--- a/fidget/src/core/eval/bulk.rs
+++ b/fidget/src/core/eval/bulk.rs
@@ -58,9 +58,12 @@ pub trait BulkEvaluator: Default {
         xs: &[f32],
         ys: &[f32],
         zs: &[f32],
+        var_count: usize,
     ) -> Result<(), Error> {
         if xs.len() != ys.len() || ys.len() != zs.len() {
             Err(Error::MismatchedSlices)
+        } else if var_count > 3 {
+            Err(Error::BadVarSlice(3, var_count))
         } else {
             Ok(())
         }

--- a/fidget/src/core/eval/tracing.rs
+++ b/fidget/src/core/eval/tracing.rs
@@ -46,6 +46,15 @@ pub trait TracingEvaluator: Default {
         Self::default()
     }
 
+    /// Helper function to return an error if the inputs are invalid
+    fn check_arguments(&self, var_count: usize) -> Result<(), Error> {
+        if var_count > 3 {
+            Err(Error::BadVarSlice(3, var_count))
+        } else {
+            Ok(())
+        }
+    }
+
     #[cfg(test)]
     fn eval_x<J: Into<Self::Data>>(
         &mut self,

--- a/fidget/src/core/vm/data.rs
+++ b/fidget/src/core/vm/data.rs
@@ -94,6 +94,11 @@ impl<const N: usize> VmData<N> {
         self.asm.slot_count()
     }
 
+    /// Returns the number of variables (inputs) in the inner VM tape
+    pub fn var_count(&self) -> usize {
+        self.asm.var_count()
+    }
+
     /// Simplifies both inner tapes, using the provided choice array
     ///
     /// To minimize allocations, this function takes a [`VmWorkspace`] and

--- a/fidget/src/core/vm/mod.rs
+++ b/fidget/src/core/vm/mod.rs
@@ -123,6 +123,11 @@ impl<const N: usize> GenericVmShape<N> {
     pub fn choice_count(&self) -> usize {
         self.0.choice_count()
     }
+
+    /// Returns the number of variables (inputs) in the tape
+    pub fn var_count(&self) -> usize {
+        self.0.var_count()
+    }
 }
 
 impl<const N: usize> Shape for GenericVmShape<N> {
@@ -258,6 +263,7 @@ impl<const N: usize> TracingEvaluator for VmIntervalEval<N> {
         let y = y.into();
         let z = z.into();
         let tape = tape.0.as_ref();
+        self.check_arguments(tape.var_count())?;
         self.0.resize_slots(tape);
 
         let mut simplify = false;
@@ -477,6 +483,7 @@ impl<const N: usize> TracingEvaluator for VmPointEval<N> {
         let y = y.into();
         let z = z.into();
         let tape = tape.0.as_ref();
+        self.check_arguments(tape.var_count())?;
         self.0.resize_slots(tape);
 
         let mut choices = self.0.choices.as_mut_slice().iter_mut();
@@ -779,7 +786,7 @@ impl<const N: usize> BulkEvaluator for VmFloatSliceEval<N> {
         zs: &[f32],
     ) -> Result<&[f32], Error> {
         let tape = tape.0.as_ref();
-        self.check_arguments(xs, ys, zs)?;
+        self.check_arguments(xs, ys, zs, tape.var_count())?;
         self.0.resize_slots(tape, xs.len());
         assert_eq!(xs.len(), ys.len());
         assert_eq!(ys.len(), zs.len());
@@ -1067,7 +1074,7 @@ impl<const N: usize> BulkEvaluator for VmGradSliceEval<N> {
         zs: &[f32],
     ) -> Result<&[Grad], Error> {
         let tape = tape.0.as_ref();
-        self.check_arguments(xs, ys, zs)?;
+        self.check_arguments(xs, ys, zs, tape.var_count())?;
         self.0.resize_slots(tape, xs.len());
         assert_eq!(xs.len(), ys.len());
         assert_eq!(ys.len(), zs.len());

--- a/fidget/src/jit/aarch64/float_slice.rs
+++ b/fidget/src/jit/aarch64/float_slice.rs
@@ -126,9 +126,7 @@ impl Assembler for FloatSliceAssembler {
             ; cmp x2, 0
             ; b.eq ->E // function exit
 
-            // Loop body:
-            //
-            ; sub x2, x2, 4 // We handle 4 items at a time
+            // Loop body: math begins below
         );
 
         Self(out)
@@ -353,6 +351,9 @@ impl Assembler for FloatSliceAssembler {
 
     fn finalize(mut self, out_reg: u8) -> Result<Mmap, Error> {
         dynasm!(self.0.ops
+            // update our "items remaining" counter
+            ; sub x2, x2, 4 // We handle 4 items at a time
+
             // Adjust the array offset pointer
             ; add x3, x3, 16
 

--- a/fidget/src/jit/aarch64/float_slice.rs
+++ b/fidget/src/jit/aarch64/float_slice.rs
@@ -8,13 +8,11 @@ pub const SIMD_WIDTH: usize = 4;
 
 /// Assembler for SIMD point-wise evaluation on `aarch64`
 ///
-/// | Argument | Register | Type                |
-/// | ---------|----------|---------------------|
-/// | X        | `x0`     | `*const [f32; 4]`   |
-/// | Y        | `x1`     | `*const [f32; 4]`   |
-/// | Z        | `x2`     | `*const [f32; 4]`   |
-/// | out      | `x3`     | `*mut [f32; 4]`     |
-/// | size     | `x4`     | `u64`               |
+/// | Argument | Register | Type                     |
+/// | ---------|----------|--------------------------|
+/// | `vars`   | `x0`     | `*mut *const [f32; 4]`   |
+/// | out      | `x1`     | `*mut [f32; 4]`          |
+/// | size     | `x2`     | `u64`                    |
 ///
 /// The arrays must be an even multiple of 4 floats, since we're using NEON and
 /// 128-bit wide operations for everything.
@@ -23,33 +21,27 @@ pub const SIMD_WIDTH: usize = 4;
 ///
 /// | Register | Description                                          |
 /// |----------|------------------------------------------------------|
-/// | `v0.s4`  | X                                                    |
-/// | `v1.s4`  | Y                                                    |
-/// | `v2.s4`  | Z                                                    |
+/// | `x3`     | Byte offset within input arrays                      |
+/// | `x4`     | Staging for loading SIMD values                      |
 /// | `v3.s4`  | Immediate value (`IMM_REG`)                          |
 /// | `v7.s4`  | Immediate value for recip (1.0)                      |
 /// | `w9`     | Staging for loading immediates                       |
 /// | `w15`    | Staging to load variables                            |
-/// | `x20-24` | Backups for `x0-5` during function calls             |
-/// | `x25`    | Function call address                                |
+/// | `x20-23` | Backups for `x0-3` during function calls             |
+/// | `x24`    | Function call address                                |
 ///
 /// The stack is configured as follows
 ///
 /// ```text
 /// | Position | Value        | Notes                                       |
 /// |----------|--------------|---------------------------------------------|
-/// | 0x230    | ...          | Register spills live up here                |
+/// | 0x228    | ...          | Register spills live up here                |
 /// |----------|--------------|---------------------------------------------|
-/// | 0x228    | `x25`        | Backup for callee-saved register            |
-/// | 0x220    | `x24`        |                                             |
+/// | 0x220    | `x24`        | Backup for callee-saved register            |
 /// | 0x218    | `x23`        |                                             |
 /// | 0x210    | `x22`        |                                             |
 /// | 0x208    | `x21`        |                                             |
 /// | 0x200    | `x20`        |                                             |
-/// |----------|--------------|---------------------------------------------|
-/// | 0x1f0    | `q2`         | During functions calls, X/Y/Z are saved on  |
-/// | 0x1e0    | `q1`         | the stack                                   |
-/// | 0x1d0    | `q0`         |                                             |
 /// |----------|--------------|---------------------------------------------|
 /// | 0x1c0    | `q31`        | During functions calls, caller-saved tape   |
 /// | 0x1b0    | `q30`        | registers are saved on the stack            |
@@ -88,7 +80,7 @@ pub const SIMD_WIDTH: usize = 4;
 /// | 0x8      | `sp` (`x30`) | Stack frame                                 |
 /// | 0x0      | `fp` (`x29`) | [current value for sp]                      |
 /// ```
-const STACK_SIZE: u32 = 0x230;
+const STACK_SIZE: u32 = 0x228;
 
 impl Assembler for FloatSliceAssembler {
     type Data = f32;
@@ -117,33 +109,26 @@ impl Assembler for FloatSliceAssembler {
             ; str x22, [sp, 0x210]
             ; str x23, [sp, 0x218]
             ; str x24, [sp, 0x220]
-            ; str x25, [sp, 0x228]
+
+            ; mov x3, 0
 
             // The loop returns here, and we check whether we need to loop
             ; ->L:
             // Remember, at this point we have
-            //  x0: x input array pointer
-            //  x1: y input array pointer
-            //  x2: z input array pointer
-            //  x3: output array pointer
-            //  x4: number of points to evaluate
+            //  x0: vars input pointer
+            //  x1: output array pointer
+            //  x2: number of points to evaluate
+            //  x3: offset within SIMD arrays
             //
-            // We'll be advancing x0, x1, x2 here (and decrementing x4 by 4);
-            // x3 is advanced in finalize().
+            // We'll be decrementing x2 by 4 here; x1 and x3 are modified in
+            // finalize().
 
-            ; cmp x4, 0
+            ; cmp x2, 0
             ; b.eq ->E // function exit
 
             // Loop body:
             //
-            // Load V0/1/2.S4 with X/Y/Z values, post-increment
-            //
-            // We're actually loading two f32s, but we can pretend they're
-            // doubles in order to move 64 bits at a time
-            ; ldr q0, [x0], 16
-            ; ldr q1, [x1], 16
-            ; ldr q2, [x2], 16
-            ; sub x4, x4, 4 // We handle 4 items at a time
+            ; sub x2, x2, 4 // We handle 4 items at a time
         );
 
         Self(out)
@@ -174,7 +159,12 @@ impl Assembler for FloatSliceAssembler {
     }
     /// Copies the given input to `out_reg`
     fn build_input(&mut self, out_reg: u8, src_arg: u8) {
-        dynasm!(self.0.ops ; mov V(reg(out_reg)).b16, V(src_arg as u32).b16);
+        assert!(src_arg as u32 * 8 < 16384);
+        dynasm!(self.0.ops
+            ; ldr x4, [x0, src_arg as u32 * 8]
+            ; add x4, x4, x3 // apply array offset
+            ; ldr Q(reg(out_reg)), [x4]
+        );
     }
     fn build_sin(&mut self, out_reg: u8, lhs_reg: u8) {
         extern "C" fn float_sin(f: f32) -> f32 {
@@ -363,11 +353,14 @@ impl Assembler for FloatSliceAssembler {
 
     fn finalize(mut self, out_reg: u8) -> Result<Mmap, Error> {
         dynasm!(self.0.ops
-            // Prepare our return value, writing to the pointer in x3
+            // Adjust the array offset pointer
+            ; add x3, x3, 16
+
+            // Prepare our return value, writing to the pointer in x1
             // It's fine to overwrite X at this point in V0, since we're not
             // using it anymore.
             ; mov v0.d[0], V(reg(out_reg)).d[1]
-            ; stp D(reg(out_reg)), d0, [x3], 16
+            ; stp D(reg(out_reg)), d0, [x1], 16
             ; b ->L
 
             ; ->E:
@@ -391,7 +384,6 @@ impl Assembler for FloatSliceAssembler {
             ; ldr x22, [sp, 0x210]
             ; ldr x23, [sp, 0x218]
             ; ldr x24, [sp, 0x220]
-            ; ldr x25, [sp, 0x228]
 
             // Fix up the stack
             ; add sp, sp, self.0.mem_offset as u32
@@ -416,11 +408,6 @@ impl FloatSliceAssembler {
             ; mov x21, x1
             ; mov x22, x2
             ; mov x23, x3
-            ; mov x24, x4
-
-            // Back up X/Y/Z values
-            ; stp q0, q1, [sp, 0x1d0]
-            ; str q2, [sp, 0x1f0]
 
             // We use registers v8-v15 (callee saved, but only lower 64 bytes)
             // and v16-v31 (caller saved)
@@ -440,10 +427,10 @@ impl FloatSliceAssembler {
 
             // Load the function address, awkwardly, into a callee-saved
             // register (so we only need to do this once)
-            ; movz x25, ((addr >> 48) as u32), lsl 48
-            ; movk x25, ((addr >> 32) as u32), lsl 32
-            ; movk x25, ((addr >> 16) as u32), lsl 16
-            ; movk x25, addr as u32
+            ; movz x24, ((addr >> 48) as u32), lsl 48
+            ; movk x24, ((addr >> 32) as u32), lsl 32
+            ; movk x24, ((addr >> 16) as u32), lsl 16
+            ; movk x24, addr as u32
 
             // We're going to back up our argument into d8/d9 (since the callee
             // only saves the bottom 64 bits).  Note that d8/d9 may be our input
@@ -453,19 +440,19 @@ impl FloatSliceAssembler {
             ; mov d9, v0.d[1]
 
             ; mov s0, v8.s[0]
-            ; blr x25
+            ; blr x24
             ; mov v8.s[0], v0.s[0]
 
             ; mov s0, v8.s[1]
-            ; blr x25
+            ; blr x24
             ; mov v8.s[1], v0.s[0]
 
             ; mov s0, v9.s[0]
-            ; blr x25
+            ; blr x24
             ; mov v9.s[0], v0.s[0]
 
             ; mov s0, v9.s[1]
-            ; blr x25
+            ; blr x24
             ; mov v9.s[1], v0.s[0]
 
             // Copy into v0, because we're about to restore v8
@@ -489,16 +476,11 @@ impl FloatSliceAssembler {
             // Set our output value
             ; mov V(reg(out_reg)).b16, v0.b16
 
-            // Restore X/Y/Z values
-            ; ldp q0, q1, [sp, 0x1d0]
-            ; ldr q2, [sp, 0x1f0]
-
             // Restore our current state
             ; mov x0, x20
             ; mov x1, x21
             ; mov x2, x22
             ; mov x3, x23
-            ; mov x4, x24
         );
     }
 }

--- a/fidget/src/jit/aarch64/grad_slice.rs
+++ b/fidget/src/jit/aarch64/grad_slice.rs
@@ -162,6 +162,7 @@ impl Assembler for GradSliceAssembler {
         dynasm!(self.0.ops
             ; ldr x4, [x0, src_arg as u32 * 8]
             ; add x4, x4, x3 // apply array offset
+            ; eor V(reg(out_reg)).b16, V(reg(out_reg)).b16, V(reg(out_reg)).b16
             ; ldr S(reg(out_reg)), [x4]
             ; fmov s6, 1.0
         );

--- a/fidget/src/jit/aarch64/grad_slice.rs
+++ b/fidget/src/jit/aarch64/grad_slice.rs
@@ -15,10 +15,8 @@ use dynasmrt::{dynasm, DynasmApi, DynasmLabelApi};
 /// | Variable   | Register | Type               |
 /// |------------|----------|--------------------|
 /// | X          | `x0`     | `*const f32`       |
-/// | Y          | `x1`     | `*const f32`       |
-/// | Z          | `x2`     | `*const f32`       |
-/// | `out`      | `x3`     | `*const [f32; 4]`  |
-/// | `count`    | `x4`     | `u64`              |
+/// | `out`      | `x1`     | `*const [f32; 4]`  |
+/// | `count`    | `x2`     | `u64`              |
 ///
 /// During evaluation, X, Y, and Z are stored in `V0-3.S4`.  Each SIMD register
 /// is in the order `[value, dx, dy, dz]`, e.g. the value for X is in `V0.S0`.
@@ -28,31 +26,25 @@ use dynasmrt::{dynasm, DynasmApi, DynasmLabelApi};
 ///
 /// | Register | Description                                          |
 /// |----------|------------------------------------------------------|
-/// | `v0.s4`  | X                                                    |
-/// | `v1.s4`  | Y                                                    |
-/// | `v2.s4`  | Z                                                    |
+/// | `x3`     | byte offset within input arrays                      |
+/// | `x4`     | Staging for loading SIMD values                      |
 /// | `v3.s4`  | Immediate value (`IMM_REG`)                          |
 /// | `v7.s4`  | Immediate value for recip (1.0)                      |
 /// | `w9`     | Staging for loading immediates                       |
 /// | `w15`    | Staging to load variables                            |
-/// | `x20-25` | Backups for `x0-5` during function calls             |
+/// | `x20-23` | Backups for `x0-3` during function calls             |
 ///
 /// The stack is configured as follows
 ///
 /// ```text
 /// | Position | Value        | Notes                                       |
 /// |----------|--------------|---------------------------------------------|
-/// | 0x228    | ...          | Register spills live up here                |
+/// | 0x220    | ...          | Register spills live up here                |
 /// |----------|--------------|---------------------------------------------|
-/// | 0x220    | `x24`        |                                             |
-/// | 0x218    | `x23`        |                                             |
+/// | 0x218    | `x23`        | Backup for callee-saved register            |
 /// | 0x210    | `x22`        |                                             |
 /// | 0x208    | `x21`        |                                             |
 /// | 0x200    | `x20`        |                                             |
-/// |----------|--------------|---------------------------------------------|
-/// | 0x1f0    | `q2`         | During functions calls, X/Y/Z are saved on  |
-/// | 0x1e0    | `q1`         | the stack                                   |
-/// | 0x1d0    | `q0`         |                                             |
 /// |----------|--------------|---------------------------------------------|
 /// | 0x1c0    | `q31`        | During functions calls, caller-saved tape   |
 /// | 0x1b0    | `q30`        | registers are saved on the stack            |
@@ -91,7 +83,7 @@ use dynasmrt::{dynasm, DynasmApi, DynasmLabelApi};
 /// | 0x8      | `sp` (`x30`) | Stack frame                                 |
 /// | 0x0      | `fp` (`x29`) | [current value for sp]                      |
 /// ```
-const STACK_SIZE: u32 = 0x228;
+const STACK_SIZE: u32 = 0x220;
 
 impl Assembler for GradSliceAssembler {
     type Data = Grad;
@@ -119,35 +111,25 @@ impl Assembler for GradSliceAssembler {
             ; str x21, [sp, 0x208]
             ; str x22, [sp, 0x210]
             ; str x23, [sp, 0x218]
-            ; str x24, [sp, 0x220]
+
+            ; mov x3, 0
 
             // The loop returns here, and we check whether we need to loop
             ; ->L:
             // Remember, at this point we have
-            //  x0: x input array pointer
-            //  x1: y input array pointer
-            //  x2: z input array pointer
-            //  x3: output array pointer
-            //  x4: number of points to evaluate
+            //  x0: vars input pointer
+            //  x1: output array pointer
+            //  x2: number of points to evaluate
+            //  x3: offset within SIMD arrays
             //
-            // We'll be advancing x0, x1, x2 here (and decrementing x4 by 1);
-            // x3 is advanced in finalize().
+            // We'll be decrementing x2 by 1 here; x1 and x3 are modified in
+            // finalize().
 
-            ; cmp x4, 0
+            ; cmp x2, 0
             ; b.eq ->E // function exit
 
-            // Load V0/1/2.S4 with X/Y/Z values, post-increment
-            //
-            // We're actually loading two f32s, but we can pretend they're
-            // doubles in order to move 64 bits at a time
-            ; fmov s6, 1.0
-            ; ldr s0, [x0], 4
-            ; mov v0.S[1], v6.S[0]
-            ; ldr s1, [x1], 4
-            ; mov v1.S[2], v6.S[0]
-            ; ldr s2, [x2], 4
-            ; mov v2.S[3], v6.S[0]
-            ; sub x4, x4, 1 // We handle 1 item at a time
+            // Loop body:
+            ; sub x2, x2, 1 // We handle 1 item at a time
 
             // Math begins below!
         );
@@ -179,7 +161,20 @@ impl Assembler for GradSliceAssembler {
     }
     /// Copies the given input to `out_reg`
     fn build_input(&mut self, out_reg: u8, src_arg: u8) {
-        dynasm!(self.0.ops ; mov V(reg(out_reg)).b16, V(src_arg as u32).b16);
+        assert!(src_arg as u32 * 8 < 16384);
+        dynasm!(self.0.ops
+            ; ldr x4, [x0, src_arg as u32 * 8]
+            ; add x4, x4, x3 // apply array offset
+            ; ldr S(reg(out_reg)), [x4]
+            ; fmov s6, 1.0
+        );
+        // Load the gradient, which is a 1.0
+        match src_arg % 3 {
+            0 => dynasm!(self.0.ops ; mov V(reg(out_reg)).S[1], v6.S[0]),
+            1 => dynasm!(self.0.ops ; mov V(reg(out_reg)).S[2], v6.S[0]),
+            2 => dynasm!(self.0.ops ; mov V(reg(out_reg)).S[3], v6.S[0]),
+            _ => unreachable!(),
+        }
     }
     fn build_sin(&mut self, out_reg: u8, lhs_reg: u8) {
         extern "C" fn grad_sin(v: Grad) -> Grad {
@@ -473,8 +468,11 @@ impl Assembler for GradSliceAssembler {
 
     fn finalize(mut self, out_reg: u8) -> Result<Mmap, Error> {
         dynasm!(self.0.ops
-            // Prepare our return value, writing to the pointer in x4
-            ; str Q(reg(out_reg)), [x3], 16
+            // Adjust the array offset pointer
+            ; add x3, x3, 4
+
+            // Prepare our return value, writing to the pointer in x1
+            ; str Q(reg(out_reg)), [x1], 16
             ; b ->L // Jump back to the loop start
 
             ; ->E:
@@ -498,7 +496,6 @@ impl Assembler for GradSliceAssembler {
             ; ldr x21, [sp, 0x208]
             ; ldr x22, [sp, 0x210]
             ; ldr x23, [sp, 0x218]
-            ; ldr x24, [sp, 0x220]
 
             // Fix up the stack
             ; add sp, sp, self.0.mem_offset as u32
@@ -524,11 +521,6 @@ impl GradSliceAssembler {
             ; mov x21, x1
             ; mov x22, x2
             ; mov x23, x3
-            ; mov x24, x4
-
-            // Back up X/Y/Z values (TODO use registers here as well?)
-            ; stp q0, q1, [sp, 0x1d0]
-            ; str q2, [sp, 0x1f0]
 
             // We use registers v8-v15 (callee saved, but only lower 64 bytes)
             // and v16-v31 (caller saved)
@@ -576,22 +568,16 @@ impl GradSliceAssembler {
             ; ldp q28, q29, [sp, 0x190]
             ; ldp q30, q31, [sp, 0x1b0]
 
-            // Copy into v4, because we're about to restore v0/1/2/3
             ; mov V(reg(out_reg)).s[0], v0.s[0]
             ; mov V(reg(out_reg)).s[1], v1.s[0]
             ; mov V(reg(out_reg)).s[2], v2.s[0]
             ; mov V(reg(out_reg)).s[3], v3.s[0]
-
-            // Restore X/Y/Z values
-            ; ldp q0, q1, [sp, 0x1d0]
-            ; ldr q2, [sp, 0x1f0]
 
             // Restore our current state
             ; mov x0, x20
             ; mov x1, x21
             ; mov x2, x22
             ; mov x3, x23
-            ; mov x4, x24
         );
     }
 
@@ -609,7 +595,6 @@ impl GradSliceAssembler {
             ; mov x21, x1
             ; mov x22, x2
             ; mov x23, x3
-            ; mov x24, x4
 
             // Back up X/Y/Z values (TODO use registers here as well?)
             ; stp q0, q1, [sp, 0x1d0]
@@ -631,12 +616,13 @@ impl GradSliceAssembler {
             ; stp q28, q29, [sp, 0x190]
             ; stp q30, q31, [sp, 0x1b0]
 
-            // Load the function address, awkwardly, into a callee-saved
-            // register (so we only need to do this once)
-            ; movz x26, ((addr >> 48) as u32), lsl 48
-            ; movk x26, ((addr >> 32) as u32), lsl 32
-            ; movk x26, ((addr >> 16) as u32), lsl 16
-            ; movk x26, addr as u32
+            // Load the function address, awkwardly, into x0 (it doesn't matter
+            // that it could be thrashed by the call, since we're only calling
+            // it once).
+            ; movz x0, ((addr >> 48) as u32), lsl 48
+            ; movk x0, ((addr >> 32) as u32), lsl 32
+            ; movk x0, ((addr >> 16) as u32), lsl 16
+            ; movk x0, addr as u32
 
             // Prepare to call our stuff!
             ; mov s0, V(reg(lhs_reg)).s[0]
@@ -650,7 +636,7 @@ impl GradSliceAssembler {
             // We do s3 last because it could be IMM_REG
             ; mov s3, V(reg(lhs_reg)).s[3]
 
-            ; blr x26
+            ; blr x0
 
             // Restore register state (lol)
             ; ldp q8, q9, [sp, 0x50]
@@ -681,7 +667,6 @@ impl GradSliceAssembler {
             ; mov x1, x21
             ; mov x2, x22
             ; mov x3, x23
-            ; mov x4, x24
         );
     }
 }

--- a/fidget/src/jit/aarch64/grad_slice.rs
+++ b/fidget/src/jit/aarch64/grad_slice.rs
@@ -128,10 +128,7 @@ impl Assembler for GradSliceAssembler {
             ; cmp x2, 0
             ; b.eq ->E // function exit
 
-            // Loop body:
-            ; sub x2, x2, 1 // We handle 1 item at a time
-
-            // Math begins below!
+            // Loop body: math begins below
         );
 
         Self(out)
@@ -468,8 +465,11 @@ impl Assembler for GradSliceAssembler {
 
     fn finalize(mut self, out_reg: u8) -> Result<Mmap, Error> {
         dynasm!(self.0.ops
+            // update our "items remaining" counter
+            ; sub x2, x2, 1 // We handle 1 item at a time
+
             // Adjust the array offset pointer
-            ; add x3, x3, 4
+            ; add x3, x3, 4 // 1 item = 4 bytes
 
             // Prepare our return value, writing to the pointer in x1
             ; str Q(reg(out_reg)), [x1], 16

--- a/fidget/src/jit/x86_64/float_slice.rs
+++ b/fidget/src/jit/x86_64/float_slice.rs
@@ -337,7 +337,7 @@ impl Assembler for FloatSliceAssembler {
             ; vmovups [rsi], Ry(reg(out_reg))
             ; add rsi, 32
             ; sub rdx, 8
-            ; add rcx, 64
+            ; add rcx, 32
             ; jmp ->L
 
             // Finalization code, which happens after all evaluation is complete

--- a/fidget/src/jit/x86_64/float_slice.rs
+++ b/fidget/src/jit/x86_64/float_slice.rs
@@ -100,7 +100,7 @@ impl Assembler for FloatSliceAssembler {
     fn build_input(&mut self, out_reg: u8, src_arg: u8) {
         let pos = 8 * (src_arg as i32);
         dynasm!(self.0.ops
-            ; movq r8, [rdi + pos]  // read the *const float from the array
+            ; mov r8, [rdi + pos]   // read the *const float from the array
             ; add r8, rcx           // offset it by array position
             ; vmovups Ry(reg(out_reg)), [r8]
         );

--- a/fidget/src/jit/x86_64/grad_slice.rs
+++ b/fidget/src/jit/x86_64/grad_slice.rs
@@ -62,20 +62,6 @@ impl Assembler for GradSliceAssembler {
         out.prepare_stack(slot_count, STACK_SIZE_UPPER + STACK_SIZE_LOWER);
         let input_pos = STACK_SIZE_UPPER as i32;
         dynasm!(out.ops
-            // Preload unchanging gradient values
-            ; mov eax, 1.0f32.to_bits() as i32
-            ; mov [rbp - (input_pos - 0x4)], eax  // d/dx(x) = 1
-            ; mov [rbp - (input_pos - 0x18)], eax // d/dy(y) = 1
-            ; mov [rbp - (input_pos - 0x2c)], eax // d/dz(z) = 1
-
-            ; xor eax, eax // set eax to 0u32, which is also 0f32
-            ; mov [rbp - (input_pos - 0x8)], eax // d/dy(x) = 0
-            ; mov [rbp - (input_pos - 0xc)], eax // d/dz(x) = 0
-            ; mov [rbp - (input_pos - 0x14)], eax // d/dx(y) = 0
-            ; mov [rbp - (input_pos - 0x1c)], eax // d/dz(y) = 0
-            ; mov [rbp - (input_pos - 0x24)], eax // d/dz(x) = 0
-            ; mov [rbp - (input_pos - 0x28)], eax // d/dz(y) = 0
-
             ; xor rcx, rcx // set the array offset (rcx) to 0
 
             // The loop returns here, and we check whether to keep looping

--- a/fidget/src/jit/x86_64/grad_slice.rs
+++ b/fidget/src/jit/x86_64/grad_slice.rs
@@ -60,7 +60,6 @@ impl Assembler for GradSliceAssembler {
             ; mov rbp, rsp
         );
         out.prepare_stack(slot_count, STACK_SIZE_UPPER + STACK_SIZE_LOWER);
-        let input_pos = STACK_SIZE_UPPER as i32;
         dynasm!(out.ops
             ; xor rcx, rcx // set the array offset (rcx) to 0
 

--- a/fidget/src/jit/x86_64/grad_slice.rs
+++ b/fidget/src/jit/x86_64/grad_slice.rs
@@ -81,7 +81,7 @@ impl Assembler for GradSliceAssembler {
             // The loop returns here, and we check whether to keep looping
             ; ->L:
 
-            ; test r8, r8
+            ; test rdx, rdx
             ; jz ->X // jump to the exit if we're done, otherwise fallthrough
         );
         Self(out)
@@ -459,8 +459,8 @@ impl Assembler for GradSliceAssembler {
             // Copy data from out_reg into the out array, then adjust it
             ; vmovups [rsi], Rx(reg(out_reg))
             ; add rsi, 16 // 4x float
-            ; sub rdx, 1
-            ; add rcx, 4
+            ; sub rdx, 1 // we process one element at a time
+            ; add rcx, 4 // input is array is single floats
             ; jmp ->L
 
             // Finalization code, which happens after all evaluation is complete
@@ -489,7 +489,6 @@ impl GradSliceAssembler {
             ; mov [rbp - 0x10], rsi
             ; mov [rbp - 0x18], rdx
             ; mov [rbp - 0x20], rcx
-            ; mov [rbp - 0x28], r8
 
             // Back up register values to the stack, saving all 128 bits
             ; vmovups [rsp], xmm4
@@ -530,7 +529,6 @@ impl GradSliceAssembler {
             ; mov rsi, [rbp - 0x10]
             ; mov rdx, [rbp - 0x18]
             ; mov rcx, [rbp - 0x20]
-            ; mov r8, [rbp - 0x28]
 
             // Collect the 4x floats into the out register
             ; vpunpcklqdq Rx(reg(out_reg)), xmm0, xmm1

--- a/fidget/src/jit/x86_64/interval.rs
+++ b/fidget/src/jit/x86_64/interval.rs
@@ -366,7 +366,7 @@ impl Assembler for IntervalAssembler {
     }
     fn build_max(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
         dynasm!(self.0.ops
-            ; mov ax, [rdi]
+            ; mov ax, [rsi]
 
             // xmm1 = lhs.upper
             ; vpshufd xmm1, Rx(reg(lhs_reg)), 0b11111101u8 as i8
@@ -410,8 +410,8 @@ impl Assembler for IntervalAssembler {
             // Fallthrough
 
             ; E:
-            ; mov [rdi], ax
-            ; add rdi, 1
+            ; mov [rsi], ax
+            ; add rsi, 1
         );
         self.0.ops.commit_local().unwrap();
     }
@@ -428,7 +428,7 @@ impl Assembler for IntervalAssembler {
             //      *choices++ |= CHOICE_BOTH
             //      out = fmin(lhs, rhs)
 
-            ; mov ax, [rdi]
+            ; mov ax, [rsi]
 
             // TODO: use cmpltss to do both comparisons?
 
@@ -474,8 +474,8 @@ impl Assembler for IntervalAssembler {
             // Fallthrough
 
             ; E:
-            ; mov [rdi], ax
-            ; add rdi, 1
+            ; mov [rsi], ax
+            ; add rsi, 1
         );
         self.0.ops.commit_local().unwrap();
     }

--- a/fidget/src/jit/x86_64/interval.rs
+++ b/fidget/src/jit/x86_64/interval.rs
@@ -15,11 +15,9 @@ use dynasmrt::{dynasm, DynasmApi, DynasmLabelApi};
 ///
 /// | Variable   | Register | Type                  |
 /// |------------|----------|-----------------------|
-/// | X          | `xmm0`   | `[f32; 2]`            |
-/// | Y          | `xmm1`   | `[f32; 2]`            |
-/// | Z          | `xmm2`   | `[f32; 2]`            |
-/// | `choices`  | `rdi`    | `*mut u8` (array)     |
-/// | `simplify` | `rsi`    | `*mut u8` (single)    |
+/// | `vars`     | `rdi`    | `*const [f32; 2]`     |
+/// | `choices`  | `rsi`    | `*mut u8` (array)     |
+/// | `simplify` | `rdx`    | `*mut u8` (single)    |
 ///
 /// The stack is configured as follows
 ///
@@ -30,11 +28,7 @@ use dynasmrt::{dynasm, DynasmApi, DynasmLabelApi};
 /// |----------|--------------|---------------------------------------------|
 /// | -0x08    | `r12`        | During functions calls, we use these        |
 /// | -0x10    | `r13`        | as temporary storage so must preserve their |
-/// |          |              | previous values on the stack                |
-/// |----------|--------------|---------------------------------------------|
-/// | -0x10    | Z            | Inputs (as 2x floats)                       |
-/// | -0x18    | Y            |                                             |
-/// | -0x20    | X            |                                             |
+/// | -0x18    | `r14`        | previous values on the stack                |
 /// |----------|--------------|---------------------------------------------|
 /// | ...      | ...          | Register spills live up here                |
 /// |----------|--------------|---------------------------------------------|
@@ -51,7 +45,7 @@ use dynasmrt::{dynasm, DynasmApi, DynasmLabelApi};
 /// | 0x08     | xmm5         |                                             |
 /// | 0x00     | xmm4         |                                             |
 /// ```
-const STACK_SIZE_UPPER: usize = 0x20; // Positions relative to `rbp`
+const STACK_SIZE_UPPER: usize = 0x18; // Positions relative to `rbp`
 const STACK_SIZE_LOWER: usize = 0x60; // Positions relative to `rsp`
 
 impl Assembler for IntervalAssembler {
@@ -66,11 +60,6 @@ impl Assembler for IntervalAssembler {
         out.prepare_stack(slot_count, STACK_SIZE_UPPER + STACK_SIZE_LOWER);
         dynasm!(out.ops
             ; vzeroupper
-
-            // Put X/Y/Z on the stack so we can use those registers
-            ; vmovsd [rbp - 0x20], xmm0
-            ; vmovsd [rbp - 0x18], xmm1
-            ; vmovsd [rbp - 0x10], xmm2
         );
         Self(out)
     }
@@ -97,10 +86,9 @@ impl Assembler for IntervalAssembler {
         );
     }
     fn build_input(&mut self, out_reg: u8, src_arg: u8) {
-        let pos = STACK_SIZE_UPPER as i32
-            - (std::mem::size_of::<Self::Data>() as i32) * (src_arg as i32);
+        let pos = 8 * (src_arg as i32);
         dynasm!(self.0.ops
-            ; vmovq Rx(reg(out_reg)), [rbp - pos]
+            ; vmovq Rx(reg(out_reg)), [rdi + pos]
         );
     }
     fn build_sin(&mut self, out_reg: u8, lhs_reg: u8) {
@@ -409,8 +397,8 @@ impl Assembler for IntervalAssembler {
             ; L:
             ; vmovq Rx(reg(out_reg)), Rx(reg(lhs_reg))
             ; or ax, CHOICE_LEFT as i16
-            ; mov cx, 1 // TODO: why can't we write 1 to [rsi] directly?
-            ; mov [rsi], cx
+            ; mov cx, 1 // TODO: why can't we write 1 to [rdx] directly?
+            ; mov [rdx], cx
             ; jmp >E
 
             // rhs.upper < lhs.lower
@@ -418,7 +406,7 @@ impl Assembler for IntervalAssembler {
             ; vmovq Rx(reg(out_reg)), Rx(reg(rhs_reg))
             ; or ax, CHOICE_RIGHT as i16
             ; mov cx, 1
-            ; mov [rsi], cx
+            ; mov [rdx], cx
             // Fallthrough
 
             ; E:
@@ -473,8 +461,8 @@ impl Assembler for IntervalAssembler {
             ; L:
             ; vmovq Rx(reg(out_reg)), Rx(reg(lhs_reg))
             ; or ax, CHOICE_LEFT as i16
-            ; mov cx, 1 // TODO: why can't we write 1 to [rsi] directly?
-            ; mov [rsi], cx
+            ; mov cx, 1 // TODO: why can't we write 1 to [rdx] directly?
+            ; mov [rdx], cx
             ; jmp >E
 
             // rhs.upper < lhs.lower
@@ -482,7 +470,7 @@ impl Assembler for IntervalAssembler {
             ; vmovq Rx(reg(out_reg)), Rx(reg(rhs_reg))
             ; or ax, CHOICE_RIGHT as i16
             ; mov cx, 1
-            ; mov [rsi], cx
+            ; mov [rdx], cx
             // Fallthrough
 
             ; E:
@@ -552,8 +540,8 @@ impl Assembler for IntervalAssembler {
             // !lhs.contains(0.0) -> RHS
             ; vmovq Rx(reg(out_reg)), Rx(reg(rhs_reg))
             ; or ax, CHOICE_RIGHT as i16
-            ; mov cx, 1 // TODO: why can't we write 1 to [rsi] directly?
-            ; mov [rsi], cx
+            ; mov cx, 1 // TODO: why can't we write 1 to [rdx] directly?
+            ; mov [rdx], cx
             ; jmp >E
 
             // xmm3 = (lower == 0) && (upper == 0)
@@ -568,8 +556,8 @@ impl Assembler for IntervalAssembler {
             // (lhs.lower == 0) && (lhs.upper == 0) -> LHS
             ; vmovq Rx(reg(out_reg)), Rx(reg(lhs_reg))
             ; or ax, CHOICE_LEFT as i16
-            ; mov cx, 1 // TODO: why can't we write 1 to [rsi] directly?
-            ; mov [rsi], cx
+            ; mov cx, 1 // TODO: why can't we write 1 to [rdx] directly?
+            ; mov [rdx], cx
             ; jmp >E
 
             // We have to combine the outputs
@@ -616,8 +604,8 @@ impl Assembler for IntervalAssembler {
             // !lhs.contains(0.0) -> LHS
             ; vmovq Rx(reg(out_reg)), Rx(reg(lhs_reg))
             ; or ax, CHOICE_LEFT as i16
-            ; mov cx, 1 // TODO: why can't we write 1 to [rsi] directly?
-            ; mov [rsi], cx
+            ; mov cx, 1 // TODO: why can't we write 1 to [rdx] directly?
+            ; mov [rdx], cx
             ; jmp >E
 
             // xmm3 = (lower == 0) && (upper == 0)
@@ -632,8 +620,8 @@ impl Assembler for IntervalAssembler {
             // (lhs.lower == 0) && (lhs.upper == 0) -> RHS
             ; vmovq Rx(reg(out_reg)), Rx(reg(rhs_reg))
             ; or ax, CHOICE_RIGHT as i16
-            ; mov cx, 1 // TODO: why can't we write 1 to [rsi] directly?
-            ; mov [rsi], cx
+            ; mov cx, 1 // TODO: why can't we write 1 to [rdx] directly?
+            ; mov [rdx], cx
             ; jmp >E
 
             // We have to combine the outputs
@@ -734,6 +722,7 @@ impl Assembler for IntervalAssembler {
             dynasm!(self.0.ops
                 ; mov r12, [rbp - 0x8]
                 ; mov r13, [rbp - 0x10]
+                ; mov r14, [rbp - 0x18]
             );
         }
         dynasm!(self.0.ops
@@ -759,6 +748,7 @@ impl IntervalAssembler {
             dynasm!(self.0.ops
                 ; mov [rbp - 0x8], r12
                 ; mov [rbp - 0x10], r13
+                ; mov [rbp - 0x18], r14
             );
             self.0.saved_callee_regs = true
         }
@@ -767,6 +757,7 @@ impl IntervalAssembler {
             // Back up choice/simplify pointers to registers
             ; mov r12, rdi
             ; mov r13, rsi
+            ; mov r14, rdx
 
             // Back up register values to the stack, treating them as doubles
             // (since we want to back up all 64 bits)
@@ -807,6 +798,7 @@ impl IntervalAssembler {
             // Restore choice/simplify pointers
             ; mov rdi, r12
             ; mov rsi, r13
+            ; mov rdx, r14
 
             // Unpack the interval result
             ; vmovq Rx(reg(out_reg)), xmm0
@@ -833,6 +825,7 @@ impl IntervalAssembler {
             // Back up choice/simplify pointers to registers
             ; mov r12, rdi
             ; mov r13, rsi
+            ; mov r14, rdx
 
             // Back up register values to the stack, treating them as doubles
             // (since we want to back up all 64 bits)
@@ -875,6 +868,7 @@ impl IntervalAssembler {
             // Restore choice/simplify pointers
             ; mov rdi, r12
             ; mov rsi, r13
+            ; mov rdx, r14
 
             // Unpack the interval result
             ; vmovq Rx(reg(out_reg)), xmm0

--- a/fidget/src/jit/x86_64/interval.rs
+++ b/fidget/src/jit/x86_64/interval.rs
@@ -526,7 +526,7 @@ impl Assembler for IntervalAssembler {
     fn build_and(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
         assert_ne!(reg(lhs_reg), IMM_REG);
         dynasm!(self.0.ops
-            ; mov ax, [rdi] // load the choice flag
+            ; mov ax, [rsi] // load the choice flag
             ; vpxor xmm1, xmm1, xmm1 // xmm1 = 0.0
 
             // xmm2 = !arg.contains(0.0)
@@ -582,15 +582,15 @@ impl Assembler for IntervalAssembler {
             ; vunpcklps Rx(reg(out_reg)), xmm1, xmm2
 
             ; E: // exit
-            ; mov [rdi], ax
-            ; add rdi, 1
+            ; mov [rsi], ax
+            ; add rsi, 1
         );
         self.0.ops.commit_local().unwrap();
     }
     fn build_or(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
         assert_ne!(reg(lhs_reg), IMM_REG);
         dynasm!(self.0.ops
-            ; mov ax, [rdi] // load the choice flag
+            ; mov ax, [rsi] // load the choice flag
             ; vpxor xmm1, xmm1, xmm1 // xmm1 = 0.0
 
             // xmm2 = !arg.contains(0.0)
@@ -647,8 +647,8 @@ impl Assembler for IntervalAssembler {
             ; vunpcklps Rx(reg(out_reg)), xmm2, xmm1
 
             ; E: // exit
-            ; mov [rdi], ax
-            ; add rdi, 1
+            ; mov [rsi], ax
+            ; add rsi, 1
         );
     }
     fn build_compare(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {

--- a/fidget/src/jit/x86_64/point.rs
+++ b/fidget/src/jit/x86_64/point.rs
@@ -62,10 +62,6 @@ impl Assembler for PointAssembler {
         out.prepare_stack(slot_count, STACK_SIZE_UPPER + STACK_SIZE_LOWER);
         dynasm!(out.ops
             ; vzeroupper
-            // Put X/Y/Z on the stack to free up those registers
-            ; vmovss [rbp - 0x18], xmm2
-            ; vmovss [rbp - 0x1c], xmm1
-            ; vmovss [rbp - 0x20], xmm0
         );
         Self(out)
     }

--- a/fidget/src/jit/x86_64/point.rs
+++ b/fidget/src/jit/x86_64/point.rs
@@ -93,8 +93,8 @@ impl Assembler for PointAssembler {
     fn build_input(&mut self, out_reg: u8, src_arg: u8) {
         let pos = 4 * (src_arg as i32);
         dynasm!(self.0.ops
-            // Pull X/Y/Z from the stack, where they've been placed by init()
-            ; vmovss Rx(reg(out_reg)), [rdi - pos]
+            // Pull the input from the rdi array
+            ; vmovss Rx(reg(out_reg)), [rdi + pos]
         );
     }
     fn build_copy(&mut self, out_reg: u8, lhs_reg: u8) {

--- a/fidget/src/jit/x86_64/point.rs
+++ b/fidget/src/jit/x86_64/point.rs
@@ -14,11 +14,9 @@ use dynasmrt::{dynasm, DynasmApi, DynasmLabelApi};
 ///
 /// | Variable   | Register | Type                  |
 /// |------------|----------|-----------------------|
-/// | X          | `xmm0`   | `f32`                 |
-/// | Y          | `xmm1`   | `f32`                 |
-/// | Z          | `xmm2`   | `f32`                 |
-/// | `choices`  | `rdi`    | `*mut u8` (array)     |
-/// | `simplify` | `rsi`    | `*mut u8` (single)    |
+/// | `vars`     | `rdi`    | `*const f32`          |
+/// | `choices`  | `rsi`    | `*mut u8` (array)     |
+/// | `simplify` | `rdx`    | `*mut u8` (single)    |
 ///
 /// X, Y, and Z are stored on the stack during code execution, to free up those
 /// registers as scratch values.
@@ -32,11 +30,7 @@ use dynasmrt::{dynasm, DynasmApi, DynasmLabelApi};
 /// |----------|--------------|---------------------------------------------|
 /// | -0x08    | `r12`        | During functions calls, we use these        |
 /// | -0x10    | `r13`        | as temporary storage so must preserve their |
-/// |          |              | previous values on the stack                |
-/// |----------|--------------|---------------------------------------------|
-/// | -0x18    | Z            | Inputs                                      |
-/// | -0x1c    | Y            |                                             |
-/// | -0x20    | X            |                                             |
+/// | -0x18    | `r14`        | previous values on the stack                |
 /// |----------|--------------|---------------------------------------------|
 /// | ...      | ...          | Register spills live up here                |
 /// |----------|--------------|---------------------------------------------|
@@ -53,7 +47,7 @@ use dynasmrt::{dynasm, DynasmApi, DynasmLabelApi};
 /// | 0x04     | xmm5         |                                             |
 /// | 0x00     | xmm4         |                                             |
 /// ```
-const STACK_SIZE_UPPER: usize = 0x20; // Positions relative to `rbp`
+const STACK_SIZE_UPPER: usize = 0x18; // Positions relative to `rbp`
 const STACK_SIZE_LOWER: usize = 0x30; // Positions relative to `rsp`
 
 impl Assembler for PointAssembler {
@@ -97,10 +91,10 @@ impl Assembler for PointAssembler {
         );
     }
     fn build_input(&mut self, out_reg: u8, src_arg: u8) {
-        let pos = STACK_SIZE_UPPER as i32 - 4 * (src_arg as i32);
+        let pos = 4 * (src_arg as i32);
         dynasm!(self.0.ops
             // Pull X/Y/Z from the stack, where they've been placed by init()
-            ; vmovss Rx(reg(out_reg)), [rbp - pos]
+            ; vmovss Rx(reg(out_reg)), [rdi - pos]
         );
     }
     fn build_copy(&mut self, out_reg: u8, lhs_reg: u8) {
@@ -218,28 +212,28 @@ impl Assembler for PointAssembler {
             ; jb >R
 
             // Fallthrough for equal, so just copy to the output register
-            ; or [rdi], CHOICE_BOTH as i8
+            ; or [rsi], CHOICE_BOTH as i8
             ; vmovss Rx(reg(out_reg)), Rx(reg(out_reg)), Rx(reg(lhs_reg))
             ; jmp >O
 
             // Fallthrough for NaN, which are !=; do a float addition to
             // propagate it to the output register.
             ; N:
-            ; or [rdi], CHOICE_BOTH as i8
+            ; or [rsi], CHOICE_BOTH as i8
             // TODO: this can't be the best way to make a NAN
             ; vaddss Rx(reg(out_reg)), Rx(reg(lhs_reg)), Rx(reg(rhs_reg))
             ; jmp >O
 
             ; L:
             ; vmovss Rx(reg(out_reg)), Rx(reg(out_reg)), Rx(reg(lhs_reg))
-            ; or [rdi], CHOICE_LEFT as i8
-            ; or [rsi], 1
+            ; or [rsi], CHOICE_LEFT as i8
+            ; or [rdx], 1
             ; jmp >O
 
             ; R:
             ; vmovss Rx(reg(out_reg)), Rx(reg(out_reg)), Rx(reg(rhs_reg))
-            ; or [rdi], CHOICE_RIGHT as i8
-            ; or [rsi], 1
+            ; or [rsi], CHOICE_RIGHT as i8
+            ; or [rdx], 1
             // fallthrough to out
 
             ; O:
@@ -254,26 +248,26 @@ impl Assembler for PointAssembler {
             ; jb >L
 
             // Fallthrough for equal, so just copy to the output register
-            ; or [rdi], CHOICE_BOTH as i8
+            ; or [rsi], CHOICE_BOTH as i8
             ; vmovss Rx(reg(out_reg)), Rx(reg(out_reg)), Rx(reg(lhs_reg))
             ; jmp >O
 
             ; N:
-            ; or [rdi], CHOICE_BOTH as i8
+            ; or [rsi], CHOICE_BOTH as i8
             // TODO: this can't be the best way to make a NAN
             ; vaddss Rx(reg(out_reg)), Rx(reg(lhs_reg)), Rx(reg(rhs_reg))
             ; jmp >O
 
             ; L:
             ; vmovss Rx(reg(out_reg)), Rx(reg(out_reg)), Rx(reg(lhs_reg))
-            ; or [rdi], CHOICE_LEFT as i8
-            ; or [rsi], 1
+            ; or [rsi], CHOICE_LEFT as i8
+            ; or [rdx], 1
             ; jmp >O
 
             ; R:
             ; vmovss Rx(reg(out_reg)), Rx(reg(out_reg)), Rx(reg(rhs_reg))
-            ; or [rdi], CHOICE_RIGHT as i8
-            ; or [rsi], 1
+            ; or [rsi], CHOICE_RIGHT as i8
+            ; or [rdx], 1
             // fallthrough to out
 
             ; O:
@@ -318,8 +312,8 @@ impl Assembler for PointAssembler {
             ; and al, cl
             ; mov cl, 2
             ; sub cl, al
-            ; or [rdi], cl // write the choice flag, based on condition flags
-            ; or [rsi], 1 // write the simplify bit
+            ; or [rsi], cl // write the choice flag, based on condition flags
+            ; or [rdx], 1 // write the simplify bit
             ; movaps Rx(reg(out_reg)), xmm1
         );
         self.0.ops.commit_local().unwrap()
@@ -339,8 +333,8 @@ impl Assembler for PointAssembler {
             ; E:
             ; and al, cl
             ; inc al
-            ; or [rdi], al // write the choice flag, based on condition flags
-            ; or [rsi], 1 // write the simplify bit
+            ; or [rsi], al // write the choice flag, based on condition flags
+            ; or [rdx], 1 // write the simplify bit
             ; movaps Rx(reg(out_reg)), xmm1
         );
         self.0.ops.commit_local().unwrap()
@@ -420,9 +414,10 @@ impl PointAssembler {
         }
         let addr = f as usize;
         dynasm!(self.0.ops
-            // Back up X/Y/Z pointers to caller-saved registers
+            // Back up pointers to caller-saved registers
             ; mov r12, rdi
             ; mov r13, rsi
+            ; mov r14, rdx
 
             // Back up all register values to the stack
             ; movss [rsp], xmm4
@@ -457,9 +452,10 @@ impl PointAssembler {
             ; movss xmm14, [rsp + 0x28]
             ; movss xmm15, [rsp + 0x2c]
 
-            // Restore X/Y/Z pointers
+            // Restore pointers
             ; mov rdi, r12
             ; mov rsi, r13
+            ; mov rdx, r14
 
             ; movss Rx(reg(out_reg)), xmm0
         );

--- a/fidget/src/jit/x86_64/point.rs
+++ b/fidget/src/jit/x86_64/point.rs
@@ -18,9 +18,6 @@ use dynasmrt::{dynasm, DynasmApi, DynasmLabelApi};
 /// | `choices`  | `rsi`    | `*mut u8` (array)     |
 /// | `simplify` | `rdx`    | `*mut u8` (single)    |
 ///
-/// X, Y, and Z are stored on the stack during code execution, to free up those
-/// registers as scratch values.
-///
 /// The stack is configured as follows
 ///
 /// ```text

--- a/fidget/src/jit/x86_64/point.rs
+++ b/fidget/src/jit/x86_64/point.rs
@@ -383,6 +383,7 @@ impl Assembler for PointAssembler {
             dynasm!(self.0.ops
                 ; mov r12, [rbp - 0x8]
                 ; mov r13, [rbp - 0x10]
+                ; mov r14, [rbp - 0x18]
             );
         }
         dynasm!(self.0.ops
@@ -409,6 +410,7 @@ impl PointAssembler {
             dynasm!(self.0.ops
                 ; mov [rbp - 0x8], r12
                 ; mov [rbp - 0x10], r13
+                ; mov [rbp - 0x18], r14
             );
             self.0.saved_callee_regs = true
         }


### PR DESCRIPTION
JIT functions now take an input array as their first argument, instead of X, Y, Z.

This frees up a few registers and paves the way for _N_-input functions.