### PR TITLE
Remove `write-xor-execute` feature + dead code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   (see [this scale-invariant adversarial model](https://www.mattkeeter.com/blog/2023-04-23-adversarial/)),
   so the extra complexity isn't worth it.
 - Added Windows support (including JIT)
+- Removed `write-xor-execute` feature, which was extra cognitive load that no
+  one had actually asked for; if you care about it, let me know!
 
 # 0.2.4
 The highlight of this release is a refactoring of how shapes are handled in Rhai

--- a/fidget/Cargo.toml
+++ b/fidget/Cargo.toml
@@ -63,11 +63,6 @@ mesh = ["dep:crossbeam-deque"]
 ## evaluator type, e.g. `float_slice_tests!(...)`.
 eval-tests = []
 
-## On Linux, this feature uses `mprotect` to prevent JIT buffers from being both
-## writable and executable at the same time.  This is best practice from a
-## security perspective, but incurs a 25% slowdown.
-write-xor-execute = []
-
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
 

--- a/fidget/src/jit/mod.rs
+++ b/fidget/src/jit/mod.rs
@@ -635,7 +635,7 @@ fn build_asm_fn_with_storage<A: Assembler>(
     mut s: Mmap,
 ) -> Mmap {
     // This guard may be a unit value on some systems
-    #[allow(clippy::let_unit_value)]
+    #[cfg(target_os = "macos")]
     let _guard = Mmap::thread_mode_write();
 
     let size_estimate = t.len() * A::bytes_per_clause();
@@ -643,7 +643,6 @@ fn build_asm_fn_with_storage<A: Assembler>(
         s = Mmap::new(size_estimate).expect("failed to build mmap")
     }
 
-    s.make_write();
     let mut asm = A::init(s, t.slot_count());
 
     for op in t.iter_asm() {


### PR DESCRIPTION
If anyone actually cares, we can always add it later, but for now it's just added cognitive burden.