### PR TITLE
Run cargo build against `wasm32-unknown-unknown` target to catch MIR failures

### DIFF
--- a/.github/workflows/check-wasm.yml
+++ b/.github/workflows/check-wasm.yml
@@ -23,4 +23,6 @@ jobs:
     - name: Install wasm target
       run: rustup target add ${{ matrix.target }}
     - name: Check
-      run: cargo check --target=${{ matrix.target }} -pfidget --no-default-features --features="rhai,render,mesh"
+      # cargo check doesn't find MIR diagnostics, so we use cargo build instead
+      # (https://github.com/rust-lang/rust/issues/49292)
+      run: cargo build --target=${{ matrix.target }} -pfidget --no-default-features --features="rhai,render,mesh"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "fidget"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "arrayvec",
  "bimap",

--- a/fidget/src/mesh/cell.rs
+++ b/fidget/src/mesh/cell.rs
@@ -19,10 +19,12 @@ impl From<Cell> for CellData {
             Cell::Empty => 1,
             Cell::Full => 2,
             Cell::Branch { index, thread } => {
+                #[cfg(not(target_arch = "wasm32"))]
                 debug_assert!(index < (1 << 54));
                 0b10 << 62 | ((thread as u64) << 54) | index as u64
             }
             Cell::Leaf(Leaf { mask, index }) => {
+                #[cfg(not(target_arch = "wasm32"))]
                 debug_assert!(index < (1 << 54));
                 (0b11 << 62) | ((mask as u64) << 54) | index as u64
             }


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/49292