### PR TITLE
Var API cleanup

### DIFF
--- a/fidget/src/core/eval/mod.rs
+++ b/fidget/src/core/eval/mod.rs
@@ -18,15 +18,18 @@ pub use tracing::TracingEvaluator;
 
 /// A tape represents something that can be evaluated by an evaluator
 ///
-/// The only property enforced on the trait is that we must have some way to
-/// recycle its internal storage.  This matters most for JIT evaluators, whose
-/// tapes are regions of executable memory-mapped RAM (which is expensive to map
-/// and unmap).
+/// It includes some kind of storage and the ability to look up variable
+/// mapping.  The variable mapping should be identical to calling
+/// [`Function::vars`] on the `Function` which produced this tape, but it's
+/// convenient to be able to look up vars locally.
 pub trait Tape {
     /// Associated type for this tape's data storage
     type Storage: Default;
 
     /// Retrieves the internal storage from this tape
+    ///
+    /// This matters most for JIT evaluators, whose tapes are regions of
+    /// executable memory-mapped RAM (which is expensive to map and unmap).
     fn recycle(self) -> Self::Storage;
 
     /// Returns a mapping from [`Var`](crate::var::Var) to evaluation index
@@ -169,9 +172,6 @@ pub trait Function: Send + Sync + Clone {
     /// This is underspecified and only used for unit testing; for tape-based
     /// functions, it's typically the length of the tape,
     fn size(&self) -> usize;
-
-    /// Returns a map from variable to index
-    fn vars(&self) -> &VarMap;
 }
 
 /// A [`Function`] which can be built from a math expression

--- a/fidget/src/core/var/mod.rs
+++ b/fidget/src/core/var/mod.rs
@@ -17,7 +17,18 @@ use std::collections::HashMap;
 /// same thing.  To generate a "local" variable, [`Var::new`] picks a random
 /// 64-bit value, which is very unlikely to collide with anything else.
 #[allow(missing_docs)]
-#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Hash,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Serialize,
+    Deserialize,
+)]
 pub enum Var {
     X,
     Y,

--- a/fidget/src/core/vm/mod.rs
+++ b/fidget/src/core/vm/mod.rs
@@ -181,10 +181,6 @@ impl<const N: usize> Function for GenericVmFunction<N> {
     fn size(&self) -> usize {
         GenericVmFunction::size(self)
     }
-
-    fn vars(&self) -> &VarMap {
-        &self.0.vars
-    }
 }
 
 impl<const N: usize> RenderHints for GenericVmFunction<N> {

--- a/fidget/src/jit/mod.rs
+++ b/fidget/src/jit/mod.rs
@@ -900,10 +900,6 @@ impl Function for JitFunction {
     fn size(&self) -> usize {
         self.0.size()
     }
-
-    fn vars(&self) -> &VarMap {
-        Function::vars(&self.0)
-    }
 }
 
 impl RenderHints for JitFunction {

--- a/wasm-demo/Cargo.lock
+++ b/wasm-demo/Cargo.lock
@@ -926,6 +926,7 @@ dependencies = [
  "clap",
  "clap_builder",
  "crossbeam-utils",
+ "getrandom",
  "libc",
  "log",
  "memchr",

--- a/wasm-demo/src/lib.rs
+++ b/wasm-demo/src/lib.rs
@@ -2,6 +2,7 @@ use fidget::{
     context::{Context, Tree},
     render::{BitRenderMode, RenderConfig},
     shape::Bounds,
+    var::Var,
     vm::{VmData, VmShape},
     Error,
 };
@@ -37,7 +38,7 @@ pub fn serialize_into_tape(t: JsTree) -> Result<Vec<u8>, String> {
 /// Deserialize a `bincode`-packed `VmData` into a `VmShape`
 #[wasm_bindgen]
 pub fn deserialize_tape(data: Vec<u8>) -> Result<JsVmShape, String> {
-    let (d, axes): (VmData<255>, [Option<usize>; 3]) =
+    let (d, axes): (VmData<255>, [Var; 3]) =
         bincode::deserialize(&data).map_err(|e| format!("{e}"))?;
     Ok(JsVmShape(VmShape::new_raw(d.into(), axes)))
 }


### PR DESCRIPTION
Remove `vars()` from `Function`; only include it in `Tape`.