### PR TITLE
Send serialized `VmData` to webworkers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -893,6 +893,7 @@ dependencies = [
  "num-traits",
  "ordered-float",
  "rhai",
+ "serde",
  "static_assertions",
  "thiserror",
  "windows",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2916,6 +2916,7 @@ dependencies = [
  "quote",
  "regex",
  "regex-automata",
+ "serde",
  "syn 1.0.109",
  "syn 2.0.48",
 ]

--- a/fidget/Cargo.toml
+++ b/fidget/Cargo.toml
@@ -20,6 +20,7 @@ ordered-float = "3"
 static_assertions = "1"
 thiserror = "1"
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
+serde = { version = "1.0", features = ["derive"] }
 
 # JIT
 dynasmrt = { version = "2.0", optional = true }

--- a/fidget/src/core/compiler/op.rs
+++ b/fidget/src/core/compiler/op.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 /// Macro to generate a set of opcodes, using the given type for registers
 macro_rules! opcodes {
     (
@@ -139,7 +141,7 @@ opcodes!(
     /// - RHS register (or immediate for `*Imm`)
     ///
     /// Each "register" represents an SSA slot, which is never reused.
-    #[derive(Copy, Clone, Debug)]
+    #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
     pub enum SsaOp<u32> {
         // default variants
     }
@@ -250,7 +252,7 @@ opcodes!(
     ///
     /// We have a maximum of 256 registers, though some tapes (e.g. ones
     /// targeting physical hardware) may choose to use fewer.
-    #[derive(Copy, Clone, Debug, PartialEq)]
+    #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum RegOp<u8> {
         // default variants
         /// Read from a memory slot to a register

--- a/fidget/src/core/compiler/reg_tape.rs
+++ b/fidget/src/core/compiler/reg_tape.rs
@@ -1,9 +1,10 @@
 //! Tape used for evaluation
 use crate::compiler::{RegOp, RegisterAllocator, SsaTape};
+use serde::{Deserialize, Serialize};
 
 /// Low-level tape for use with the Fidget virtual machine (or to be lowered
 /// further into machine instructions).
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Serialize, Deserialize)]
 pub struct RegTape {
     tape: Vec<RegOp>,
 

--- a/fidget/src/core/compiler/ssa_tape.rs
+++ b/fidget/src/core/compiler/ssa_tape.rs
@@ -4,6 +4,7 @@ use crate::{
     context::{BinaryOpcode, Node, Op, UnaryOpcode},
     Context, Error,
 };
+use serde::{Deserialize, Serialize};
 
 use std::collections::{HashMap, HashSet};
 
@@ -16,7 +17,7 @@ use std::collections::{HashMap, HashSet};
 /// - 4-byte RHS register (or immediate `f32`)
 ///
 /// All register addressing is absolute.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct SsaTape {
     /// The tape is stored in reverse order, such that the root of the tree is
     /// the first item in the tape.

--- a/fidget/src/core/vm/data.rs
+++ b/fidget/src/core/vm/data.rs
@@ -57,7 +57,7 @@ use crate::{
 /// Despite this peek at its internals, users are unlikely to touch `VmData`
 /// directly; a [`VmShape`](crate::vm::VmShape) wraps the `VmData` and
 /// implements our common traits.
-#[derive(Default)]
+#[derive(Default, serde::Serialize, serde::Deserialize)]
 pub struct VmData<const N: usize = { u8::MAX as usize }> {
     ssa: SsaTape,
     asm: RegTape,

--- a/fidget/src/core/vm/data.rs
+++ b/fidget/src/core/vm/data.rs
@@ -5,6 +5,7 @@ use crate::{
     vm::Choice,
     Error,
 };
+use serde::{Deserialize, Serialize};
 
 /// A flattened math expression, ready for evaluation or further compilation.
 ///
@@ -57,7 +58,7 @@ use crate::{
 /// Despite this peek at its internals, users are unlikely to touch `VmData`
 /// directly; a [`VmShape`](crate::vm::VmShape) wraps the `VmData` and
 /// implements our common traits.
-#[derive(Default, serde::Serialize, serde::Deserialize)]
+#[derive(Default, Serialize, Deserialize)]
 pub struct VmData<const N: usize = { u8::MAX as usize }> {
     ssa: SsaTape,
     asm: RegTape,

--- a/fidget/src/core/vm/mod.rs
+++ b/fidget/src/core/vm/mod.rs
@@ -94,6 +94,12 @@ impl AsRef<[Choice]> for VmTrace {
 #[derive(Clone)]
 pub struct GenericVmShape<const N: usize>(Arc<VmData<N>>);
 
+impl<const N: usize> From<VmData<N>> for GenericVmShape<N> {
+    fn from(d: VmData<N>) -> Self {
+        Self(d.into())
+    }
+}
+
 impl<const N: usize> GenericVmShape<N> {
     pub(crate) fn simplify_inner(
         &self,

--- a/wasm-demo/Cargo.lock
+++ b/wasm-demo/Cargo.lock
@@ -101,6 +101,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +268,7 @@ dependencies = [
  "num-traits",
  "ordered-float",
  "rhai",
+ "serde",
  "static_assertions",
  "thiserror",
  "windows",
@@ -269,6 +279,7 @@ dependencies = [
 name = "fidget-wasm-demo"
 version = "0.1.0"
 dependencies = [
+ "bincode",
  "fidget",
  "nalgebra",
  "rhai",
@@ -541,6 +552,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f398075ce1e6a179b46f51bd88d0598b92b00d3551f1a2d4ac49e771b56ac354"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.198"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.198"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.59",
 ]
 
 [[package]]

--- a/wasm-demo/Cargo.lock
+++ b/wasm-demo/Cargo.lock
@@ -897,6 +897,7 @@ dependencies = [
  "quote",
  "regex",
  "regex-automata",
+ "serde",
  "syn 1.0.109",
  "syn 2.0.59",
 ]

--- a/wasm-demo/Cargo.toml
+++ b/wasm-demo/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
+bincode = "1.3.3"
 fidget = {path = "../fidget", default-features = false, features = ["rhai", "mesh", "render"]}
 wasm-bindgen = "0.2.92"
 nalgebra = "0.31"

--- a/wasm-demo/index.ts
+++ b/wasm-demo/index.ts
@@ -55,17 +55,9 @@ class App {
 
   onScriptChanged(text: string) {
     let shape = null;
-    let result = null;
+    let result = "Ok(..)";
     try {
-      const shapeTree = fidget.eval_script(text);
-      const tape = fidget.serialize_into_tape(shapeTree);
-      result = "Ok(..)";
-
-      this.start_time = performance.now();
-      this.workers_done = 0;
-      this.workers.forEach((w) => {
-        w.postMessage(new ShapeRequest(tape));
-      });
+      shape = fidget.eval_script(text);
     } catch (error) {
       // Do some string formatting to make errors cleaner
       result = error
@@ -75,6 +67,15 @@ class App {
         .replace(" (expecting ", "\n(expecting ");
     }
     this.output.setText(result);
+
+    if (shape) {
+      const tape = fidget.serialize_into_tape(shape);
+      this.start_time = performance.now();
+      this.workers_done = 0;
+      this.workers.forEach((w) => {
+        w.postMessage(new ShapeRequest(tape));
+      });
+    }
   }
 
   onWorkerMessage(i: number, req: WorkerResponse) {

--- a/wasm-demo/index.ts
+++ b/wasm-demo/index.ts
@@ -6,7 +6,7 @@ import { defaultKeymap } from "@codemirror/commands";
 
 import {
   ResponseKind,
-  ScriptRequest,
+  ShapeRequest,
   StartRequest,
   WorkerResponse,
   WorkerRequest,
@@ -58,12 +58,13 @@ class App {
     let result = null;
     try {
       const shapeTree = fidget.eval_script(text);
+      const tape = fidget.serialize_into_tape(shapeTree);
       result = "Ok(..)";
 
       this.start_time = performance.now();
       this.workers_done = 0;
       this.workers.forEach((w) => {
-        w.postMessage(new ScriptRequest(text));
+        w.postMessage(new ShapeRequest(tape));
       });
     } catch (error) {
       // Do some string formatting to make errors cleaner

--- a/wasm-demo/message.ts
+++ b/wasm-demo/message.ts
@@ -1,6 +1,6 @@
 export enum RequestKind {
   Start,
-  Script,
+  Shape,
 }
 
 export class StartRequest {
@@ -13,17 +13,17 @@ export class StartRequest {
   }
 }
 
-export class ScriptRequest {
-  kind: RequestKind.Script;
-  script: string;
+export class ShapeRequest {
+  kind: RequestKind.Shape;
+  tape: Uint8Array;
 
-  constructor(s: string) {
-    this.script = s;
-    this.kind = RequestKind.Script;
+  constructor(tape: Uint8Array) {
+    this.tape = tape;
+    this.kind = RequestKind.Shape;
   }
 }
 
-export type WorkerRequest = ScriptRequest | StartRequest;
+export type WorkerRequest = ShapeRequest | StartRequest;
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/wasm-demo/worker.ts
+++ b/wasm-demo/worker.ts
@@ -20,10 +20,7 @@ class Worker {
   }
 
   render(s: ShapeRequest) {
-    let start = performance.now();
     const shape = fidget.deserialize_tape(s.tape);
-    let end = performance.now();
-    console.log(`deserialized in ${end - start} ms`);
     const out = fidget.render_region(
       shape,
       RENDER_SIZE,

--- a/wasm-demo/worker.ts
+++ b/wasm-demo/worker.ts
@@ -1,7 +1,7 @@
 import {
   ImageResponse,
   RequestKind,
-  ScriptRequest,
+  ShapeRequest,
   StartRequest,
   StartedResponse,
   WorkerRequest,
@@ -19,10 +19,13 @@ class Worker {
     this.index = req.index;
   }
 
-  render(s: ScriptRequest) {
-    const tree = fidget.eval_script(s.script);
+  render(s: ShapeRequest) {
+    let start = performance.now();
+    const shape = fidget.deserialize_tape(s.tape);
+    let end = performance.now();
+    console.log(`deserialized in ${end - start} ms`);
     const out = fidget.render_region(
-      tree,
+      shape,
       RENDER_SIZE,
       this.index,
       WORKERS_PER_SIDE,
@@ -42,8 +45,8 @@ async function run() {
         worker = new Worker(req as StartRequest);
         break;
       }
-      case RequestKind.Script: {
-        worker!.render(req as ScriptRequest);
+      case RequestKind.Shape: {
+        worker!.render(req as ShapeRequest);
         break;
       }
       default:

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -22,6 +22,7 @@ crossbeam-utils = { version = "0.8" }
 once_cell = { version = "1" }
 regex = { version = "1", default-features = false, features = ["perf", "std"] }
 regex-automata = { version = "0.4", default-features = false, features = ["dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal"] }
+serde = { version = "1", features = ["alloc", "derive"] }
 
 [build-dependencies]
 once_cell = { version = "1" }


### PR DESCRIPTION
This avoids duplicate script evaluation and is noticeably faster