### PR TITLE
Support interpolation for 2D rendering modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 # 0.2.7 (in progress)
+- Changed to 2D rendering API to support render modes which use linear
+  interpolation to process full / empty regions
+    - Specifically, `RenderMode::interval` now returns an `IntervalAction`,
+      which can be `Fill(..)`, `Recurse`, or `Interpolate`.
+    - Modify `SdfRenderMode` use this interpolation; the previous pixel-perfect
+      behavior is renamed to `SdfPixelRenderModel`
+    - Make `RenderMode` trait methods static, because they weren't using `&self`
+    - Change signature of `fidget::render::render2d` to pass the mode only as a
+      generic parameter, instead of an argument
 
 # 0.2.6
 This is a relatively small release; there are a few features to improve the

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -209,11 +209,10 @@ fn run2d<S: fidget::eval::Shape>(
         if sdf {
             let mut image = vec![];
             for _ in 0..settings.n {
-                image = fidget::render::render2d(
-                    shape.clone(),
-                    &cfg,
-                    &fidget::render::SdfRenderMode,
-                );
+                image = fidget::render::render2d::<
+                    _,
+                    fidget::render::SdfRenderMode,
+                >(shape.clone(), &cfg);
             }
             image
                 .into_iter()
@@ -222,11 +221,10 @@ fn run2d<S: fidget::eval::Shape>(
         } else {
             let mut image = vec![];
             for _ in 0..settings.n {
-                image = fidget::render::render2d(
-                    shape.clone(),
-                    &cfg,
-                    &fidget::render::DebugRenderMode,
-                );
+                image = fidget::render::render2d::<
+                    _,
+                    fidget::render::DebugRenderMode,
+                >(shape.clone(), &cfg);
             }
             image
                 .into_iter()

--- a/fidget/benches/render.rs
+++ b/fidget/benches/render.rs
@@ -24,11 +24,10 @@ pub fn prospero_size_sweep(c: &mut Criterion) {
         group.bench_function(BenchmarkId::new("vm", size), move |b| {
             b.iter(|| {
                 let tape = shape_vm.clone();
-                black_box(fidget::render::render2d(
-                    tape,
-                    cfg,
-                    &fidget::render::BitRenderMode,
-                ))
+                black_box(fidget::render::render2d::<
+                    _,
+                    fidget::render::BitRenderMode,
+                >(tape, cfg))
             })
         });
 
@@ -42,11 +41,10 @@ pub fn prospero_size_sweep(c: &mut Criterion) {
             group.bench_function(BenchmarkId::new("jit", size), move |b| {
                 b.iter(|| {
                     let tape = shape_jit.clone();
-                    black_box(fidget::render::render2d(
-                        tape,
-                        cfg,
-                        &fidget::render::BitRenderMode,
-                    ))
+                    black_box(fidget::render::render2d::<
+                        _,
+                        fidget::render::BitRenderMode,
+                    >(tape, cfg))
                 })
             });
         }
@@ -72,11 +70,10 @@ pub fn prospero_thread_sweep(c: &mut Criterion) {
         group.bench_function(BenchmarkId::new("vm", threads), move |b| {
             b.iter(|| {
                 let tape = shape_vm.clone();
-                black_box(fidget::render::render2d(
-                    tape,
-                    cfg,
-                    &fidget::render::BitRenderMode,
-                ))
+                black_box(fidget::render::render2d::<
+                    _,
+                    fidget::render::BitRenderMode,
+                >(tape, cfg))
             })
         });
         #[cfg(feature = "jit")]
@@ -90,11 +87,10 @@ pub fn prospero_thread_sweep(c: &mut Criterion) {
             group.bench_function(BenchmarkId::new("jit", threads), move |b| {
                 b.iter(|| {
                     let tape = shape_jit.clone();
-                    black_box(fidget::render::render2d(
-                        tape,
-                        cfg,
-                        &fidget::render::BitRenderMode,
-                    ))
+                    black_box(fidget::render::render2d::<
+                        _,
+                        fidget::render::BitRenderMode,
+                    >(tape, cfg))
                 })
             });
         }

--- a/fidget/src/lib.rs
+++ b/fidget/src/lib.rs
@@ -210,7 +210,7 @@
 //!     ..RenderConfig::default()
 //! };
 //! let shape = VmShape::from_tree(&tree);
-//! let out = cfg.run(shape, &BitRenderMode)?;
+//! let out = cfg.run::<_, BitRenderMode>(shape)?;
 //! let mut iter = out.iter();
 //! for y in 0..cfg.image_size {
 //!     for x in 0..cfg.image_size {

--- a/fidget/src/render/config.rs
+++ b/fidget/src/render/config.rs
@@ -210,9 +210,8 @@ impl RenderConfig<2> {
     pub fn run<S: Shape, M: RenderMode + Sync>(
         &self,
         shape: S,
-        mode: &M,
     ) -> Result<Vec<<M as RenderMode>::Output>, Error> {
-        Ok(crate::render::render2d::<S, M>(shape, self, mode))
+        Ok(crate::render::render2d::<S, M>(shape, self))
     }
 }
 

--- a/fidget/src/render/render2d.rs
+++ b/fidget/src/render/render2d.rs
@@ -122,17 +122,17 @@ impl RenderMode for BitRenderMode {
     }
 }
 
-/// Rendering mode which mimicks many SDF demos on ShaderToy
-pub struct SdfRenderMode;
+/// Pixel-perfect render mode which mimicks many SDF demos on ShaderToy
+///
+/// This mode recurses down to individual pixels, so it doesn't take advantage
+/// of skipping empty / full regions; use [`SdfRenderMode`] for a
+/// faster-but-approximate visualization.
+pub struct SdfPixelRenderMode;
 
-impl RenderMode for SdfRenderMode {
+impl RenderMode for SdfPixelRenderMode {
     type Output = [u8; 3];
-    fn interval(i: Interval, _depth: usize) -> IntervalAction<[u8; 3]> {
-        if i.upper() < 0.0 || i.lower() > 0.0 {
-            IntervalAction::Interpolate
-        } else {
-            IntervalAction::Recurse
-        }
+    fn interval(_i: Interval, _depth: usize) -> IntervalAction<[u8; 3]> {
+        IntervalAction::Recurse
     }
     fn pixel(f: f32) -> [u8; 3] {
         let r = 1.0 - 0.1f32.copysign(f);
@@ -156,6 +156,26 @@ impl RenderMode for SdfRenderMode {
         };
 
         [run(r), run(g), run(b)]
+    }
+}
+
+/// Fast rendering mode which mimicks many SDF demos on ShaderToy
+///
+/// Unlike [`SdfPixelRenderMode`], this mode uses linear interpolation when
+/// evaluating empty or full regions, which is significantly faster.
+pub struct SdfRenderMode;
+
+impl RenderMode for SdfRenderMode {
+    type Output = [u8; 3];
+    fn interval(i: Interval, _depth: usize) -> IntervalAction<[u8; 3]> {
+        if i.upper() < 0.0 || i.lower() > 0.0 {
+            IntervalAction::Interpolate
+        } else {
+            IntervalAction::Recurse
+        }
+    }
+    fn pixel(f: f32) -> [u8; 3] {
+        SdfPixelRenderMode::pixel(f)
     }
 }
 

--- a/fidget/src/render/render2d.rs
+++ b/fidget/src/render/render2d.rs
@@ -244,16 +244,18 @@ impl<S: Shape, M: RenderMode> Worker<'_, S, M> {
                     .eval_float_slice
                     .eval(shape.f_tape(&mut self.tape_storage), &xs, &ys, &zs)
                     .unwrap();
+                // Bilinear interpolation on a per-pixel basis
                 for y in 0..tile_size {
+                    // Y interpolation
                     let y_frac = (y as f32 - 1.0) / (tile_size as f32);
+                    let v0 = vs[0] * (1.0 - y_frac) + vs[1] * y_frac;
+                    let v1 = vs[2] * (1.0 - y_frac) + vs[3] * y_frac;
+
                     let mut i = self.config.tile_to_offset(tile, 0, y);
                     for x in 0..tile_size {
+                        // X interpolation
                         let x_frac = (x as f32 - 1.0) / (tile_size as f32);
-
-                        // Bilinear interpolation
-                        let v0 = vs[0] * (1.0 - x_frac) + vs[2] * x_frac;
-                        let v1 = vs[1] * (1.0 - x_frac) + vs[3] * x_frac;
-                        let v = v0 * (1.0 - y_frac) + v1 * y_frac;
+                        let v = v0 * (1.0 - x_frac) + v1 * x_frac;
 
                         // Write out the pixel
                         self.image[i] = mode.pixel(v);

--- a/viewer/src/main.rs
+++ b/viewer/src/main.rs
@@ -169,11 +169,10 @@ fn render<S: fidget::eval::Shape>(
 
             match mode {
                 TwoDMode::Color => {
-                    let image = fidget::render::render2d(
-                        shape,
-                        &config,
-                        &fidget::render::BitRenderMode,
-                    );
+                    let image = fidget::render::render2d::<
+                        _,
+                        fidget::render::BitRenderMode,
+                    >(shape, &config);
                     let c = egui::Color32::from_rgba_unmultiplied(
                         color[0],
                         color[1],
@@ -188,22 +187,20 @@ fn render<S: fidget::eval::Shape>(
                 }
 
                 TwoDMode::Sdf => {
-                    let image = fidget::render::render2d(
-                        shape,
-                        &config,
-                        &fidget::render::SdfRenderMode,
-                    );
+                    let image = fidget::render::render2d::<
+                        _,
+                        fidget::render::SdfRenderMode,
+                    >(shape, &config);
                     for (p, i) in pixels.iter_mut().zip(&image) {
                         *p = egui::Color32::from_rgb(i[0], i[1], i[2]);
                     }
                 }
 
                 TwoDMode::Debug => {
-                    let image = fidget::render::render2d(
-                        shape,
-                        &config,
-                        &fidget::render::DebugRenderMode,
-                    );
+                    let image = fidget::render::render2d::<
+                        _,
+                        fidget::render::DebugRenderMode,
+                    >(shape, &config);
                     for (p, i) in pixels.iter_mut().zip(&image) {
                         let c = i.as_debug_color();
                         *p = egui::Color32::from_rgb(c[0], c[1], c[2]);

--- a/wasm-demo/Cargo.lock
+++ b/wasm-demo/Cargo.lock
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "fidget"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "arrayvec",
  "bimap",

--- a/wasm-demo/src/lib.rs
+++ b/wasm-demo/src/lib.rs
@@ -90,7 +90,7 @@ pub fn render_region(
             ..RenderConfig::default()
         };
 
-        let out = cfg.run(shape, &BitRenderMode)?;
+        let out = cfg.run::<_, BitRenderMode>(shape)?;
         Ok(out
             .into_iter()
             .flat_map(|b| {


### PR DESCRIPTION
Changed to 2D rendering API to support render modes which use linear interpolation to process full / empty regions
- Specifically, `RenderMode::interval` now returns an `IntervalAction`, which can be `Fill(..)`, `Recurse`, or `Interpolate`.
- Modify `SdfRenderMode` use this interpolation; the previous pixel-perfect behavior is renamed to `SdfPixelRenderModel`
- Make `RenderMode` trait methods static, because they weren't using `&self`
- Change signature of `fidget::render::render2d` to pass the mode only as a generic parameter, instead of an argument
