### PR TITLE
Change bulk evaluation signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
     - Change signature of `fidget::render::render2d` to pass the mode only as a
       generic parameter, instead of an argument
 - Add new operations: `floor`, `ceil`, `round`, `atan2`
+- Changed `BulkEvaluator::eval` signature to take x, y, z arguments as `&[T]`
+  instead of `&[f32]`.  This is more flexible for gradient evaluation, because
+  it allows the caller to specify up to three gradients, without pinning them to
+  specific argument.
 
 # 0.2.6
 This is a relatively small release; there are a few features to improve the

--- a/fidget/src/core/eval/bulk.rs
+++ b/fidget/src/core/eval/bulk.rs
@@ -40,9 +40,9 @@ pub trait BulkEvaluator: Default {
     fn eval(
         &mut self,
         tape: &Self::Tape,
-        x: &[f32],
-        y: &[f32],
-        z: &[f32],
+        x: &[Self::Data],
+        y: &[Self::Data],
+        z: &[Self::Data],
     ) -> Result<&[Self::Data], Error>;
 
     /// Build a new empty evaluator

--- a/fidget/src/core/eval/transform.rs
+++ b/fidget/src/core/eval/transform.rs
@@ -98,7 +98,12 @@ impl Transformable for Grad {
         z: Grad,
         mat: Matrix4<f32>,
     ) -> (Grad, Grad, Grad) {
-        todo!()
+        let out = [0, 1, 2, 3].map(|i| {
+            let row = mat.row(i);
+            x * row[0] + y * row[1] + z * row[2] + Grad::from(row[3])
+        });
+
+        (out[0] / out[3], out[1] / out[3], out[2] / out[3])
     }
 }
 

--- a/fidget/src/core/eval/transform.rs
+++ b/fidget/src/core/eval/transform.rs
@@ -1,5 +1,5 @@
 use crate::{
-    eval::{BulkEvaluator, Interval, Shape, Tape, TracingEvaluator},
+    eval::{BulkEvaluator, Grad, Interval, Shape, Tape, TracingEvaluator},
     Error,
 };
 use nalgebra::{Matrix4, Point3, Vector3};
@@ -91,6 +91,17 @@ impl Transformable for Interval {
     }
 }
 
+impl Transformable for Grad {
+    fn transform(
+        x: Grad,
+        y: Grad,
+        z: Grad,
+        mat: Matrix4<f32>,
+    ) -> (Grad, Grad, Grad) {
+        todo!()
+    }
+}
+
 impl<T: TracingEvaluator> TracingEvaluator for TransformedTracingEval<T>
 where
     <T as TracingEvaluator>::Data: Transformable,
@@ -115,37 +126,51 @@ where
 }
 
 /// A generic [`BulkEvaluator`] which applies a transform matrix
-#[derive(Default)]
-pub struct TransformedBulkEval<E> {
+pub struct TransformedBulkEval<E: BulkEvaluator> {
     eval: E,
-    xs: Vec<f32>,
-    ys: Vec<f32>,
-    zs: Vec<f32>,
+    xs: Vec<E::Data>,
+    ys: Vec<E::Data>,
+    zs: Vec<E::Data>,
 }
 
-impl<T: BulkEvaluator> BulkEvaluator for TransformedBulkEval<T> {
-    type Data = <T as BulkEvaluator>::Data;
-    type Tape = TransformedTape<<T as BulkEvaluator>::Tape>;
-    type TapeStorage = <T as BulkEvaluator>::TapeStorage;
+impl<E: BulkEvaluator> Default for TransformedBulkEval<E> {
+    fn default() -> Self {
+        Self {
+            eval: E::default(),
+            xs: vec![],
+            ys: vec![],
+            zs: vec![],
+        }
+    }
+}
+
+impl<E: BulkEvaluator> BulkEvaluator for TransformedBulkEval<E>
+where
+    <E as BulkEvaluator>::Data: Transformable,
+{
+    type Data = <E as BulkEvaluator>::Data;
+    type Tape = TransformedTape<<E as BulkEvaluator>::Tape>;
+    type TapeStorage = <E as BulkEvaluator>::TapeStorage;
     fn eval(
         &mut self,
         tape: &Self::Tape,
-        x: &[f32],
-        y: &[f32],
-        z: &[f32],
+        x: &[E::Data],
+        y: &[E::Data],
+        z: &[E::Data],
     ) -> Result<&[Self::Data], Error> {
         if x.len() != y.len() || x.len() != z.len() {
             return Err(Error::MismatchedSlices);
         }
         let n = x.len();
-        self.xs.resize(n, 0.0);
-        self.ys.resize(n, 0.0);
-        self.zs.resize(n, 0.0);
+        self.xs.resize(n, E::Data::from(0.0));
+        self.ys.resize(n, E::Data::from(0.0));
+        self.zs.resize(n, E::Data::from(0.0));
         for i in 0..x.len() {
-            let p = tape.mat.transform_point(&Point3::new(x[i], y[i], z[i]));
-            self.xs[i] = p.x;
-            self.ys[i] = p.y;
-            self.zs[i] = p.z;
+            let (x, y, z) =
+                Transformable::transform(x[i], y[i], z[i], tape.mat);
+            self.xs[i] = x;
+            self.ys[i] = y;
+            self.zs[i] = z;
         }
         self.eval.eval(&tape.tape, &self.xs, &self.ys, &self.zs)
     }

--- a/fidget/src/core/types/grad.rs
+++ b/fidget/src/core/types/grad.rs
@@ -295,6 +295,18 @@ impl std::ops::Mul<Grad> for Grad {
     }
 }
 
+impl std::ops::Mul<f32> for Grad {
+    type Output = Self;
+    fn mul(self, rhs: f32) -> Self {
+        Self {
+            v: self.v * rhs,
+            dx: self.dx * rhs,
+            dy: self.dy * rhs,
+            dz: self.dz * rhs,
+        }
+    }
+}
+
 impl std::ops::Div<Grad> for Grad {
     type Output = Self;
     fn div(self, rhs: Self) -> Self {

--- a/fidget/src/core/vm/mod.rs
+++ b/fidget/src/core/vm/mod.rs
@@ -1142,9 +1142,9 @@ impl<const N: usize> BulkEvaluator for VmGradSliceEval<N> {
     fn eval(
         &mut self,
         tape: &Self::Tape,
-        xs: &[f32],
-        ys: &[f32],
-        zs: &[f32],
+        xs: &[Grad],
+        ys: &[Grad],
+        zs: &[Grad],
     ) -> Result<&[Grad], Error> {
         let tape = tape.0.as_ref();
         self.check_arguments(xs, ys, zs, tape.var_count())?;
@@ -1159,9 +1159,9 @@ impl<const N: usize> BulkEvaluator for VmGradSliceEval<N> {
                 RegOp::Input(out, j) => {
                     for i in 0..size {
                         v[out][i] = match j {
-                            0 => Grad::new(xs[i], 1.0, 0.0, 0.0),
-                            1 => Grad::new(ys[i], 0.0, 1.0, 0.0),
-                            2 => Grad::new(zs[i], 0.0, 0.0, 1.0),
+                            0 => xs[i],
+                            1 => ys[i],
+                            2 => zs[i],
                             _ => panic!("Invalid input: {}", i),
                         }
                     }

--- a/fidget/src/core/vm/mod.rs
+++ b/fidget/src/core/vm/mod.rs
@@ -1265,7 +1265,7 @@ impl<const N: usize> BulkEvaluator for VmGradSliceEval<N> {
                 }
                 RegOp::MulRegImm(out, arg, imm) => {
                     for i in 0..size {
-                        v[out][i] = v[arg][i] * imm.into();
+                        v[out][i] = v[arg][i] * imm;
                     }
                 }
                 RegOp::DivRegImm(out, arg, imm) => {

--- a/fidget/src/jit/aarch64/float_slice.rs
+++ b/fidget/src/jit/aarch64/float_slice.rs
@@ -8,11 +8,11 @@ pub const SIMD_WIDTH: usize = 4;
 
 /// Assembler for SIMD point-wise evaluation on `aarch64`
 ///
-/// | Argument | Register | Type                     |
-/// | ---------|----------|--------------------------|
-/// | `vars`   | `x0`     | `*mut *const [f32; 4]`   |
-/// | out      | `x1`     | `*mut [f32; 4]`          |
-/// | size     | `x2`     | `u64`                    |
+/// | Argument | Register | Type                       |
+/// | ---------|----------|----------------------------|
+/// | `vars`   | `x0`     | `*const *const [f32; 4]`   |
+/// | `out`    | `x1`     | `*mut [f32; 4]`            |
+/// | `count`  | `x2`     | `u64`                      |
 ///
 /// The arrays must be an even multiple of 4 floats, since we're using NEON and
 /// 128-bit wide operations for everything.

--- a/fidget/src/jit/aarch64/grad_slice.rs
+++ b/fidget/src/jit/aarch64/grad_slice.rs
@@ -12,11 +12,11 @@ use dynasmrt::{dynasm, DynasmApi, DynasmLabelApi};
 ///
 /// Registers as pased in as follows:
 ///
-/// | Variable   | Register | Type               |
-/// |------------|----------|--------------------|
-/// | `vars`     | `x0`     | `*const [f32; 4]`  |
-/// | `out`      | `x1`     | `*const [f32; 4]`  |
-/// | `count`    | `x2`     | `u64`              |
+/// | Variable   | Register | Type                    |
+/// |------------|----------|-------------------------|
+/// | `vars`     | `x0`     | `*mut *const [f32; 4]`  |
+/// | `out`      | `x1`     | `*mut [f32; 4]`         |
+/// | `count`    | `x2`     | `u64`                   |
 ///
 /// During evaluation, variables are loaded into SIMD registers in the order
 /// `[value, dx, dy, dz]`, e.g. if we load `vars[0]` into `V0`, its value would

--- a/fidget/src/jit/aarch64/grad_slice.rs
+++ b/fidget/src/jit/aarch64/grad_slice.rs
@@ -12,11 +12,11 @@ use dynasmrt::{dynasm, DynasmApi, DynasmLabelApi};
 ///
 /// Registers as pased in as follows:
 ///
-/// | Variable   | Register | Type                    |
-/// |------------|----------|-------------------------|
-/// | `vars`     | `x0`     | `*mut *const [f32; 4]`  |
-/// | `out`      | `x1`     | `*mut [f32; 4]`         |
-/// | `count`    | `x2`     | `u64`                   |
+/// | Variable   | Register | Type                      |
+/// |------------|----------|---------------------------|
+/// | `vars`     | `x0`     | `*const *const [f32; 4]`  |
+/// | `out`      | `x1`     | `*mut [f32; 4]`           |
+/// | `count`    | `x2`     | `u64`                     |
 ///
 /// During evaluation, variables are loaded into SIMD registers in the order
 /// `[value, dx, dy, dz]`, e.g. if we load `vars[0]` into `V0`, its value would

--- a/fidget/src/jit/mod.rs
+++ b/fidget/src/jit/mod.rs
@@ -1068,9 +1068,9 @@ pub struct JitBulkFn<T> {
     var_count: usize,
     fn_bulk: jit_fn!(
         unsafe fn(
-            *const *const f32, // vars
-            *mut T,            // out
-            u64,               // size
+            *const *const T, // vars
+            *mut T,          // out
+            u64,             // size
         ) -> T
     ),
 }
@@ -1104,9 +1104,9 @@ impl<T: From<f32> + Copy + SimdSize> JitBulkEval<T> {
     fn eval(
         &mut self,
         tape: &JitBulkFn<T>,
-        xs: &[f32],
-        ys: &[f32],
-        zs: &[f32],
+        xs: &[T],
+        ys: &[T],
+        zs: &[T],
     ) -> &[T] {
         assert!(tape.var_count <= 3);
         let n = xs.len();
@@ -1122,9 +1122,9 @@ impl<T: From<f32> + Copy + SimdSize> JitBulkEval<T> {
             // that should be optimized out; we can't use a constant assertion
             // here due to the same compiler limitations.
             const MAX_SIMD_WIDTH: usize = 8;
-            let mut x = [0.0; MAX_SIMD_WIDTH];
-            let mut y = [0.0; MAX_SIMD_WIDTH];
-            let mut z = [0.0; MAX_SIMD_WIDTH];
+            let mut x = [T::from(0.0); MAX_SIMD_WIDTH];
+            let mut y = [T::from(0.0); MAX_SIMD_WIDTH];
+            let mut z = [T::from(0.0); MAX_SIMD_WIDTH];
             assert!(T::SIMD_SIZE <= MAX_SIMD_WIDTH);
 
             x[0..n].copy_from_slice(xs);
@@ -1203,9 +1203,9 @@ impl BulkEvaluator for JitGradSliceEval {
     fn eval(
         &mut self,
         tape: &Self::Tape,
-        xs: &[f32],
-        ys: &[f32],
-        zs: &[f32],
+        xs: &[Self::Data],
+        ys: &[Self::Data],
+        zs: &[Self::Data],
     ) -> Result<&[Self::Data], Error> {
         self.check_arguments(xs, ys, zs, tape.var_count)?;
         Ok(self.0.eval(tape, xs, ys, zs))

--- a/fidget/src/jit/x86_64/grad_slice.rs
+++ b/fidget/src/jit/x86_64/grad_slice.rs
@@ -12,11 +12,11 @@ use dynasmrt::{dynasm, DynasmApi, DynasmLabelApi};
 ///
 /// Registers as pased in as follows:
 ///
-/// | Variable   | Register | Type                   |
-/// |------------|----------|------------------------|
-/// | `vars`     | `rdi`    | `*mut *const [f32; 4]` |
-/// | `out`      | `rsi`    | `*mut [f32; 4]`        |
-/// | `count`    | `rdx`    | `u64`                  |
+/// | Variable   | Register | Type                     |
+/// |------------|----------|--------------------------|
+/// | `vars`     | `rdi`    | `*const *const [f32; 4]` |
+/// | `out`      | `rsi`    | `*mut [f32; 4]`          |
+/// | `count`    | `rdx`    | `u64`                    |
 ///
 /// During evaluation, `rcx` is used to track offset within `vars`.
 ///


### PR DESCRIPTION
Changed `BulkEvaluator::eval` signature to take x, y, z arguments as `&[T]` instead of `&[f32]`.  This is more flexible for gradient evaluation, because it allows the caller to specify up to three gradients, without pinning them to specific argument.

(this is a building block for eventually decoupling evaluation from specifically requiring`(x, y, z)` arguments)