### PR TITLE
Avoid walking the same `Tree` twice during import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Fixed stack overflows when handling very deep `Tree` objects
     - Added a non-recursive `Drop` implementation
     - Rewrote `Context::import` to use the heap instead of stack
+- Updated `Context::import` to cache the `TreeOp →  Node` mapping, which is a
+  minor optimization (probably only relevant for unreasonably large `Tree`
+  objects)
 
 # 0.2.5
 The highlight of this release is native Windows support (including JIT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Fixed stack overflows when handling very deep `Tree` objects
     - Added a non-recursive `Drop` implementation
     - Rewrote `Context::import` to use the heap instead of stack
-- Updated `Context::import` to cache the `TreeOp →  Node` mapping, which is a
+- Updated `Context::import` to cache the `TreeOp → Node` mapping, which is a
   minor optimization (probably only relevant for unreasonably large `Tree`
   objects)
 

--- a/fidget/src/core/context/mod.rs
+++ b/fidget/src/core/context/mod.rs
@@ -957,6 +957,9 @@ impl Context {
         let mut stack = vec![];
 
         // Cache of TreeOp -> Node mapping under a particular frame (axes)
+        //
+        // This isn't required for correctness, but can be a speed optimization
+        // (because it means we don't have to walk the same tree twice).
         let mut seen = HashMap::new();
 
         while let Some(t) = todo.pop() {
@@ -1036,6 +1039,10 @@ impl Context {
                         }
                     }
                     // Update the cache with the new tree, if relevant
+                    //
+                    // The `strong_count` check is a rough heuristic to avoid
+                    // caching if there's only a single owner of the tree.  This
+                    // isn't perfect, but it doesn't need to be for correctness.
                     if matches!(
                         t.as_ref(),
                         TreeOp::Unary(..) | TreeOp::Binary(..)

--- a/fidget/src/core/context/tree.rs
+++ b/fidget/src/core/context/tree.rs
@@ -423,7 +423,7 @@ mod test {
         ctx.import(&x);
         let small = start.elapsed();
 
-        // Build a new tree with 4 copies of the original
+        // Build a new tree with 4 remapped versions of the original
         let x = x.remap_xyz(Tree::y(), Tree::z(), Tree::x())
             * x.remap_xyz(Tree::z(), Tree::x(), Tree::y())
             * x.remap_xyz(Tree::y(), Tree::x(), Tree::z())


### PR DESCRIPTION
Using a map to cache `(Axes, *const TreeOp) → Node`