### PR TITLE
Fix register corruption in AArch64 Interval JIT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
     - Move `Var` and `VarMap` into `fidget::vars` module, because they're no
       longer specific to a `Context`.
     - `Op::Input` now takes a `u32` argument, instead of a `u8`
+- Fixed a bug in the AArch64 JIT would which could corrupt certain registers
+  during interval evaluation.
 
 # 0.2.7
 This release brings us to opcode parity with `libfive`'s operators, adding

--- a/fidget/src/jit/aarch64/interval.rs
+++ b/fidget/src/jit/aarch64/interval.rs
@@ -796,8 +796,6 @@ impl IntervalAssembler {
             ; stp d26, d27, [sp, 0xa0]
             ; stp d28, d29, [sp, 0xb0]
             ; stp d30, d31, [sp, 0xc0]
-            ; stp d0, d1, [sp, 0xd0]
-            ; str d2, [sp, 0xe0]
 
             // Load the function address, awkwardly, into x0 (it doesn't matter
             // that it's about to be overwritten, because we only call it once)
@@ -865,8 +863,6 @@ impl IntervalAssembler {
             ; stp d26, d27, [sp, 0xa0]
             ; stp d28, d29, [sp, 0xb0]
             ; stp d30, d31, [sp, 0xc0]
-            ; stp d0, d1, [sp, 0xd0]
-            ; str d2, [sp, 0xe0]
 
             // Load the function address, awkwardly, into a caller-saved
             // register (so we only need to do this once)


### PR DESCRIPTION
We no longer need to save `d0,1,2`, and in fact they're overwriting `x20,21`.