### PR TITLE
Add vars to shape evaluation

### DIFF
--- a/fidget/src/core/compiler/ssa_tape.rs
+++ b/fidget/src/core/compiler/ssa_tape.rs
@@ -33,10 +33,7 @@ impl SsaTape {
     ///
     /// This should always succeed unless the `root` is from a different
     /// `Context`, in which case `Error::BadNode` will be returned.
-    pub fn new(
-        ctx: &Context,
-        root: Node,
-    ) -> Result<(Self, VarMap<usize>), Error> {
+    pub fn new(ctx: &Context, root: Node) -> Result<(Self, VarMap), Error> {
         let mut mapping = HashMap::new();
         let mut parent_count: HashMap<Node, usize> = HashMap::new();
         let mut slot_count = 0;
@@ -63,8 +60,7 @@ impl SsaTape {
                 }
                 _ => {
                     if let Op::Input(v) = op {
-                        let next = vars.len();
-                        vars.entry(*v).or_insert(next);
+                        vars.insert(*v);
                     }
                     let i = slot_count;
                     slot_count += 1;

--- a/fidget/src/core/context/mod.rs
+++ b/fidget/src/core/context/mod.rs
@@ -1051,10 +1051,10 @@ impl Context {
                         TreeOp::Input(s) => {
                             let axes = axes.last().unwrap();
                             stack.push(match *s {
-                                "X" => axes.0,
-                                "Y" => axes.1,
-                                "Z" => axes.2,
-                                s => panic!("invalid tree input string {s:?}"),
+                                Var::X => axes.0,
+                                Var::Y => axes.1,
+                                Var::Z => axes.2,
+                                v @ Var::V(..) => self.var(v),
                             });
                         }
                         TreeOp::Unary(_op, arg) => {

--- a/fidget/src/core/context/tree.rs
+++ b/fidget/src/core/context/tree.rs
@@ -1,5 +1,6 @@
 //! Context-free math trees
 use super::op::{BinaryOpcode, UnaryOpcode};
+use crate::var::Var;
 use std::sync::Arc;
 
 /// Opcode type for trees
@@ -9,8 +10,8 @@ use std::sync::Arc;
 #[derive(Debug)]
 #[allow(missing_docs)]
 pub enum TreeOp {
-    /// Input (at the moment, limited to "X", "Y", "Z")
-    Input(&'static str),
+    /// Input (an arbitrary [`Var`])
+    Input(Var),
     Const(f64),
     Binary(BinaryOpcode, Arc<TreeOp>, Arc<TreeOp>),
     Unary(UnaryOpcode, Arc<TreeOp>),
@@ -94,6 +95,12 @@ impl From<f32> for Tree {
     }
 }
 
+impl From<Var> for Tree {
+    fn from(v: Var) -> Tree {
+        Tree(Arc::new(TreeOp::Input(v)))
+    }
+}
+
 /// Owned handle for a standalone math tree
 #[derive(Clone, Debug)]
 pub struct Tree(Arc<TreeOp>);
@@ -152,13 +159,13 @@ impl Tree {
 #[allow(missing_docs)]
 impl Tree {
     pub fn x() -> Self {
-        Tree(Arc::new(TreeOp::Input("X")))
+        Tree(Arc::new(TreeOp::Input(Var::X)))
     }
     pub fn y() -> Self {
-        Tree(Arc::new(TreeOp::Input("Y")))
+        Tree(Arc::new(TreeOp::Input(Var::Y)))
     }
     pub fn z() -> Self {
-        Tree(Arc::new(TreeOp::Input("Z")))
+        Tree(Arc::new(TreeOp::Input(Var::Z)))
     }
     pub fn constant(f: f64) -> Self {
         Tree(Arc::new(TreeOp::Const(f)))

--- a/fidget/src/core/eval/bulk.rs
+++ b/fidget/src/core/eval/bulk.rs
@@ -32,10 +32,10 @@ pub trait BulkEvaluator: Default {
     ///
     /// Returns an error if the `x`, `y`, `z`, and `out` slices are of different
     /// lengths.
-    fn eval(
+    fn eval<V: std::ops::Deref<Target = [Self::Data]>>(
         &mut self,
         tape: &Self::Tape,
-        vars: &[&[Self::Data]],
+        vars: &[V],
     ) -> Result<&[Self::Data], Error>;
 
     /// Build a new empty evaluator
@@ -44,9 +44,9 @@ pub trait BulkEvaluator: Default {
     }
 
     /// Helper function to return an error if the inputs are invalid
-    fn check_arguments(
+    fn check_arguments<V: std::ops::Deref<Target = [Self::Data]>>(
         &self,
-        vars: &[&[Self::Data]],
+        vars: &[V],
         var_count: usize,
     ) -> Result<(), Error> {
         // It's fine if the caller has given us extra variables (e.g. due to

--- a/fidget/src/core/eval/mod.rs
+++ b/fidget/src/core/eval/mod.rs
@@ -28,6 +28,9 @@ pub trait Tape {
 
     /// Retrieves the internal storage from this tape
     fn recycle(self) -> Self::Storage;
+
+    /// Returns a mapping from [`Var`](crate::var::Var) to evaluation index
+    fn vars(&self) -> &VarMap<usize>;
 }
 
 /// Represents the trace captured by a tracing evaluation

--- a/fidget/src/core/eval/mod.rs
+++ b/fidget/src/core/eval/mod.rs
@@ -30,7 +30,7 @@ pub trait Tape {
     fn recycle(self) -> Self::Storage;
 
     /// Returns a mapping from [`Var`](crate::var::Var) to evaluation index
-    fn vars(&self) -> &VarMap<usize>;
+    fn vars(&self) -> &VarMap;
 }
 
 /// Represents the trace captured by a tracing evaluation
@@ -171,7 +171,7 @@ pub trait Function: Send + Sync + Clone {
     fn size(&self) -> usize;
 
     /// Returns a map from variable to index
-    fn vars(&self) -> &VarMap<usize>;
+    fn vars(&self) -> &VarMap;
 }
 
 /// A [`Function`] which can be built from a math expression

--- a/fidget/src/core/eval/test/float_slice.rs
+++ b/fidget/src/core/eval/test/float_slice.rs
@@ -8,7 +8,10 @@ use crate::{
     context::Context,
     eval::{Function, MathFunction},
     shape::{EzShape, Shape},
+    var::{Var, VarIndex},
+    Error,
 };
+use std::collections::HashMap;
 
 /// Helper struct to put constrains on our `Shape` object
 pub struct TestFloatSlice<F>(std::marker::PhantomData<*const F>);
@@ -132,6 +135,51 @@ impl<F: Function + MathFunction> TestFloatSlice<F> {
             eval.eval(&tape, &args, &[0.0; 4], &[0.0; 4],).unwrap(),
             args.map(f32::sin),
         );
+    }
+
+    pub fn test_f_var() {
+        let v = Var::new();
+        let mut ctx = Context::new();
+
+        let x = ctx.x();
+        let y = ctx.y();
+        let v_ = ctx.var(v);
+
+        let a = ctx.add(x, y).unwrap();
+        let a = ctx.add(a, v_).unwrap();
+
+        let s = Shape::<F>::new(&mut ctx, a).unwrap();
+
+        let mut eval = Shape::<F>::new_float_slice_eval();
+        let tape = s.ez_float_slice_tape();
+        assert!(eval
+            .eval(&tape, &[1.0, 2.0], &[2.0, 3.0], &[0.0, 0.0])
+            .is_err());
+        let mut h: HashMap<VarIndex, &[f32]> = HashMap::new();
+        assert!(eval
+            .eval_v(&tape, &[1.0, 2.0], &[2.0, 3.0], &[0.0, 0.0], &h)
+            .is_err());
+        let index = v.index().unwrap();
+        h.insert(index, &[4.0, 5.0]);
+        assert_eq!(
+            eval.eval_v(&tape, &[1.0, 2.0], &[2.0, 3.0], &[0.0, 0.0], &h)
+                .unwrap(),
+            &[7.0, 10.0]
+        );
+        h.insert(index, &[4.0, 5.0, 6.0]);
+        assert!(matches!(
+            eval.eval_v(&tape, &[1.0, 2.0], &[2.0, 3.0], &[0.0, 0.0], &h),
+            Err(Error::MismatchedSlices)
+        ));
+
+        // Get a new var index that isn't valid for this tape
+        let v2 = Var::new();
+        h.insert(index, &[4.0, 5.0]);
+        h.insert(v2.index().unwrap(), &[4.0, 5.0]);
+        assert!(matches!(
+            eval.eval_v(&tape, &[1.0, 2.0], &[2.0, 3.0], &[0.0, 0.0], &h),
+            Err(Error::BadVarSlice(..))
+        ));
     }
 
     pub fn test_f_stress_n(depth: usize) {
@@ -395,6 +443,7 @@ macro_rules! float_slice_tests {
         $crate::float_slice_test!(test_give_take, $t);
         $crate::float_slice_test!(test_vectorized, $t);
         $crate::float_slice_test!(test_f_sin, $t);
+        $crate::float_slice_test!(test_f_var, $t);
         $crate::float_slice_test!(test_f_stress, $t);
 
         mod f_unary {

--- a/fidget/src/core/shape/mod.rs
+++ b/fidget/src/core/shape/mod.rs
@@ -303,7 +303,7 @@ impl<F: MathFunction> Shape<F> {
     ) -> Result<Self, Error> {
         let f = F::new(ctx, node)?;
         let vars = f.vars();
-        let axes = axes.map(|v| vars.get(&v).cloned());
+        let axes = axes.map(|v| vars.get(&v));
         Ok(Self {
             f,
             axes,
@@ -347,7 +347,7 @@ impl<T: Tape> ShapeTape<T> {
     }
 
     /// Returns a mapping from [`Var`](crate::var::Var) to evaluation index
-    pub fn vars(&self) -> &VarMap<usize> {
+    pub fn vars(&self) -> &VarMap {
         self.tape.vars()
     }
 }
@@ -425,10 +425,10 @@ where
         let vs = tape.vars();
         for (var, value) in vars {
             if let Some(i) = vs.get(&Var::V(*var)) {
-                if *i < self.scratch.len() {
-                    self.scratch[*i] = (*value).into();
+                if i < self.scratch.len() {
+                    self.scratch[i] = (*value).into();
                 } else {
-                    return Err(Error::BadVarIndex(*i, self.scratch.len()));
+                    return Err(Error::BadVarIndex(i, self.scratch.len()));
                 }
             } else {
                 // Passing in Bonus Variables is allowed (for now)
@@ -546,10 +546,10 @@ where
         let vs = tape.vars();
         for (var, value) in vars {
             if let Some(i) = vs.get(&Var::V(*var)) {
-                if *i < self.scratch.len() {
-                    self.scratch[*i].copy_from_slice(value);
+                if i < self.scratch.len() {
+                    self.scratch[i].copy_from_slice(value);
                 } else {
-                    return Err(Error::BadVarIndex(*i, self.scratch.len()));
+                    return Err(Error::BadVarIndex(i, self.scratch.len()));
                 }
             } else {
                 // Passing in Bonus Variables is allowed (for now)

--- a/fidget/src/core/shape/mod.rs
+++ b/fidget/src/core/shape/mod.rs
@@ -30,7 +30,7 @@ use crate::{
     context::{Context, Node, Tree},
     eval::{BulkEvaluator, Function, MathFunction, Tape, TracingEvaluator},
     types::{Grad, Interval},
-    var::Var,
+    var::{Var, VarIndex, VarMap},
     Error,
 };
 use nalgebra::{Matrix4, Point3};
@@ -67,6 +67,7 @@ impl<F: Function + Clone> Shape<F> {
     pub fn new_point_eval() -> ShapeTracingEval<F::PointEval> {
         ShapeTracingEval {
             eval: F::PointEval::default(),
+            scratch: vec![],
         }
     }
 
@@ -74,6 +75,7 @@ impl<F: Function + Clone> Shape<F> {
     pub fn new_interval_eval() -> ShapeTracingEval<F::IntervalEval> {
         ShapeTracingEval {
             eval: F::IntervalEval::default(),
+            scratch: vec![],
         }
     }
 
@@ -81,9 +83,7 @@ impl<F: Function + Clone> Shape<F> {
     pub fn new_float_slice_eval() -> ShapeBulkEval<F::FloatSliceEval> {
         ShapeBulkEval {
             eval: F::FloatSliceEval::default(),
-            xs: vec![],
-            ys: vec![],
-            zs: vec![],
+            scratch: vec![],
         }
     }
 
@@ -91,9 +91,7 @@ impl<F: Function + Clone> Shape<F> {
     pub fn new_grad_slice_eval() -> ShapeBulkEval<F::GradSliceEval> {
         ShapeBulkEval {
             eval: F::GradSliceEval::default(),
-            xs: vec![],
-            ys: vec![],
-            zs: vec![],
+            scratch: vec![],
         }
     }
 
@@ -347,22 +345,43 @@ impl<T: Tape> ShapeTape<T> {
     pub fn recycle(self) -> T::Storage {
         self.tape.recycle()
     }
+
+    /// Returns a mapping from [`Var`](crate::var::Var) to evaluation index
+    pub fn vars(&self) -> &VarMap<usize> {
+        self.tape.vars()
+    }
 }
 
 /// Wrapper around a [`TracingEvaluator`]
 ///
 /// Unlike the raw tracing evaluator, a [`ShapeTracingEval`] knows about the
 /// tape's X, Y, Z axes and optional transform matrix.
-#[derive(Debug, Default)]
-pub struct ShapeTracingEval<E> {
+#[derive(Debug)]
+pub struct ShapeTracingEval<E: TracingEvaluator> {
     eval: E,
+    scratch: Vec<E::Data>,
+}
+
+impl<E: TracingEvaluator> Default for ShapeTracingEval<E> {
+    fn default() -> Self {
+        Self {
+            eval: E::default(),
+            scratch: vec![],
+        }
+    }
 }
 
 impl<E: TracingEvaluator> ShapeTracingEval<E>
 where
     <E as TracingEvaluator>::Data: Transformable,
 {
-    pub fn eval<F: Into<E::Data>>(
+    /// Tracing evaluation of the given tape with X, Y, Z input arguments
+    ///
+    /// Before evaluation, the tape's transform matrix is applied (if present).
+    ///
+    /// If the tape has other variables, [`eval_v`](Self::eval_v) should be
+    /// called instead (and this function will return an error.
+    pub fn eval<F: Into<E::Data> + Copy>(
         &mut self,
         tape: &ShapeTape<E::Tape>,
         x: F,
@@ -376,13 +395,13 @@ where
     /// Tracing evaluation of a single sample
     ///
     /// Before evaluation, the tape's transform matrix is applied (if present).
-    pub fn eval_v<F: Into<E::Data>>(
+    pub fn eval_v<F: Into<E::Data> + Copy>(
         &mut self,
         tape: &ShapeTape<E::Tape>,
         x: F,
         y: F,
         z: F,
-        vars: &HashMap<Var, F>,
+        vars: &HashMap<VarIndex, F>,
     ) -> Result<(E::Data, Option<&E::Trace>), Error> {
         let x = x.into();
         let y = y.into();
@@ -393,19 +412,30 @@ where
             (x, y, z)
         };
 
-        let mut vars = [None, None, None];
+        self.scratch.resize(tape.vars().len(), 0f32.into());
         if let Some(a) = tape.axes[0] {
-            vars[a] = Some(x);
+            self.scratch[a] = x;
         }
         if let Some(b) = tape.axes[1] {
-            vars[b] = Some(y);
+            self.scratch[b] = y;
         }
         if let Some(c) = tape.axes[2] {
-            vars[c] = Some(z);
+            self.scratch[c] = z;
         }
-        let n = vars.iter().position(Option::is_none).unwrap_or(3);
-        let vars = vars.map(|v| v.unwrap_or(0f32.into()));
-        self.eval.eval(&tape.tape, &vars[..n])
+        let vs = tape.vars();
+        for (var, value) in vars {
+            if let Some(i) = vs.get(&Var::V(*var)) {
+                if *i < self.scratch.len() {
+                    self.scratch[*i] = (*value).into();
+                } else {
+                    return Err(Error::BadVarIndex(*i, self.scratch.len()));
+                }
+            } else {
+                // Passing in Bonus Variables is allowed (for now)
+            }
+        }
+
+        self.eval.eval(&tape.tape, &self.scratch)
     }
 
     #[cfg(test)]
@@ -438,9 +468,7 @@ where
 #[derive(Debug, Default)]
 pub struct ShapeBulkEval<E: BulkEvaluator> {
     eval: E,
-    xs: Vec<E::Data>,
-    ys: Vec<E::Data>,
-    zs: Vec<E::Data>,
+    scratch: Vec<Vec<E::Data>>,
 }
 
 impl<E: BulkEvaluator> ShapeBulkEval<E>
@@ -457,59 +485,78 @@ where
         y: &[E::Data],
         z: &[E::Data],
     ) -> Result<&[E::Data], Error> {
-        let h = HashMap::default();
+        let h: HashMap<VarIndex, &[E::Data]> = HashMap::default();
         self.eval_v(tape, x, y, z, &h)
     }
 
     /// Bulk evaluation of many samples
     ///
     /// Before evaluation, the tape's transform matrix is applied (if present).
-    pub fn eval_v(
+    pub fn eval_v<V: std::ops::Deref<Target = [E::Data]>>(
         &mut self,
         tape: &ShapeTape<E::Tape>,
         x: &[E::Data],
         y: &[E::Data],
         z: &[E::Data],
-        vs: &HashMap<Var, &[E::Data]>,
+        vars: &HashMap<VarIndex, V>,
     ) -> Result<&[E::Data], Error> {
-        let (xs, ys, zs) = if let Some(mat) = tape.transform {
-            if x.len() != y.len() || x.len() != z.len() {
-                return Err(Error::MismatchedSlices);
+        // Make sure our scratch arrays are big enough for this evaluation
+        if x.len() != y.len() || x.len() != z.len() {
+            return Err(Error::MismatchedSlices);
+        }
+        let n = x.len();
+        if vars.values().any(|vs| vs.len() != n) {
+            return Err(Error::MismatchedSlices);
+        }
+        self.scratch.resize_with(tape.vars().len(), Vec::new);
+        for s in &mut self.scratch {
+            s.resize(n, 0.0.into());
+        }
+
+        if let Some(mat) = tape.transform {
+            self.scratch.resize_with(tape.vars().len(), Vec::new);
+            for s in &mut self.scratch {
+                s.resize(n, 0.0.into());
             }
-            let n = x.len();
-            self.xs.resize(n, 0.0.into());
-            self.ys.resize(n, 0.0.into());
-            self.zs.resize(n, 0.0.into());
             for i in 0..n {
                 let (x, y, z) = Transformable::transform(x[i], y[i], z[i], mat);
-                self.xs[i] = x;
-                self.ys[i] = y;
-                self.zs[i] = z;
+                if let Some(a) = tape.axes[0] {
+                    self.scratch[a][i] = x;
+                }
+                if let Some(b) = tape.axes[1] {
+                    self.scratch[b][i] = y;
+                }
+                if let Some(c) = tape.axes[2] {
+                    self.scratch[c][i] = z;
+                }
             }
-            (self.xs.as_slice(), self.ys.as_slice(), self.zs.as_slice())
         } else {
-            (x, y, z)
-        };
-        let mut vars = [None, None, None];
-        if let Some(a) = tape.axes[0] {
-            vars[a] = Some(xs);
-        }
-        if let Some(b) = tape.axes[1] {
-            vars[b] = Some(ys);
-        }
-        if let Some(c) = tape.axes[2] {
-            vars[c] = Some(zs);
-        }
-        let n = vars.iter().position(|v| v.is_none()).unwrap_or(3);
-        let vars = if vars.iter().all(Option::is_some) {
-            vars.map(Option::unwrap)
-        } else if let Some(q) = vars.iter().find(|v| v.is_some()) {
-            vars.map(|v| v.unwrap_or_else(|| q.unwrap()))
-        } else {
-            [[].as_slice(); 3]
+            if let Some(a) = tape.axes[0] {
+                self.scratch[a].copy_from_slice(x);
+            }
+            if let Some(b) = tape.axes[1] {
+                self.scratch[b].copy_from_slice(y);
+            }
+            if let Some(c) = tape.axes[2] {
+                self.scratch[c].copy_from_slice(z);
+            }
+            // TODO fast path if there are no extra vars, reusing slices
         };
 
-        self.eval.eval(&tape.tape, &vars[..n])
+        let vs = tape.vars();
+        for (var, value) in vars {
+            if let Some(i) = vs.get(&Var::V(*var)) {
+                if *i < self.scratch.len() {
+                    self.scratch[*i].copy_from_slice(value);
+                } else {
+                    return Err(Error::BadVarIndex(*i, self.scratch.len()));
+                }
+            } else {
+                // Passing in Bonus Variables is allowed (for now)
+            }
+        }
+
+        self.eval.eval(&tape.tape, &self.scratch)
     }
 }
 

--- a/fidget/src/core/var/mod.rs
+++ b/fidget/src/core/var/mod.rs
@@ -52,6 +52,15 @@ impl Var {
         let v: u64 = rand::random();
         Var::V(VarIndex(v))
     }
+
+    /// Returns the [`VarIndex`] from a [`Var::V`] instance, or `None`
+    pub fn index(&self) -> Option<VarIndex> {
+        if let Var::V(i) = *self {
+            Some(i)
+        } else {
+            None
+        }
+    }
 }
 
 impl std::fmt::Display for Var {

--- a/fidget/src/core/var/mod.rs
+++ b/fidget/src/core/var/mod.rs
@@ -22,8 +22,24 @@ pub enum Var {
     X,
     Y,
     Z,
-    V(u64),
+    V(VarIndex),
 }
+
+/// Type for a variable index (implemented as a `u64`)
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Hash,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Serialize,
+    Deserialize,
+)]
+#[serde(transparent)]
+pub struct VarIndex(u64);
 
 impl Var {
     /// Returns a new variable, with a random 64-bit index
@@ -34,7 +50,7 @@ impl Var {
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         let v: u64 = rand::random();
-        Var::V(v)
+        Var::V(VarIndex(v))
     }
 }
 
@@ -44,8 +60,8 @@ impl std::fmt::Display for Var {
             Var::X => write!(f, "X"),
             Var::Y => write!(f, "Y"),
             Var::Z => write!(f, "Z"),
-            Var::V(v) if *v < 256 => write!(f, "v_{v}"),
-            Var::V(v) => write!(f, "V({v:x})"),
+            Var::V(VarIndex(v)) if *v < 256 => write!(f, "v_{v}"),
+            Var::V(VarIndex(v)) => write!(f, "V({v:x})"),
         }
     }
 }
@@ -63,7 +79,7 @@ pub struct VarMap<T> {
     x: Option<T>,
     y: Option<T>,
     z: Option<T>,
-    v: HashMap<u64, T>,
+    v: HashMap<VarIndex, T>,
 }
 
 impl<T> Default for VarMap<T> {
@@ -129,7 +145,7 @@ impl<T> VarMap<T> {
 #[allow(missing_docs)]
 pub enum VarMapEntry<'a, T> {
     Option(&'a mut Option<T>),
-    Hash(std::collections::hash_map::Entry<'a, u64, T>),
+    Hash(std::collections::hash_map::Entry<'a, VarIndex, T>),
 }
 
 #[allow(missing_docs)]

--- a/fidget/src/core/vm/data.rs
+++ b/fidget/src/core/vm/data.rs
@@ -71,7 +71,7 @@ pub struct VmData<const N: usize = { u8::MAX as usize }> {
     ///
     /// This member is stored in a shared pointer because it's passed down to
     /// children (constructed with [`VmData::simplify`]).
-    pub vars: Arc<VarMap<usize>>,
+    pub vars: Arc<VarMap>,
 }
 
 impl<const N: usize> VmData<N> {

--- a/fidget/src/core/vm/mod.rs
+++ b/fidget/src/core/vm/mod.rs
@@ -37,6 +37,10 @@ impl<const N: usize> Tape for GenericVmFunction<N> {
     fn recycle(self) -> Self::Storage {
         // nothing to do here
     }
+
+    fn vars(&self) -> &VarMap<usize> {
+        &self.0.vars
+    }
 }
 
 /// A trace captured by a VM evaluation

--- a/fidget/src/core/vm/mod.rs
+++ b/fidget/src/core/vm/mod.rs
@@ -38,7 +38,7 @@ impl<const N: usize> Tape for GenericVmFunction<N> {
         // nothing to do here
     }
 
-    fn vars(&self) -> &VarMap<usize> {
+    fn vars(&self) -> &VarMap {
         &self.0.vars
     }
 }
@@ -182,7 +182,7 @@ impl<const N: usize> Function for GenericVmFunction<N> {
         GenericVmFunction::size(self)
     }
 
-    fn vars(&self) -> &VarMap<usize> {
+    fn vars(&self) -> &VarMap {
         &self.0.vars
     }
 }

--- a/fidget/src/core/vm/mod.rs
+++ b/fidget/src/core/vm/mod.rs
@@ -808,10 +808,10 @@ impl<const N: usize> BulkEvaluator for VmFloatSliceEval<N> {
     type Tape = GenericVmFunction<N>;
     type TapeStorage = ();
 
-    fn eval(
+    fn eval<V: std::ops::Deref<Target = [Self::Data]>>(
         &mut self,
         tape: &Self::Tape,
-        vars: &[&[f32]],
+        vars: &[V],
     ) -> Result<&[f32], Error> {
         let tape = tape.0.as_ref();
         self.check_arguments(vars, tape.var_count())?;
@@ -823,7 +823,7 @@ impl<const N: usize> BulkEvaluator for VmFloatSliceEval<N> {
         for op in tape.iter_asm() {
             match op {
                 RegOp::Input(out, i) => {
-                    v[out][0..size].copy_from_slice(vars[i as usize]);
+                    v[out][0..size].copy_from_slice(&vars[i as usize]);
                 }
                 RegOp::NegReg(out, arg) => {
                     for i in 0..size {
@@ -1117,10 +1117,10 @@ impl<const N: usize> BulkEvaluator for VmGradSliceEval<N> {
     type Tape = GenericVmFunction<N>;
     type TapeStorage = ();
 
-    fn eval(
+    fn eval<V: std::ops::Deref<Target = [Self::Data]>>(
         &mut self,
         tape: &Self::Tape,
-        vars: &[&[Grad]],
+        vars: &[V],
     ) -> Result<&[Grad], Error> {
         let tape = tape.0.as_ref();
         self.check_arguments(vars, tape.var_count())?;
@@ -1131,7 +1131,7 @@ impl<const N: usize> BulkEvaluator for VmGradSliceEval<N> {
         for op in tape.iter_asm() {
             match op {
                 RegOp::Input(out, i) => {
-                    v[out][0..size].copy_from_slice(vars[i as usize]);
+                    v[out][0..size].copy_from_slice(&vars[i as usize]);
                 }
                 RegOp::NegReg(out, arg) => {
                     for i in 0..size {

--- a/fidget/src/error.rs
+++ b/fidget/src/error.rs
@@ -37,13 +37,17 @@ pub enum Error {
     #[error("choice slice length ({0}) does not match choice count ({1})")]
     BadChoiceSlice(usize, usize),
 
-    /// Slice lengths are mismatched
-    #[error("slice lengths are mismatched")]
+    /// Variable slice lengths are mismatched
+    #[error("variable slice lengths are mismatched")]
     MismatchedSlices,
 
-    /// Var slice length does not match var count
-    #[error("var slice length ({0}) does not match var count ({1})")]
+    /// Variable slice length does not match expected count
+    #[error("variable slice length ({0}) does not match expected count ({1})")]
     BadVarSlice(usize, usize),
+
+    /// Variable index exceeds max var index for this tape
+    #[error("variable index ({0}) exceeds max var index for this tape ({1})")]
+    BadVarIndex(usize, usize),
 
     /// This name is reserved for 3D coordinates
     #[error("this name is reserved for 3D coordinates")]

--- a/fidget/src/jit/mod.rs
+++ b/fidget/src/jit/mod.rs
@@ -1121,8 +1121,12 @@ unsafe impl<T> Sync for JitBulkFn<T> {}
 
 impl<T: From<f32> + Copy + SimdSize> JitBulkEval<T> {
     /// Evaluate multiple points
-    fn eval(&mut self, tape: &JitBulkFn<T>, vars: &[&[T]]) -> &[T] {
-        let n = vars.first().map(|v| v.len()).unwrap_or(0);
+    fn eval<V: std::ops::Deref<Target = [T]>>(
+        &mut self,
+        tape: &JitBulkFn<T>,
+        vars: &[V],
+    ) -> &[T] {
+        let n = vars.first().map(|v| v.deref().len()).unwrap_or(0);
         self.out.resize(n, f32::NAN.into());
         self.out.fill(f32::NAN.into());
 
@@ -1192,10 +1196,10 @@ impl BulkEvaluator for JitFloatSliceEval {
     type Tape = JitBulkFn<Self::Data>;
     type TapeStorage = Mmap;
 
-    fn eval(
+    fn eval<V: std::ops::Deref<Target = [Self::Data]>>(
         &mut self,
         tape: &Self::Tape,
-        vars: &[&[Self::Data]],
+        vars: &[V],
     ) -> Result<&[Self::Data], Error> {
         self.check_arguments(vars, tape.vars().len())?;
         Ok(self.0.eval(tape, vars))
@@ -1210,10 +1214,10 @@ impl BulkEvaluator for JitGradSliceEval {
     type Tape = JitBulkFn<Self::Data>;
     type TapeStorage = Mmap;
 
-    fn eval(
+    fn eval<V: std::ops::Deref<Target = [Self::Data]>>(
         &mut self,
         tape: &Self::Tape,
-        vars: &[&[Self::Data]],
+        vars: &[V],
     ) -> Result<&[Self::Data], Error> {
         self.check_arguments(vars, tape.vars().len())?;
         Ok(self.0.eval(tape, vars))

--- a/fidget/src/jit/mod.rs
+++ b/fidget/src/jit/mod.rs
@@ -1136,7 +1136,8 @@ impl<T: From<f32> + Copy + SimdSize> JitBulkEval<T> {
         if n < T::SIMD_SIZE {
             assert!(T::SIMD_SIZE <= MAX_SIMD_WIDTH);
 
-            self.scratch.resize(n, [T::from(0.0); MAX_SIMD_WIDTH]);
+            self.scratch
+                .resize(vars.len(), [T::from(0.0); MAX_SIMD_WIDTH]);
             for (v, t) in vars.iter().zip(self.scratch.iter_mut()) {
                 t[0..n].copy_from_slice(v);
             }

--- a/fidget/src/jit/mod.rs
+++ b/fidget/src/jit/mod.rs
@@ -901,7 +901,7 @@ impl Function for JitFunction {
         self.0.size()
     }
 
-    fn vars(&self) -> &VarMap<usize> {
+    fn vars(&self) -> &VarMap {
         Function::vars(&self.0)
     }
 }
@@ -962,7 +962,7 @@ pub struct JitTracingFn<T> {
     #[allow(unused)]
     mmap: Mmap,
     choice_count: usize,
-    vars: Arc<VarMap<usize>>,
+    vars: Arc<VarMap>,
     fn_trace: jit_fn!(
         unsafe fn(
             *const T, // vars
@@ -978,7 +978,7 @@ impl<T> Tape for JitTracingFn<T> {
         self.mmap
     }
 
-    fn vars(&self) -> &VarMap<usize> {
+    fn vars(&self) -> &VarMap {
         &self.vars
     }
 }
@@ -1058,7 +1058,7 @@ impl TracingEvaluator for JitPointEval {
 pub struct JitBulkFn<T> {
     #[allow(unused)]
     mmap: Mmap,
-    vars: Arc<VarMap<usize>>,
+    vars: Arc<VarMap>,
     fn_bulk: jit_fn!(
         unsafe fn(
             *const *const T, // vars
@@ -1074,7 +1074,7 @@ impl<T> Tape for JitBulkFn<T> {
         self.mmap
     }
 
-    fn vars(&self) -> &VarMap<usize> {
+    fn vars(&self) -> &VarMap {
         &self.vars
     }
 }


### PR DESCRIPTION
This adds an `eval_v` function to the `Shape` API, taking a `HashMap<VarIndex, T>` for (non-X/Y/Z) variable values.