### PR TITLE
Speed up function tests

### DIFF
--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -271,12 +271,12 @@ fn main() -> Result<()> {
             let buffer = match settings.eval {
                 #[cfg(feature = "jit")]
                 EvalMode::Jit => {
-                    let shape = fidget::jit::JitShape::new(&mut ctx, root)?;
+                    let shape = fidget::jit::JitShape::new(&ctx, root)?;
                     info!("Built shape in {:?}", start.elapsed());
                     run2d(shape, &settings, brute, sdf)
                 }
                 EvalMode::Vm => {
-                    let shape = fidget::vm::VmShape::new(&mut ctx, root)?;
+                    let shape = fidget::vm::VmShape::new(&ctx, root)?;
                     info!("Built shape in {:?}", start.elapsed());
                     run2d(shape, &settings, brute, sdf)
                 }
@@ -308,12 +308,12 @@ fn main() -> Result<()> {
             let buffer = match settings.eval {
                 #[cfg(feature = "jit")]
                 EvalMode::Jit => {
-                    let shape = fidget::jit::JitShape::new(&mut ctx, root)?;
+                    let shape = fidget::jit::JitShape::new(&ctx, root)?;
                     info!("Built shape in {:?}", start.elapsed());
                     run3d(shape, &settings, isometric, color)
                 }
                 EvalMode::Vm => {
-                    let shape = fidget::vm::VmShape::new(&mut ctx, root)?;
+                    let shape = fidget::vm::VmShape::new(&ctx, root)?;
                     info!("Built shape in {:?}", start.elapsed());
                     run3d(shape, &settings, isometric, color)
                 }
@@ -342,12 +342,12 @@ fn main() -> Result<()> {
             let mesh = match settings.eval {
                 #[cfg(feature = "jit")]
                 EvalMode::Jit => {
-                    let shape = fidget::jit::JitShape::new(&mut ctx, root)?;
+                    let shape = fidget::jit::JitShape::new(&ctx, root)?;
                     info!("Built shape in {:?}", start.elapsed());
                     run_mesh(shape, &settings)
                 }
                 EvalMode::Vm => {
-                    let shape = fidget::vm::VmShape::new(&mut ctx, root)?;
+                    let shape = fidget::vm::VmShape::new(&ctx, root)?;
                     info!("Built shape in {:?}", start.elapsed());
                     run_mesh(shape, &settings)
                 }

--- a/fidget/benches/function_call.rs
+++ b/fidget/benches/function_call.rs
@@ -9,12 +9,12 @@ use fidget::{
 
 pub fn run_bench<F: Function + MathFunction>(
     c: &mut Criterion,
-    mut ctx: Context,
+    ctx: Context,
     node: Node,
     test_name: &'static str,
     name: &'static str,
 ) {
-    let shape_vm = &Shape::<F>::new(&mut ctx, node).unwrap();
+    let shape_vm = &Shape::<F>::new(&ctx, node).unwrap();
 
     let mut eval = Shape::<F>::new_float_slice_eval();
     let tape = shape_vm.ez_float_slice_tape();

--- a/fidget/benches/mesh.rs
+++ b/fidget/benches/mesh.rs
@@ -5,11 +5,10 @@ use criterion::{
 const COLONNADE: &str = include_str!("../../models/colonnade.vm");
 
 pub fn colonnade_octree_thread_sweep(c: &mut Criterion) {
-    let (mut ctx, root) =
-        fidget::Context::from_text(COLONNADE.as_bytes()).unwrap();
-    let shape_vm = &fidget::vm::VmShape::new(&mut ctx, root).unwrap();
+    let (ctx, root) = fidget::Context::from_text(COLONNADE.as_bytes()).unwrap();
+    let shape_vm = &fidget::vm::VmShape::new(&ctx, root).unwrap();
     #[cfg(feature = "jit")]
-    let shape_jit = &fidget::jit::JitShape::new(&mut ctx, root).unwrap();
+    let shape_jit = &fidget::jit::JitShape::new(&ctx, root).unwrap();
 
     let mut group =
         c.benchmark_group("speed vs threads (colonnade, octree) (depth 6)");
@@ -36,9 +35,8 @@ pub fn colonnade_octree_thread_sweep(c: &mut Criterion) {
 }
 
 pub fn colonnade_mesh(c: &mut Criterion) {
-    let (mut ctx, root) =
-        fidget::Context::from_text(COLONNADE.as_bytes()).unwrap();
-    let shape_vm = &fidget::vm::VmShape::new(&mut ctx, root).unwrap();
+    let (ctx, root) = fidget::Context::from_text(COLONNADE.as_bytes()).unwrap();
+    let shape_vm = &fidget::vm::VmShape::new(&ctx, root).unwrap();
     let cfg = fidget::mesh::Settings {
         depth: 8,
         ..Default::default()

--- a/fidget/benches/render.rs
+++ b/fidget/benches/render.rs
@@ -6,12 +6,11 @@ use fidget::shape::RenderHints;
 const PROSPERO: &str = include_str!("../../models/prospero.vm");
 
 pub fn prospero_size_sweep(c: &mut Criterion) {
-    let (mut ctx, root) =
-        fidget::Context::from_text(PROSPERO.as_bytes()).unwrap();
-    let shape_vm = &fidget::vm::VmShape::new(&mut ctx, root).unwrap();
+    let (ctx, root) = fidget::Context::from_text(PROSPERO.as_bytes()).unwrap();
+    let shape_vm = &fidget::vm::VmShape::new(&ctx, root).unwrap();
 
     #[cfg(feature = "jit")]
-    let shape_jit = &fidget::jit::JitShape::new(&mut ctx, root).unwrap();
+    let shape_jit = &fidget::jit::JitShape::new(&ctx, root).unwrap();
 
     let mut group =
         c.benchmark_group("speed vs image size (prospero, 2d) (8 threads)");
@@ -52,12 +51,11 @@ pub fn prospero_size_sweep(c: &mut Criterion) {
 }
 
 pub fn prospero_thread_sweep(c: &mut Criterion) {
-    let (mut ctx, root) =
-        fidget::Context::from_text(PROSPERO.as_bytes()).unwrap();
-    let shape_vm = &fidget::vm::VmShape::new(&mut ctx, root).unwrap();
+    let (ctx, root) = fidget::Context::from_text(PROSPERO.as_bytes()).unwrap();
+    let shape_vm = &fidget::vm::VmShape::new(&ctx, root).unwrap();
 
     #[cfg(feature = "jit")]
-    let shape_jit = &fidget::jit::JitShape::new(&mut ctx, root).unwrap();
+    let shape_jit = &fidget::jit::JitShape::new(&ctx, root).unwrap();
 
     let mut group =
         c.benchmark_group("speed vs threads (prospero, 2d) (1024 x 1024)");

--- a/fidget/src/core/eval/test/grad_slice.rs
+++ b/fidget/src/core/eval/test/grad_slice.rs
@@ -42,7 +42,7 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
     pub fn test_g_x() {
         let mut ctx = Context::new();
         let x = ctx.x();
-        let shape = Shape::<F>::new(&mut ctx, x).unwrap();
+        let shape = Shape::<F>::new(&ctx, x).unwrap();
 
         let tape = shape.ez_grad_slice_tape();
         assert_eq!(
@@ -54,7 +54,7 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
     pub fn test_g_y() {
         let mut ctx = Context::new();
         let y = ctx.y();
-        let shape = Shape::<F>::new(&mut ctx, y).unwrap();
+        let shape = Shape::<F>::new(&ctx, y).unwrap();
 
         let tape = shape.ez_grad_slice_tape();
         assert_eq!(
@@ -66,7 +66,7 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
     pub fn test_g_z() {
         let mut ctx = Context::new();
         let z = ctx.z();
-        let shape = Shape::<F>::new(&mut ctx, z).unwrap();
+        let shape = Shape::<F>::new(&ctx, z).unwrap();
 
         let tape = shape.ez_grad_slice_tape();
         assert_eq!(
@@ -79,7 +79,7 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         let mut ctx = Context::new();
         let x = ctx.x();
         let s = ctx.square(x).unwrap();
-        let shape = Shape::<F>::new(&mut ctx, s).unwrap();
+        let shape = Shape::<F>::new(&ctx, s).unwrap();
 
         let tape = shape.ez_grad_slice_tape();
         assert_eq!(
@@ -104,7 +104,7 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         let mut ctx = Context::new();
         let x = ctx.x();
         let s = ctx.abs(x).unwrap();
-        let shape = Shape::<F>::new(&mut ctx, s).unwrap();
+        let shape = Shape::<F>::new(&ctx, s).unwrap();
 
         let tape = shape.ez_grad_slice_tape();
         assert_eq!(
@@ -121,7 +121,7 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         let mut ctx = Context::new();
         let x = ctx.x();
         let s = ctx.sqrt(x).unwrap();
-        let shape = Shape::<F>::new(&mut ctx, s).unwrap();
+        let shape = Shape::<F>::new(&ctx, s).unwrap();
 
         let tape = shape.ez_grad_slice_tape();
         assert_eq!(
@@ -138,7 +138,7 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         let mut ctx = Context::new();
         let x = ctx.x();
         let s = ctx.sin(x).unwrap();
-        let shape = Shape::<F>::new(&mut ctx, s).unwrap();
+        let shape = Shape::<F>::new(&ctx, s).unwrap();
         let tape = shape.ez_grad_slice_tape();
 
         let v = Self::eval_xyz(&tape, &[1.0, 2.0, 3.0], &[0.0; 3], &[0.0; 3]);
@@ -149,7 +149,7 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         let y = ctx.y();
         let y = ctx.mul(y, 2.0).unwrap();
         let s = ctx.sin(y).unwrap();
-        let shape = Shape::<F>::new(&mut ctx, s).unwrap();
+        let shape = Shape::<F>::new(&ctx, s).unwrap();
         let tape = shape.ez_grad_slice_tape();
         let v = Self::eval_xyz(&tape, &[0.0; 3], &[1.0, 2.0, 3.0], &[0.0; 3]);
         v[0].compare_eq(Grad::new(2f32.sin(), 0.0, 2.0 * 2f32.cos(), 0.0));
@@ -162,7 +162,7 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         let x = ctx.x();
         let y = ctx.y();
         let s = ctx.mul(x, y).unwrap();
-        let shape = Shape::<F>::new(&mut ctx, s).unwrap();
+        let shape = Shape::<F>::new(&ctx, s).unwrap();
 
         let tape = shape.ez_grad_slice_tape();
         assert_eq!(
@@ -187,7 +187,7 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         let mut ctx = Context::new();
         let x = ctx.x();
         let s = ctx.div(x, 2.0).unwrap();
-        let shape = Shape::<F>::new(&mut ctx, s).unwrap();
+        let shape = Shape::<F>::new(&ctx, s).unwrap();
 
         let tape = shape.ez_grad_slice_tape();
         assert_eq!(
@@ -200,7 +200,7 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         let mut ctx = Context::new();
         let x = ctx.x();
         let s = ctx.recip(x).unwrap();
-        let shape = Shape::<F>::new(&mut ctx, s).unwrap();
+        let shape = Shape::<F>::new(&ctx, s).unwrap();
 
         let tape = shape.ez_grad_slice_tape();
         assert_eq!(
@@ -218,7 +218,7 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         let x = ctx.x();
         let y = ctx.y();
         let m = ctx.min(x, y).unwrap();
-        let shape = Shape::<F>::new(&mut ctx, m).unwrap();
+        let shape = Shape::<F>::new(&ctx, m).unwrap();
 
         let tape = shape.ez_grad_slice_tape();
         assert_eq!(
@@ -238,7 +238,7 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         let z = ctx.z();
         let min = ctx.min(x, y).unwrap();
         let max = ctx.max(min, z).unwrap();
-        let shape = Shape::<F>::new(&mut ctx, max).unwrap();
+        let shape = Shape::<F>::new(&ctx, max).unwrap();
 
         let tape = shape.ez_grad_slice_tape();
         assert_eq!(
@@ -260,7 +260,7 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         let x = ctx.x();
         let y = ctx.y();
         let m = ctx.max(x, y).unwrap();
-        let shape = Shape::<F>::new(&mut ctx, m).unwrap();
+        let shape = Shape::<F>::new(&ctx, m).unwrap();
 
         let tape = shape.ez_grad_slice_tape();
         assert_eq!(
@@ -277,7 +277,7 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         let mut ctx = Context::new();
         let x = ctx.x();
         let m = ctx.not(x).unwrap();
-        let shape = Shape::<F>::new(&mut ctx, m).unwrap();
+        let shape = Shape::<F>::new(&ctx, m).unwrap();
 
         let tape = shape.ez_grad_slice_tape();
         assert_eq!(
@@ -296,7 +296,7 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         let sum = ctx.add(x2, y2).unwrap();
         let sqrt = ctx.sqrt(sum).unwrap();
         let sub = ctx.sub(sqrt, 0.5).unwrap();
-        let shape = Shape::<F>::new(&mut ctx, sub).unwrap();
+        let shape = Shape::<F>::new(&ctx, sub).unwrap();
 
         let tape = shape.ez_grad_slice_tape();
         assert_eq!(
@@ -318,7 +318,7 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
     }
 
     pub fn test_g_stress_n(depth: usize) {
-        let (mut ctx, node) = build_stress_fn(depth);
+        let (ctx, node) = build_stress_fn(depth);
 
         // Pick an input slice that's guaranteed to be > 1 SIMD registers
         let args = (0..32).map(|i| i as f32 / 32f32).collect::<Vec<f32>>();
@@ -328,7 +328,7 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         let z: Vec<f32> =
             args[2..].iter().chain(&args[0..2]).cloned().collect();
 
-        let shape = Shape::<F>::new(&mut ctx, node).unwrap();
+        let shape = Shape::<F>::new(&ctx, node).unwrap();
         let tape = shape.ez_grad_slice_tape();
 
         let out = Self::eval_xyz(&tape, &x, &y, &z);
@@ -353,7 +353,7 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         // that S is also a VmShape, but this comparison isn't particularly
         // expensive, so we'll do it regardless.
         use crate::vm::VmShape;
-        let shape = VmShape::new(&mut ctx, node).unwrap();
+        let shape = VmShape::new(&ctx, node).unwrap();
         let tape = shape.ez_grad_slice_tape();
 
         let cmp = TestGradSlice::<VmFunction>::eval_xyz(&tape, &x, &y, &z);
@@ -376,7 +376,7 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         for (i, v) in [ctx.x(), ctx.y(), ctx.z()].into_iter().enumerate() {
             let node = C::build(&mut ctx, v);
 
-            let shape = Shape::<F>::new(&mut ctx, node).unwrap();
+            let shape = Shape::<F>::new(&ctx, node).unwrap();
             let tape = shape.ez_grad_slice_tape();
 
             let out = match i {
@@ -529,7 +529,7 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
                 for (j, &u) in inputs.iter().enumerate() {
                     let node = C::build(&mut ctx, v, u);
 
-                    let shape = Shape::<F>::new(&mut ctx, node).unwrap();
+                    let shape = Shape::<F>::new(&ctx, node).unwrap();
                     let tape = shape.ez_grad_slice_tape();
 
                     let out = match (i, j) {
@@ -576,7 +576,7 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
                     let c = ctx.constant(*rhs as f64);
                     let node = C::build(&mut ctx, v, c);
 
-                    let shape = Shape::<F>::new(&mut ctx, node).unwrap();
+                    let shape = Shape::<F>::new(&ctx, node).unwrap();
                     let tape = shape.ez_grad_slice_tape();
 
                     let out = match i {
@@ -617,7 +617,7 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
                     let c = ctx.constant(*lhs as f64);
                     let node = C::build(&mut ctx, c, v);
 
-                    let shape = Shape::<F>::new(&mut ctx, node).unwrap();
+                    let shape = Shape::<F>::new(&ctx, node).unwrap();
                     let tape = shape.ez_grad_slice_tape();
 
                     let out = match i {

--- a/fidget/src/core/eval/test/grad_slice.rs
+++ b/fidget/src/core/eval/test/grad_slice.rs
@@ -5,9 +5,9 @@
 use super::{build_stress_fn, test_args, CanonicalBinaryOp, CanonicalUnaryOp};
 use crate::{
     context::Context,
-    eval::{BulkEvaluator, Function, MathFunction},
-    shape::{EzShape, Shape, ShapeTape},
+    eval::{BulkEvaluator, Function, MathFunction, Tape},
     types::Grad,
+    var::Var,
     vm::VmFunction,
 };
 
@@ -19,9 +19,7 @@ pub struct TestGradSlice<F>(std::marker::PhantomData<*const F>);
 
 impl<F: Function + MathFunction> TestGradSlice<F> {
     fn eval_xyz(
-        tape: &ShapeTape<
-            <<F as Function>::GradSliceEval as BulkEvaluator>::Tape,
-        >,
+        tape: &<<F as Function>::GradSliceEval as BulkEvaluator>::Tape,
         xs: &[f32],
         ys: &[f32],
         zs: &[f32],
@@ -35,16 +33,32 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         let zs: Vec<_> =
             zs.iter().map(|z| Grad::new(*z, 0.0, 0.0, 1.0)).collect();
 
-        let mut eval = Shape::<F>::new_grad_slice_eval();
-        eval.eval(tape, &xs, &ys, &zs).unwrap().to_owned()
+        let vars = tape.vars();
+        let mut out = [
+            vec![Grad::from(0.0); xs.len()],
+            vec![Grad::from(0.0); ys.len()],
+            vec![Grad::from(0.0); zs.len()],
+        ];
+        if let Some(ix) = vars.get(&Var::X) {
+            out[ix] = xs;
+        }
+        if let Some(iy) = vars.get(&Var::Y) {
+            out[iy] = ys;
+        }
+        if let Some(iz) = vars.get(&Var::Z) {
+            out[iz] = zs;
+        }
+
+        let mut eval = F::new_grad_slice_eval();
+        eval.eval(tape, &out).unwrap().to_owned()
     }
 
     pub fn test_g_x() {
         let mut ctx = Context::new();
         let x = ctx.x();
-        let shape = Shape::<F>::new(&ctx, x).unwrap();
+        let shape = F::new(&ctx, x).unwrap();
 
-        let tape = shape.ez_grad_slice_tape();
+        let tape = shape.grad_slice_tape(Default::default());
         assert_eq!(
             Self::eval_xyz(&tape, &[2.0], &[3.0], &[4.0])[0],
             Grad::new(2.0, 1.0, 0.0, 0.0)
@@ -54,9 +68,9 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
     pub fn test_g_y() {
         let mut ctx = Context::new();
         let y = ctx.y();
-        let shape = Shape::<F>::new(&ctx, y).unwrap();
+        let shape = F::new(&ctx, y).unwrap();
 
-        let tape = shape.ez_grad_slice_tape();
+        let tape = shape.grad_slice_tape(Default::default());
         assert_eq!(
             Self::eval_xyz(&tape, &[2.0], &[3.0], &[4.0])[0],
             Grad::new(3.0, 0.0, 1.0, 0.0)
@@ -66,9 +80,9 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
     pub fn test_g_z() {
         let mut ctx = Context::new();
         let z = ctx.z();
-        let shape = Shape::<F>::new(&ctx, z).unwrap();
+        let shape = F::new(&ctx, z).unwrap();
 
-        let tape = shape.ez_grad_slice_tape();
+        let tape = shape.grad_slice_tape(Default::default());
         assert_eq!(
             Self::eval_xyz(&tape, &[2.0], &[3.0], &[4.0])[0],
             Grad::new(4.0, 0.0, 0.0, 1.0)
@@ -79,9 +93,9 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         let mut ctx = Context::new();
         let x = ctx.x();
         let s = ctx.square(x).unwrap();
-        let shape = Shape::<F>::new(&ctx, s).unwrap();
+        let shape = F::new(&ctx, s).unwrap();
 
-        let tape = shape.ez_grad_slice_tape();
+        let tape = shape.grad_slice_tape(Default::default());
         assert_eq!(
             Self::eval_xyz(&tape, &[0.0], &[0.0], &[0.0])[0],
             Grad::new(0.0, 0.0, 0.0, 0.0)
@@ -104,9 +118,9 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         let mut ctx = Context::new();
         let x = ctx.x();
         let s = ctx.abs(x).unwrap();
-        let shape = Shape::<F>::new(&ctx, s).unwrap();
+        let shape = F::new(&ctx, s).unwrap();
 
-        let tape = shape.ez_grad_slice_tape();
+        let tape = shape.grad_slice_tape(Default::default());
         assert_eq!(
             Self::eval_xyz(&tape, &[2.0], &[0.0], &[0.0])[0],
             Grad::new(2.0, 1.0, 0.0, 0.0)
@@ -121,9 +135,9 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         let mut ctx = Context::new();
         let x = ctx.x();
         let s = ctx.sqrt(x).unwrap();
-        let shape = Shape::<F>::new(&ctx, s).unwrap();
+        let shape = F::new(&ctx, s).unwrap();
 
-        let tape = shape.ez_grad_slice_tape();
+        let tape = shape.grad_slice_tape(Default::default());
         assert_eq!(
             Self::eval_xyz(&tape, &[1.0], &[0.0], &[0.0])[0],
             Grad::new(1.0, 0.5, 0.0, 0.0)
@@ -138,8 +152,8 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         let mut ctx = Context::new();
         let x = ctx.x();
         let s = ctx.sin(x).unwrap();
-        let shape = Shape::<F>::new(&ctx, s).unwrap();
-        let tape = shape.ez_grad_slice_tape();
+        let shape = F::new(&ctx, s).unwrap();
+        let tape = shape.grad_slice_tape(Default::default());
 
         let v = Self::eval_xyz(&tape, &[1.0, 2.0, 3.0], &[0.0; 3], &[0.0; 3]);
         v[0].compare_eq(Grad::new(1f32.sin(), 1f32.cos(), 0.0, 0.0));
@@ -149,8 +163,8 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         let y = ctx.y();
         let y = ctx.mul(y, 2.0).unwrap();
         let s = ctx.sin(y).unwrap();
-        let shape = Shape::<F>::new(&ctx, s).unwrap();
-        let tape = shape.ez_grad_slice_tape();
+        let shape = F::new(&ctx, s).unwrap();
+        let tape = shape.grad_slice_tape(Default::default());
         let v = Self::eval_xyz(&tape, &[0.0; 3], &[1.0, 2.0, 3.0], &[0.0; 3]);
         v[0].compare_eq(Grad::new(2f32.sin(), 0.0, 2.0 * 2f32.cos(), 0.0));
         v[1].compare_eq(Grad::new(4f32.sin(), 0.0, 2.0 * 4f32.cos(), 0.0));
@@ -162,9 +176,9 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         let x = ctx.x();
         let y = ctx.y();
         let s = ctx.mul(x, y).unwrap();
-        let shape = Shape::<F>::new(&ctx, s).unwrap();
+        let shape = F::new(&ctx, s).unwrap();
 
-        let tape = shape.ez_grad_slice_tape();
+        let tape = shape.grad_slice_tape(Default::default());
         assert_eq!(
             Self::eval_xyz(&tape, &[1.0], &[0.0], &[0.0])[0],
             Grad::new(0.0, 0.0, 1.0, 0.0)
@@ -187,9 +201,9 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         let mut ctx = Context::new();
         let x = ctx.x();
         let s = ctx.div(x, 2.0).unwrap();
-        let shape = Shape::<F>::new(&ctx, s).unwrap();
+        let shape = F::new(&ctx, s).unwrap();
 
-        let tape = shape.ez_grad_slice_tape();
+        let tape = shape.grad_slice_tape(Default::default());
         assert_eq!(
             Self::eval_xyz(&tape, &[1.0], &[0.0], &[0.0])[0],
             Grad::new(0.5, 0.5, 0.0, 0.0)
@@ -200,9 +214,9 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         let mut ctx = Context::new();
         let x = ctx.x();
         let s = ctx.recip(x).unwrap();
-        let shape = Shape::<F>::new(&ctx, s).unwrap();
+        let shape = F::new(&ctx, s).unwrap();
 
-        let tape = shape.ez_grad_slice_tape();
+        let tape = shape.grad_slice_tape(Default::default());
         assert_eq!(
             Self::eval_xyz(&tape, &[1.0], &[0.0], &[0.0])[0],
             Grad::new(1.0, -1.0, 0.0, 0.0)
@@ -218,9 +232,9 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         let x = ctx.x();
         let y = ctx.y();
         let m = ctx.min(x, y).unwrap();
-        let shape = Shape::<F>::new(&ctx, m).unwrap();
+        let shape = F::new(&ctx, m).unwrap();
 
-        let tape = shape.ez_grad_slice_tape();
+        let tape = shape.grad_slice_tape(Default::default());
         assert_eq!(
             Self::eval_xyz(&tape, &[2.0], &[3.0], &[0.0])[0],
             Grad::new(2.0, 1.0, 0.0, 0.0)
@@ -238,9 +252,9 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         let z = ctx.z();
         let min = ctx.min(x, y).unwrap();
         let max = ctx.max(min, z).unwrap();
-        let shape = Shape::<F>::new(&ctx, max).unwrap();
+        let shape = F::new(&ctx, max).unwrap();
 
-        let tape = shape.ez_grad_slice_tape();
+        let tape = shape.grad_slice_tape(Default::default());
         assert_eq!(
             Self::eval_xyz(&tape, &[2.0], &[3.0], &[0.0])[0],
             Grad::new(2.0, 1.0, 0.0, 0.0)
@@ -260,9 +274,9 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         let x = ctx.x();
         let y = ctx.y();
         let m = ctx.max(x, y).unwrap();
-        let shape = Shape::<F>::new(&ctx, m).unwrap();
+        let shape = F::new(&ctx, m).unwrap();
 
-        let tape = shape.ez_grad_slice_tape();
+        let tape = shape.grad_slice_tape(Default::default());
         assert_eq!(
             Self::eval_xyz(&tape, &[2.0], &[3.0], &[0.0])[0],
             Grad::new(3.0, 0.0, 1.0, 0.0)
@@ -277,9 +291,9 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         let mut ctx = Context::new();
         let x = ctx.x();
         let m = ctx.not(x).unwrap();
-        let shape = Shape::<F>::new(&ctx, m).unwrap();
+        let shape = F::new(&ctx, m).unwrap();
 
-        let tape = shape.ez_grad_slice_tape();
+        let tape = shape.grad_slice_tape(Default::default());
         assert_eq!(
             Self::eval_xyz(&tape, &[0.0], &[0.0], &[0.0])[0],
             Grad::new(1.0, 0.0, 0.0, 0.0)
@@ -296,9 +310,9 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         let sum = ctx.add(x2, y2).unwrap();
         let sqrt = ctx.sqrt(sum).unwrap();
         let sub = ctx.sub(sqrt, 0.5).unwrap();
-        let shape = Shape::<F>::new(&ctx, sub).unwrap();
+        let shape = F::new(&ctx, sub).unwrap();
 
-        let tape = shape.ez_grad_slice_tape();
+        let tape = shape.grad_slice_tape(Default::default());
         assert_eq!(
             Self::eval_xyz(&tape, &[1.0], &[0.0], &[0.0])[0],
             Grad::new(0.5, 1.0, 0.0, 0.0)
@@ -328,8 +342,8 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         let z: Vec<f32> =
             args[2..].iter().chain(&args[0..2]).cloned().collect();
 
-        let shape = Shape::<F>::new(&ctx, node).unwrap();
-        let tape = shape.ez_grad_slice_tape();
+        let shape = F::new(&ctx, node).unwrap();
+        let tape = shape.grad_slice_tape(Default::default());
 
         let out = Self::eval_xyz(&tape, &x, &y, &z);
 
@@ -352,9 +366,9 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         // Compare against the VmShape evaluator as a baseline.  It's possible
         // that S is also a VmShape, but this comparison isn't particularly
         // expensive, so we'll do it regardless.
-        use crate::vm::VmShape;
-        let shape = VmShape::new(&ctx, node).unwrap();
-        let tape = shape.ez_grad_slice_tape();
+        let shape = VmFunction::new(&ctx, node).unwrap();
+        #[allow(clippy::unit_arg)]
+        let tape = shape.grad_slice_tape(Default::default());
 
         let cmp = TestGradSlice::<VmFunction>::eval_xyz(&tape, &x, &y, &z);
         for (a, b) in out.iter().zip(cmp.iter()) {
@@ -370,23 +384,27 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
 
     pub fn test_unary<C: CanonicalUnaryOp>() {
         let args = test_args();
-        let zero = vec![0.0; args.len()];
 
         let mut ctx = Context::new();
-        for (i, v) in [ctx.x(), ctx.y(), ctx.z()].into_iter().enumerate() {
-            let node = C::build(&mut ctx, v);
+        let v = ctx.var(Var::new());
+        let node = C::build(&mut ctx, v);
+        let shape = F::new(&ctx, node).unwrap();
+        let tape = shape.grad_slice_tape(Default::default());
+        let mut eval = F::new_grad_slice_eval();
 
-            let shape = Shape::<F>::new(&ctx, node).unwrap();
-            let tape = shape.ez_grad_slice_tape();
-
-            let out = match i {
-                0 => Self::eval_xyz(&tape, &args, &zero, &zero),
-                1 => Self::eval_xyz(&tape, &zero, &args, &zero),
-                2 => Self::eval_xyz(&tape, &zero, &zero, &args),
-                _ => unreachable!(),
-            };
+        for i in 0..3 {
+            let args = args
+                .iter()
+                .map(|&v| match i {
+                    0 => Grad::new(v, 1.0, 0.0, 0.0),
+                    1 => Grad::new(v, 0.0, 1.0, 0.0),
+                    2 => Grad::new(v, 0.0, 0.0, 1.0),
+                    _ => unreachable!(),
+                })
+                .collect::<Vec<Grad>>();
+            let out = eval.eval(&tape, &[args.as_slice()]).unwrap();
             for (a, &o) in args.iter().zip(out.iter()) {
-                let v = C::eval_f64(*a as f64);
+                let v = C::eval_f64(a.v as f64);
                 let err = (v as f32 - o.v).abs();
                 let err_frac = err / (v.abs() as f32).max(o.v.abs());
                 assert!(
@@ -398,13 +416,13 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
                     C::NAME,
                 );
 
-                if C::discontinuous_at(*a) {
+                if C::discontinuous_at(a.v) {
                     continue;
                 }
 
                 let grad = o.d(i);
                 if !v.is_nan() && grad < 1e9 && !grad.is_infinite() {
-                    let a = *a as f64;
+                    let a = a.v as f64;
                     let d = C::eval_f64(a + EPSILON);
                     let est_grad = (d - v) / EPSILON;
                     let mut err = (est_grad as f32 - grad).abs();
@@ -529,8 +547,8 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
                 for (j, &u) in inputs.iter().enumerate() {
                     let node = C::build(&mut ctx, v, u);
 
-                    let shape = Shape::<F>::new(&ctx, node).unwrap();
-                    let tape = shape.ez_grad_slice_tape();
+                    let shape = F::new(&ctx, node).unwrap();
+                    let tape = shape.grad_slice_tape(Default::default());
 
                     let out = match (i, j) {
                         (0, 0) => Self::eval_xyz(&tape, &args, &zero, &zero),
@@ -576,8 +594,8 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
                     let c = ctx.constant(*rhs as f64);
                     let node = C::build(&mut ctx, v, c);
 
-                    let shape = Shape::<F>::new(&ctx, node).unwrap();
-                    let tape = shape.ez_grad_slice_tape();
+                    let shape = F::new(&ctx, node).unwrap();
+                    let tape = shape.grad_slice_tape(Default::default());
 
                     let out = match i {
                         0 => Self::eval_xyz(&tape, &args, &zero, &zero),
@@ -617,8 +635,8 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
                     let c = ctx.constant(*lhs as f64);
                     let node = C::build(&mut ctx, c, v);
 
-                    let shape = Shape::<F>::new(&ctx, node).unwrap();
-                    let tape = shape.ez_grad_slice_tape();
+                    let shape = F::new(&ctx, node).unwrap();
+                    let tape = shape.grad_slice_tape(Default::default());
 
                     let out = match i {
                         0 => Self::eval_xyz(&tape, &args, &zero, &zero),

--- a/fidget/src/core/eval/test/interval.rs
+++ b/fidget/src/core/eval/test/interval.rs
@@ -788,7 +788,7 @@ where
     }
 
     pub fn test_i_stress_n(depth: usize) {
-        let (mut ctx, node) = build_stress_fn(depth);
+        let (ctx, node) = build_stress_fn(depth);
 
         // Pick an input slice that's guaranteed to be > 1 SIMD register
         let args = (0..32).map(|i| i as f32 / 32f32).collect::<Vec<f32>>();
@@ -813,7 +813,7 @@ where
         // Compare against the VmShape evaluator as a baseline.  It's possible
         // that S is also a VmShape, but this comparison isn't particularly
         // expensive, so we'll do it regardless.
-        let shape = VmShape::new(&mut ctx, node).unwrap();
+        let shape = VmShape::new(&ctx, node).unwrap();
         let mut eval = VmShape::new_interval_eval();
         let tape = shape.ez_interval_tape();
 

--- a/fidget/src/core/eval/test/interval.rs
+++ b/fidget/src/core/eval/test/interval.rs
@@ -4,15 +4,16 @@
 //! for interval evaluators; otherwise, the module has no public exports.
 
 use super::{
-    build_stress_fn, test_args, test_args_n, CanonicalBinaryOp,
-    CanonicalUnaryOp,
+    bind_xy, bind_xyz, build_stress_fn, test_args, test_args_n,
+    CanonicalBinaryOp, CanonicalUnaryOp,
 };
 use crate::{
     context::Context,
-    eval::{Function, MathFunction},
-    shape::{EzShape, Shape},
+    eval::{Function, MathFunction, Tape, TracingEvaluator},
+    shape::EzShape,
     types::Interval,
-    vm::Choice,
+    var::Var,
+    vm::{Choice, VmShape},
 };
 
 /// Helper struct to put constrains on our `Shape` object
@@ -28,27 +29,27 @@ where
         let x = ctx.x();
         let y = ctx.y();
 
-        let shape = Shape::<F>::new(&mut ctx, x).unwrap();
-        let tape = shape.ez_interval_tape();
-        let mut eval = Shape::<F>::new_interval_eval();
+        let shape = F::new(&ctx, x).unwrap();
+        let tape = shape.interval_tape(Default::default());
+        let mut eval = F::new_interval_eval();
         assert_eq!(
-            eval.eval_xy(&tape, [0.0, 1.0], [2.0, 3.0]),
+            eval.eval(&tape, &[[0.0, 1.0].into()]).unwrap().0,
             [0.0, 1.0].into()
         );
         assert_eq!(
-            eval.eval_xy(&tape, [1.0, 5.0], [2.0, 3.0]),
+            eval.eval(&tape, &[[1.0, 5.0].into()]).unwrap().0,
             [1.0, 5.0].into()
         );
 
-        let shape = Shape::<F>::new(&mut ctx, y).unwrap();
-        let tape = shape.ez_interval_tape();
-        let mut eval = Shape::<F>::new_interval_eval();
+        let shape = F::new(&ctx, y).unwrap();
+        let tape = shape.interval_tape(Default::default());
+        let mut eval = F::new_interval_eval();
         assert_eq!(
-            eval.eval_xy(&tape, [0.0, 1.0], [2.0, 3.0]),
+            eval.eval(&tape, &[[2.0, 3.0].into()]).unwrap().0,
             [2.0, 3.0].into()
         );
         assert_eq!(
-            eval.eval_xy(&tape, [1.0, 5.0], [4.0, 5.0]),
+            eval.eval(&tape, &[[4.0, 5.0].into()]).unwrap().0,
             [4.0, 5.0].into()
         );
     }
@@ -58,31 +59,47 @@ where
         let x = ctx.x();
         let abs_x = ctx.abs(x).unwrap();
 
-        let shape = Shape::<F>::new(&mut ctx, abs_x).unwrap();
-        let tape = shape.ez_interval_tape();
-        let mut eval = Shape::<F>::new_interval_eval();
-        assert_eq!(eval.eval_x(&tape, [0.0, 1.0]), [0.0, 1.0].into());
-        assert_eq!(eval.eval_x(&tape, [1.0, 5.0]), [1.0, 5.0].into());
-        assert_eq!(eval.eval_x(&tape, [-2.0, 5.0]), [0.0, 5.0].into());
-        assert_eq!(eval.eval_x(&tape, [-6.0, 5.0]), [0.0, 6.0].into());
-        assert_eq!(eval.eval_x(&tape, [-6.0, -1.0]), [1.0, 6.0].into());
+        let shape = F::new(&ctx, abs_x).unwrap();
+        let tape = shape.interval_tape(Default::default());
+        let mut eval = F::new_interval_eval();
+        assert_eq!(
+            eval.eval(&tape, &[[0.0, 1.0].into()]).unwrap().0,
+            [0.0, 1.0].into()
+        );
+        assert_eq!(
+            eval.eval(&tape, &[[1.0, 5.0].into()]).unwrap().0,
+            [1.0, 5.0].into()
+        );
+        assert_eq!(
+            eval.eval(&tape, &[[-2.0, 5.0].into()]).unwrap().0,
+            [0.0, 5.0].into()
+        );
+        assert_eq!(
+            eval.eval(&tape, &[[-6.0, 5.0].into()]).unwrap().0,
+            [0.0, 6.0].into()
+        );
+        assert_eq!(
+            eval.eval(&tape, &[[-6.0, -1.0].into()]).unwrap().0,
+            [1.0, 6.0].into()
+        );
 
         let y = ctx.y();
         let abs_y = ctx.abs(y).unwrap();
         let sum = ctx.add(abs_x, abs_y).unwrap();
-        let shape = Shape::<F>::new(&mut ctx, sum).unwrap();
-        let tape = shape.ez_interval_tape();
-        let mut eval = Shape::<F>::new_interval_eval();
+        let shape = F::new(&ctx, sum).unwrap();
+        let tape = shape.interval_tape(Default::default());
+        let vs = bind_xy(&tape);
+        let mut eval = F::new_interval_eval();
         assert_eq!(
-            eval.eval_xy(&tape, [0.0, 1.0], [0.0, 1.0]),
+            eval.eval(&tape, &vs([0.0, 1.0], [0.0, 1.0])).unwrap().0,
             [0.0, 2.0].into()
         );
         assert_eq!(
-            eval.eval_xy(&tape, [1.0, 5.0], [-2.0, 3.0]),
+            eval.eval(&tape, &vs([1.0, 5.0], [-2.0, 3.0])).unwrap().0,
             [1.0, 8.0].into()
         );
         assert_eq!(
-            eval.eval_xy(&tape, [1.0, 5.0], [-4.0, 3.0]),
+            eval.eval(&tape, &vs([1.0, 5.0], [-4.0, 3.0])).unwrap().0,
             [1.0, 9.0].into()
         );
     }
@@ -93,11 +110,14 @@ where
         let v = ctx.add(x, 0.5).unwrap();
         let out = ctx.abs(v).unwrap();
 
-        let shape = Shape::<F>::new(&mut ctx, out).unwrap();
-        let tape = shape.ez_interval_tape();
-        let mut eval = Shape::<F>::new_interval_eval();
+        let shape = F::new(&ctx, out).unwrap();
+        let tape = shape.interval_tape(Default::default());
+        let mut eval = F::new_interval_eval();
 
-        assert_eq!(eval.eval_x(&tape, [-1.0, 1.0]), [0.0, 1.5].into());
+        assert_eq!(
+            eval.eval(&tape, &[[-1.0, 1.0].into()]).unwrap().0,
+            [0.0, 1.5].into()
+        );
     }
 
     pub fn test_i_sqrt() {
@@ -105,25 +125,29 @@ where
         let x = ctx.x();
         let sqrt_x = ctx.sqrt(x).unwrap();
 
-        let shape = Shape::<F>::new(&mut ctx, sqrt_x).unwrap();
-        let tape = shape.ez_interval_tape();
-        let mut eval = Shape::<F>::new_interval_eval();
-        assert_eq!(eval.eval_x(&tape, [0.0, 1.0]), [0.0, 1.0].into());
-        assert_eq!(eval.eval_x(&tape, [0.0, 4.0]), [0.0, 2.0].into());
+        let shape = F::new(&ctx, sqrt_x).unwrap();
+        let tape = shape.interval_tape(Default::default());
+        let mut eval = F::new_interval_eval();
+        assert_eq!(
+            eval.eval(&tape, &[[0.0, 1.0].into()]).unwrap().0,
+            [0.0, 1.0].into()
+        );
+        assert_eq!(
+            eval.eval(&tape, &[[0.0, 4.0].into()]).unwrap().0,
+            [0.0, 2.0].into()
+        );
 
         // Even a partial negative returns a NAN interval
-        let nanan = eval.eval_x(&tape, [-2.0, 4.0]);
+        let nanan = eval.eval(&tape, &[[-2.0, 4.0].into()]).unwrap().0;
         assert!(nanan.lower().is_nan());
         assert!(nanan.upper().is_nan());
 
         // Full negatives are right out
-        let nanan = eval.eval_x(&tape, [-2.0, -1.0]);
+        let nanan = eval.eval(&tape, &[[-2.0, -1.0].into()]).unwrap().0;
         assert!(nanan.lower().is_nan());
         assert!(nanan.upper().is_nan());
 
-        let (v, _) = eval
-            .eval(&tape, [f32::NAN; 2], [0.0, 1.0], [0.0; 2])
-            .unwrap();
+        let (v, _) = eval.eval(&tape, &[[f32::NAN; 2].into()]).unwrap();
         assert!(v.lower().is_nan());
         assert!(v.upper().is_nan());
     }
@@ -133,19 +157,35 @@ where
         let x = ctx.x();
         let sqrt_x = ctx.square(x).unwrap();
 
-        let shape = Shape::<F>::new(&mut ctx, sqrt_x).unwrap();
-        let tape = shape.ez_interval_tape();
-        let mut eval = Shape::<F>::new_interval_eval();
-        assert_eq!(eval.eval_x(&tape, [0.0, 1.0]), [0.0, 1.0].into());
-        assert_eq!(eval.eval_x(&tape, [0.0, 4.0]), [0.0, 16.0].into());
-        assert_eq!(eval.eval_x(&tape, [2.0, 4.0]), [4.0, 16.0].into());
-        assert_eq!(eval.eval_x(&tape, [-2.0, 4.0]), [0.0, 16.0].into());
-        assert_eq!(eval.eval_x(&tape, [-6.0, -2.0]), [4.0, 36.0].into());
-        assert_eq!(eval.eval_x(&tape, [-6.0, 1.0]), [0.0, 36.0].into());
+        let shape = F::new(&ctx, sqrt_x).unwrap();
+        let tape = shape.interval_tape(Default::default());
+        let mut eval = F::new_interval_eval();
+        assert_eq!(
+            eval.eval(&tape, &[[0.0, 1.0].into()]).unwrap().0,
+            [0.0, 1.0].into()
+        );
+        assert_eq!(
+            eval.eval(&tape, &[[0.0, 4.0].into()]).unwrap().0,
+            [0.0, 16.0].into()
+        );
+        assert_eq!(
+            eval.eval(&tape, &[[2.0, 4.0].into()]).unwrap().0,
+            [4.0, 16.0].into()
+        );
+        assert_eq!(
+            eval.eval(&tape, &[[-2.0, 4.0].into()]).unwrap().0,
+            [0.0, 16.0].into()
+        );
+        assert_eq!(
+            eval.eval(&tape, &[[-6.0, -2.0].into()]).unwrap().0,
+            [4.0, 36.0].into()
+        );
+        assert_eq!(
+            eval.eval(&tape, &[[-6.0, 1.0].into()]).unwrap().0,
+            [0.0, 36.0].into()
+        );
 
-        let (v, _) = eval
-            .eval(&tape, [f32::NAN; 2], [0.0, 1.0], [0.0; 2])
-            .unwrap();
+        let (v, _) = eval.eval(&tape, &[[f32::NAN; 2].into()]).unwrap();
         assert!(v.lower().is_nan());
         assert!(v.upper().is_nan());
     }
@@ -154,20 +194,27 @@ where
         let mut ctx = Context::new();
         let x = ctx.x();
         let s = ctx.sin(x).unwrap();
-        let shape = Shape::<F>::new(&mut ctx, s).unwrap();
-        let tape = shape.ez_interval_tape();
+        let shape = F::new(&ctx, s).unwrap();
+        let tape = shape.interval_tape(Default::default());
 
-        let mut eval = Shape::<F>::new_interval_eval();
-        assert_eq!(eval.eval_x(&tape, [0.0, 1.0]), [-1.0, 1.0].into());
+        let mut eval = F::new_interval_eval();
+        assert_eq!(
+            eval.eval(&tape, &[[0.0, 1.0].into()]).unwrap().0,
+            [-1.0, 1.0].into()
+        );
 
         let y = ctx.y();
         let y = ctx.mul(y, 2.0).unwrap();
         let s = ctx.sin(y).unwrap();
         let s = ctx.add(x, s).unwrap();
-        let shape = Shape::<F>::new(&mut ctx, s).unwrap();
-        let tape = shape.ez_interval_tape();
+        let shape = F::new(&ctx, s).unwrap();
+        let tape = shape.interval_tape(Default::default());
+        let vs = bind_xy(&tape);
 
-        assert_eq!(eval.eval_x(&tape, [0.0, 3.0]), [-1.0, 4.0].into());
+        assert_eq!(
+            eval.eval(&tape, &vs([0.0, 3.0], [0.0, 0.0])).unwrap().0,
+            [-1.0, 4.0].into()
+        );
     }
 
     pub fn test_i_neg() {
@@ -175,19 +222,35 @@ where
         let x = ctx.x();
         let neg_x = ctx.neg(x).unwrap();
 
-        let shape = Shape::<F>::new(&mut ctx, neg_x).unwrap();
-        let tape = shape.ez_interval_tape();
-        let mut eval = Shape::<F>::new_interval_eval();
-        assert_eq!(eval.eval_x(&tape, [0.0, 1.0]), [-1.0, 0.0].into());
-        assert_eq!(eval.eval_x(&tape, [0.0, 4.0]), [-4.0, 0.0].into());
-        assert_eq!(eval.eval_x(&tape, [2.0, 4.0]), [-4.0, -2.0].into());
-        assert_eq!(eval.eval_x(&tape, [-2.0, 4.0]), [-4.0, 2.0].into());
-        assert_eq!(eval.eval_x(&tape, [-6.0, -2.0]), [2.0, 6.0].into());
-        assert_eq!(eval.eval_x(&tape, [-6.0, 1.0]), [-1.0, 6.0].into());
+        let shape = F::new(&ctx, neg_x).unwrap();
+        let tape = shape.interval_tape(Default::default());
+        let mut eval = F::new_interval_eval();
+        assert_eq!(
+            eval.eval(&tape, &[[0.0, 1.0].into()]).unwrap().0,
+            [-1.0, 0.0].into()
+        );
+        assert_eq!(
+            eval.eval(&tape, &[[0.0, 4.0].into()]).unwrap().0,
+            [-4.0, 0.0].into()
+        );
+        assert_eq!(
+            eval.eval(&tape, &[[2.0, 4.0].into()]).unwrap().0,
+            [-4.0, -2.0].into()
+        );
+        assert_eq!(
+            eval.eval(&tape, &[[-2.0, 4.0].into()]).unwrap().0,
+            [-4.0, 2.0].into()
+        );
+        assert_eq!(
+            eval.eval(&tape, &[[-6.0, -2.0].into()]).unwrap().0,
+            [2.0, 6.0].into()
+        );
+        assert_eq!(
+            eval.eval(&tape, &[[-6.0, 1.0].into()]).unwrap().0,
+            [-1.0, 6.0].into()
+        );
 
-        let (v, _) = eval
-            .eval(&tape, [f32::NAN; 2], [0.0, 1.0], [0.0; 2])
-            .unwrap();
+        let (v, _) = eval.eval(&tape, &[[f32::NAN; 2].into()]).unwrap();
         assert!(v.lower().is_nan());
         assert!(v.upper().is_nan());
     }
@@ -197,10 +260,13 @@ where
         let x = ctx.x();
         let not_x = ctx.not(x).unwrap();
 
-        let shape = Shape::<F>::new(&mut ctx, not_x).unwrap();
-        let tape = shape.ez_interval_tape();
-        let mut eval = Shape::<F>::new_interval_eval();
-        assert_eq!(eval.eval_x(&tape, [-5.0, 0.0]), [0.0, 1.0].into());
+        let shape = F::new(&ctx, not_x).unwrap();
+        let tape = shape.interval_tape(Default::default());
+        let mut eval = F::new_interval_eval();
+        assert_eq!(
+            eval.eval(&tape, &[[-5.0, 0.0].into()]).unwrap().0,
+            [0.0, 1.0].into()
+        );
     }
 
     pub fn test_i_mul() {
@@ -209,39 +275,36 @@ where
         let y = ctx.y();
         let mul = ctx.mul(x, y).unwrap();
 
-        let shape = Shape::<F>::new(&mut ctx, mul).unwrap();
-        let tape = shape.ez_interval_tape();
-        let mut eval = Shape::<F>::new_interval_eval();
+        let shape = F::new(&ctx, mul).unwrap();
+        let tape = shape.interval_tape(Default::default());
+        let vs = bind_xy(&tape);
+        let mut eval = F::new_interval_eval();
         assert_eq!(
-            eval.eval_xy(&tape, [0.0, 1.0], [0.0, 1.0]),
+            eval.eval(&tape, &vs([0.0, 1.0], [0.0, 1.0])).unwrap().0,
             [0.0, 1.0].into()
         );
         assert_eq!(
-            eval.eval_xy(&tape, [0.0, 1.0], [0.0, 2.0]),
+            eval.eval(&tape, &vs([0.0, 1.0], [0.0, 2.0])).unwrap().0,
             [0.0, 2.0].into()
         );
         assert_eq!(
-            eval.eval_xy(&tape, [-2.0, 1.0], [0.0, 1.0]),
+            eval.eval(&tape, &vs([-2.0, 1.0], [0.0, 1.0])).unwrap().0,
             [-2.0, 1.0].into()
         );
         assert_eq!(
-            eval.eval_xy(&tape, [-2.0, -1.0], [-5.0, -4.0]),
+            eval.eval(&tape, &vs([-2.0, -1.0], [-5.0, -4.0])).unwrap().0,
             [4.0, 10.0].into()
         );
         assert_eq!(
-            eval.eval_xy(&tape, [-3.0, -1.0], [-2.0, 6.0]),
+            eval.eval(&tape, &vs([-3.0, -1.0], [-2.0, 6.0])).unwrap().0,
             [-18.0, 6.0].into()
         );
 
-        let (v, _) = eval
-            .eval(&tape, [f32::NAN; 2], [0.0, 1.0], [0.0; 2])
-            .unwrap();
+        let (v, _) = eval.eval(&tape, &vs([f32::NAN; 2], [0.0, 1.0])).unwrap();
         assert!(v.lower().is_nan());
         assert!(v.upper().is_nan());
 
-        let (v, _) = eval
-            .eval(&tape, [0.0, 1.0], [f32::NAN; 2], [0.0; 2])
-            .unwrap();
+        let (v, _) = eval.eval(&tape, &vs([0.0, 1.0], [f32::NAN; 2])).unwrap();
         assert!(v.lower().is_nan());
         assert!(v.upper().is_nan());
     }
@@ -250,18 +313,30 @@ where
         let mut ctx = Context::new();
         let x = ctx.x();
         let mul = ctx.mul(x, 2.0).unwrap();
-        let shape = Shape::<F>::new(&mut ctx, mul).unwrap();
-        let tape = shape.ez_interval_tape();
-        let mut eval = Shape::<F>::new_interval_eval();
-        assert_eq!(eval.eval_x(&tape, [0.0, 1.0]), [0.0, 2.0].into());
-        assert_eq!(eval.eval_x(&tape, [1.0, 2.0]), [2.0, 4.0].into());
+        let shape = F::new(&ctx, mul).unwrap();
+        let tape = shape.interval_tape(Default::default());
+        let mut eval = F::new_interval_eval();
+        assert_eq!(
+            eval.eval(&tape, &[[0.0, 1.0].into()]).unwrap().0,
+            [0.0, 2.0].into()
+        );
+        assert_eq!(
+            eval.eval(&tape, &[[1.0, 2.0].into()]).unwrap().0,
+            [2.0, 4.0].into()
+        );
 
         let mul = ctx.mul(x, -3.0).unwrap();
-        let shape = Shape::<F>::new(&mut ctx, mul).unwrap();
-        let tape = shape.ez_interval_tape();
-        let mut eval = Shape::<F>::new_interval_eval();
-        assert_eq!(eval.eval_x(&tape, [0.0, 1.0]), [-3.0, 0.0].into());
-        assert_eq!(eval.eval_x(&tape, [1.0, 2.0]), [-6.0, -3.0].into());
+        let shape = F::new(&ctx, mul).unwrap();
+        let tape = shape.interval_tape(Default::default());
+        let mut eval = F::new_interval_eval();
+        assert_eq!(
+            eval.eval(&tape, &[[0.0, 1.0].into()]).unwrap().0,
+            [-3.0, 0.0].into()
+        );
+        assert_eq!(
+            eval.eval(&tape, &[[1.0, 2.0].into()]).unwrap().0,
+            [-6.0, -3.0].into()
+        );
     }
 
     pub fn test_i_sub() {
@@ -270,27 +345,28 @@ where
         let y = ctx.y();
         let sub = ctx.sub(x, y).unwrap();
 
-        let shape = Shape::<F>::new(&mut ctx, sub).unwrap();
-        let tape = shape.ez_interval_tape();
-        let mut eval = Shape::<F>::new_interval_eval();
+        let shape = F::new(&ctx, sub).unwrap();
+        let tape = shape.interval_tape(Default::default());
+        let vs = bind_xy(&tape);
+        let mut eval = F::new_interval_eval();
         assert_eq!(
-            eval.eval_xy(&tape, [0.0, 1.0], [0.0, 1.0]),
+            eval.eval(&tape, &vs([0.0, 1.0], [0.0, 1.0])).unwrap().0,
             [-1.0, 1.0].into()
         );
         assert_eq!(
-            eval.eval_xy(&tape, [0.0, 1.0], [0.0, 2.0]),
+            eval.eval(&tape, &vs([0.0, 1.0], [0.0, 2.0])).unwrap().0,
             [-2.0, 1.0].into()
         );
         assert_eq!(
-            eval.eval_xy(&tape, [-2.0, 1.0], [0.0, 1.0]),
+            eval.eval(&tape, &vs([-2.0, 1.0], [0.0, 1.0])).unwrap().0,
             [-3.0, 1.0].into()
         );
         assert_eq!(
-            eval.eval_xy(&tape, [-2.0, -1.0], [-5.0, -4.0]),
+            eval.eval(&tape, &vs([-2.0, -1.0], [-5.0, -4.0])).unwrap().0,
             [2.0, 4.0].into()
         );
         assert_eq!(
-            eval.eval_xy(&tape, [-3.0, -1.0], [-2.0, 6.0]),
+            eval.eval(&tape, &vs([-3.0, -1.0], [-2.0, 6.0])).unwrap().0,
             [-9.0, 1.0].into()
         );
     }
@@ -299,42 +375,60 @@ where
         let mut ctx = Context::new();
         let x = ctx.x();
         let sub = ctx.sub(x, 2.0).unwrap();
-        let shape = Shape::<F>::new(&mut ctx, sub).unwrap();
-        let tape = shape.ez_interval_tape();
-        let mut eval = Shape::<F>::new_interval_eval();
-        assert_eq!(eval.eval_x(&tape, [0.0, 1.0]), [-2.0, -1.0].into());
-        assert_eq!(eval.eval_x(&tape, [1.0, 2.0]), [-1.0, 0.0].into());
+        let shape = F::new(&ctx, sub).unwrap();
+        let tape = shape.interval_tape(Default::default());
+        let mut eval = F::new_interval_eval();
+        assert_eq!(
+            eval.eval(&tape, &[[0.0, 1.0].into()]).unwrap().0,
+            [-2.0, -1.0].into()
+        );
+        assert_eq!(
+            eval.eval(&tape, &[[1.0, 2.0].into()]).unwrap().0,
+            [-1.0, 0.0].into()
+        );
 
         let sub = ctx.sub(-3.0, x).unwrap();
-        let shape = Shape::<F>::new(&mut ctx, sub).unwrap();
-        let tape = shape.ez_interval_tape();
-        let mut eval = Shape::<F>::new_interval_eval();
-        assert_eq!(eval.eval_x(&tape, [0.0, 1.0]), [-4.0, -3.0].into());
-        assert_eq!(eval.eval_x(&tape, [1.0, 2.0]), [-5.0, -4.0].into());
+        let shape = F::new(&ctx, sub).unwrap();
+        let tape = shape.interval_tape(Default::default());
+        let mut eval = F::new_interval_eval();
+        assert_eq!(
+            eval.eval(&tape, &[[0.0, 1.0].into()]).unwrap().0,
+            [-4.0, -3.0].into()
+        );
+        assert_eq!(
+            eval.eval(&tape, &[[1.0, 2.0].into()]).unwrap().0,
+            [-5.0, -4.0].into()
+        );
     }
 
     pub fn test_i_recip() {
         let mut ctx = Context::new();
         let x = ctx.x();
         let recip = ctx.recip(x).unwrap();
-        let shape = Shape::<F>::new(&mut ctx, recip).unwrap();
-        let tape = shape.ez_interval_tape();
-        let mut eval = Shape::<F>::new_interval_eval();
+        let shape = F::new(&ctx, recip).unwrap();
+        let tape = shape.interval_tape(Default::default());
+        let mut eval = F::new_interval_eval();
 
-        let nanan = eval.eval_x(&tape, [0.0, 1.0]);
+        let nanan = eval.eval(&tape, &[[0.0, 1.0].into()]).unwrap().0;
         assert!(nanan.lower().is_nan());
         assert!(nanan.upper().is_nan());
 
-        let nanan = eval.eval_x(&tape, [-1.0, 0.0]);
+        let nanan = eval.eval(&tape, &[[-1.0, 0.0].into()]).unwrap().0;
         assert!(nanan.lower().is_nan());
         assert!(nanan.upper().is_nan());
 
-        let nanan = eval.eval_x(&tape, [-2.0, 3.0]);
+        let nanan = eval.eval(&tape, &[[-2.0, 3.0].into()]).unwrap().0;
         assert!(nanan.lower().is_nan());
         assert!(nanan.upper().is_nan());
 
-        assert_eq!(eval.eval_x(&tape, [-2.0, -1.0]), [-1.0, -0.5].into());
-        assert_eq!(eval.eval_x(&tape, [1.0, 2.0]), [0.5, 1.0].into());
+        assert_eq!(
+            eval.eval(&tape, &[[-2.0, -1.0].into()]).unwrap().0,
+            [-1.0, -0.5].into()
+        );
+        assert_eq!(
+            eval.eval(&tape, &[[1.0, 2.0].into()]).unwrap().0,
+            [0.5, 1.0].into()
+        );
     }
 
     pub fn test_i_div() {
@@ -342,43 +436,40 @@ where
         let x = ctx.x();
         let y = ctx.y();
         let div = ctx.div(x, y).unwrap();
-        let shape = Shape::<F>::new(&mut ctx, div).unwrap();
-        let tape = shape.ez_interval_tape();
-        let mut eval = Shape::<F>::new_interval_eval();
+        let shape = F::new(&ctx, div).unwrap();
+        let tape = shape.interval_tape(Default::default());
+        let vs = bind_xy(&tape);
+        let mut eval = F::new_interval_eval();
 
-        let nanan = eval.eval_xy(&tape, [0.0, 1.0], [-1.0, 1.0]);
+        let nanan = eval.eval(&tape, &vs([0.0, 1.0], [-1.0, 1.0])).unwrap().0;
         assert!(nanan.lower().is_nan());
         assert!(nanan.upper().is_nan());
 
-        let nanan = eval.eval_xy(&tape, [0.0, 1.0], [-2.0, 0.0]);
+        let nanan = eval.eval(&tape, &vs([0.0, 1.0], [-2.0, 0.0])).unwrap().0;
         assert!(nanan.lower().is_nan());
         assert!(nanan.upper().is_nan());
 
-        let nanan = eval.eval_xy(&tape, [0.0, 1.0], [0.0, 4.0]);
+        let nanan = eval.eval(&tape, &vs([0.0, 1.0], [0.0, 4.0])).unwrap().0;
         assert!(nanan.lower().is_nan());
         assert!(nanan.upper().is_nan());
 
-        let out = eval.eval_xy(&tape, [-1.0, 0.0], [1.0, 2.0]);
+        let out = eval.eval(&tape, &vs([-1.0, 0.0], [1.0, 2.0])).unwrap().0;
         assert_eq!(out, [-1.0, 0.0].into());
 
-        let out = eval.eval_xy(&tape, [-1.0, 4.0], [-1.0, -0.5]);
+        let out = eval.eval(&tape, &vs([-1.0, 4.0], [-1.0, -0.5])).unwrap().0;
         assert_eq!(out, [-8.0, 2.0].into());
 
-        let out = eval.eval_xy(&tape, [1.0, 4.0], [-1.0, -0.5]);
+        let out = eval.eval(&tape, &vs([1.0, 4.0], [-1.0, -0.5])).unwrap().0;
         assert_eq!(out, [-8.0, -1.0].into());
 
-        let out = eval.eval_xy(&tape, [-1.0, 4.0], [0.5, 1.0]);
+        let out = eval.eval(&tape, &vs([-1.0, 4.0], [0.5, 1.0])).unwrap().0;
         assert_eq!(out, [-2.0, 8.0].into());
 
-        let (v, _) = eval
-            .eval(&tape, [f32::NAN; 2], [0.0, 1.0], [0.0; 2])
-            .unwrap();
+        let (v, _) = eval.eval(&tape, &vs([f32::NAN; 2], [0.0, 1.0])).unwrap();
         assert!(v.lower().is_nan());
         assert!(v.upper().is_nan());
 
-        let (v, _) = eval
-            .eval(&tape, [0.0, 1.0], [f32::NAN; 2], [0.0; 2])
-            .unwrap();
+        let (v, _) = eval.eval(&tape, &vs([0.0, 1.0], [f32::NAN; 2])).unwrap();
         assert!(v.lower().is_nan());
         assert!(v.upper().is_nan());
     }
@@ -389,34 +480,30 @@ where
         let y = ctx.y();
         let min = ctx.min(x, y).unwrap();
 
-        let shape = Shape::<F>::new(&mut ctx, min).unwrap();
-        let tape = shape.ez_interval_tape();
-        let mut eval = Shape::<F>::new_interval_eval();
-        let (r, data) =
-            eval.eval(&tape, [0.0, 1.0], [0.5, 1.5], [0.0; 2]).unwrap();
+        let shape = F::new(&ctx, min).unwrap();
+        let tape = shape.interval_tape(Default::default());
+        let vs = bind_xy(&tape);
+        let mut eval = F::new_interval_eval();
+        let (r, data) = eval.eval(&tape, &vs([0.0, 1.0], [0.5, 1.5])).unwrap();
         assert_eq!(r, [0.0, 1.0].into());
         assert!(data.is_none());
 
-        let (r, data) =
-            eval.eval(&tape, [0.0, 1.0], [2.0, 3.0], [0.0; 2]).unwrap();
+        let (r, data) = eval.eval(&tape, &vs([0.0, 1.0], [2.0, 3.0])).unwrap();
         assert_eq!(r, [0.0, 1.0].into());
         assert_eq!(data.unwrap().as_ref(), &[Choice::Left]);
 
-        let (r, data) =
-            eval.eval(&tape, [2.0, 3.0], [0.0, 1.0], [0.0; 2]).unwrap();
+        let (r, data) = eval.eval(&tape, &vs([2.0, 3.0], [0.0, 1.0])).unwrap();
         assert_eq!(r, [0.0, 1.0].into());
         assert_eq!(data.unwrap().as_ref(), &[Choice::Right]);
 
-        let (v, data) = eval
-            .eval(&tape, [f32::NAN; 2], [0.0, 1.0], [0.0; 2])
-            .unwrap();
+        let (v, data) =
+            eval.eval(&tape, &vs([f32::NAN; 2], [0.0, 1.0])).unwrap();
         assert!(v.lower().is_nan());
         assert!(v.upper().is_nan());
         assert!(data.is_none());
 
-        let (v, data) = eval
-            .eval(&tape, [0.0, 1.0], [f32::NAN; 2], [0.0; 2])
-            .unwrap();
+        let (v, data) =
+            eval.eval(&tape, &vs([0.0, 1.0], [f32::NAN; 2])).unwrap();
         assert!(v.lower().is_nan());
         assert!(v.upper().is_nan());
         assert!(data.is_none());
@@ -427,21 +514,18 @@ where
         let x = ctx.x();
         let min = ctx.min(x, 1.0).unwrap();
 
-        let shape = Shape::<F>::new(&mut ctx, min).unwrap();
-        let tape = shape.ez_interval_tape();
-        let mut eval = Shape::<F>::new_interval_eval();
-        let (r, data) =
-            eval.eval(&tape, [0.0, 1.0], [0.0; 2], [0.0; 2]).unwrap();
+        let shape = F::new(&ctx, min).unwrap();
+        let tape = shape.interval_tape(Default::default());
+        let mut eval = F::new_interval_eval();
+        let (r, data) = eval.eval(&tape, &[[0.0, 1.0].into()]).unwrap();
         assert_eq!(r, [0.0, 1.0].into());
         assert!(data.is_none());
 
-        let (r, data) =
-            eval.eval(&tape, [-1.0, 0.0], [0.0; 2], [0.0; 2]).unwrap();
+        let (r, data) = eval.eval(&tape, &[[-1.0, 0.0].into()]).unwrap();
         assert_eq!(r, [-1.0, 0.0].into());
         assert_eq!(data.unwrap().as_ref(), &[Choice::Left]);
 
-        let (r, data) =
-            eval.eval(&tape, [2.0, 3.0], [0.0; 2], [0.0; 2]).unwrap();
+        let (r, data) = eval.eval(&tape, &[[2.0, 3.0].into()]).unwrap();
         assert_eq!(r, [1.0, 1.0].into());
         assert_eq!(data.unwrap().as_ref(), &[Choice::Right]);
     }
@@ -452,57 +536,54 @@ where
         let y = ctx.y();
         let max = ctx.max(x, y).unwrap();
 
-        let shape = Shape::<F>::new(&mut ctx, max).unwrap();
-        let tape = shape.ez_interval_tape();
-        let mut eval = Shape::<F>::new_interval_eval();
-        let (r, data) =
-            eval.eval(&tape, [0.0, 1.0], [0.5, 1.5], [0.0; 2]).unwrap();
+        let shape = F::new(&ctx, max).unwrap();
+        let tape = shape.interval_tape(Default::default());
+        let vs = bind_xy(&tape);
+        let mut eval = F::new_interval_eval();
+        let (r, data) = eval.eval(&tape, &vs([0.0, 1.0], [0.5, 1.5])).unwrap();
         assert_eq!(r, [0.5, 1.5].into());
         assert!(data.is_none());
 
-        let (r, data) =
-            eval.eval(&tape, [0.0, 1.0], [2.0, 3.0], [0.0; 2]).unwrap();
+        let (r, data) = eval.eval(&tape, &vs([0.0, 1.0], [2.0, 3.0])).unwrap();
         assert_eq!(r, [2.0, 3.0].into());
         assert_eq!(data.unwrap().as_ref(), &[Choice::Right]);
 
-        let (r, data) =
-            eval.eval(&tape, [2.0, 3.0], [0.0, 1.0], [0.0; 2]).unwrap();
+        let (r, data) = eval.eval(&tape, &vs([2.0, 3.0], [0.0, 1.0])).unwrap();
         assert_eq!(r, [2.0, 3.0].into());
         assert_eq!(data.unwrap().as_ref(), &[Choice::Left]);
 
-        let (v, data) = eval
-            .eval(&tape, [f32::NAN; 2], [0.0, 1.0], [0.0; 2])
-            .unwrap();
+        let (v, data) =
+            eval.eval(&tape, &vs([f32::NAN; 2], [0.0, 1.0])).unwrap();
         assert!(v.lower().is_nan());
         assert!(v.upper().is_nan());
         assert!(data.is_none());
 
-        let (v, data) = eval
-            .eval(&tape, [0.0, 1.0], [f32::NAN; 2], [0.0; 2])
-            .unwrap();
+        let (v, data) =
+            eval.eval(&tape, &vs([0.0, 1.0], [f32::NAN; 2])).unwrap();
         assert!(v.lower().is_nan());
         assert!(v.upper().is_nan());
         assert!(data.is_none());
 
         let z = ctx.z();
         let max_xy_z = ctx.max(max, z).unwrap();
-        let shape = Shape::<F>::new(&mut ctx, max_xy_z).unwrap();
-        let tape = shape.ez_interval_tape();
-        let mut eval = Shape::<F>::new_interval_eval();
+        let shape = F::new(&ctx, max_xy_z).unwrap();
+        let tape = shape.interval_tape(Default::default());
+        let vs = bind_xyz(&tape);
+        let mut eval = F::new_interval_eval();
         let (r, data) = eval
-            .eval(&tape, [2.0, 3.0], [0.0, 1.0], [4.0, 5.0])
+            .eval(&tape, &vs([2.0, 3.0], [0.0, 1.0], [4.0, 5.0]))
             .unwrap();
         assert_eq!(r, [4.0, 5.0].into());
         assert_eq!(data.unwrap().as_ref(), &[Choice::Left, Choice::Right]);
 
         let (r, data) = eval
-            .eval(&tape, [2.0, 3.0], [0.0, 1.0], [1.0, 4.0])
+            .eval(&tape, &vs([2.0, 3.0], [0.0, 1.0], [1.0, 4.0]))
             .unwrap();
         assert_eq!(r, [2.0, 4.0].into());
         assert_eq!(data.unwrap().as_ref(), &[Choice::Left, Choice::Both]);
 
         let (r, data) = eval
-            .eval(&tape, [2.0, 3.0], [0.0, 1.0], [1.0, 1.5])
+            .eval(&tape, &vs([2.0, 3.0], [0.0, 1.0], [1.0, 1.5]))
             .unwrap();
         assert_eq!(r, [2.0, 3.0].into());
         assert_eq!(data.unwrap().as_ref(), &[Choice::Left, Choice::Left]);
@@ -514,30 +595,27 @@ where
         let y = ctx.y();
         let v = ctx.and(x, y).unwrap();
 
-        let shape = Shape::<F>::new(&mut ctx, v).unwrap();
-        let tape = shape.ez_interval_tape();
-        let mut eval = Shape::<F>::new_interval_eval();
-        let (r, trace) = eval
-            .eval(&tape, [0.0, 0.0], [-1.0, 3.0], [0.0, 0.0])
-            .unwrap();
+        let shape = F::new(&ctx, v).unwrap();
+        let tape = shape.interval_tape(Default::default());
+        let vs = bind_xy(&tape);
+        let mut eval = F::new_interval_eval();
+        let (r, trace) =
+            eval.eval(&tape, &vs([0.0, 0.0], [-1.0, 3.0])).unwrap();
         assert_eq!(r, [0.0, 0.0].into());
         assert_eq!(trace.unwrap().as_ref(), &[Choice::Left]);
 
-        let (r, trace) = eval
-            .eval(&tape, [-1.0, -0.2], [-1.0, 3.0], [0.0, 0.0])
-            .unwrap();
+        let (r, trace) =
+            eval.eval(&tape, &vs([-1.0, -0.2], [-1.0, 3.0])).unwrap();
         assert_eq!(r, [-1.0, 3.0].into());
         assert_eq!(trace.unwrap().as_ref(), &[Choice::Right]);
 
-        let (r, trace) = eval
-            .eval(&tape, [0.2, 1.3], [-1.0, 3.0], [0.0, 0.0])
-            .unwrap();
+        let (r, trace) =
+            eval.eval(&tape, &vs([0.2, 1.3], [-1.0, 3.0])).unwrap();
         assert_eq!(r, [-1.0, 3.0].into());
         assert_eq!(trace.unwrap().as_ref(), &[Choice::Right]);
 
-        let (r, trace) = eval
-            .eval(&tape, [-0.2, 1.3], [1.0, 3.0], [0.0, 0.0])
-            .unwrap();
+        let (r, trace) =
+            eval.eval(&tape, &vs([-0.2, 1.3], [1.0, 3.0])).unwrap();
         assert_eq!(r, [0.0, 3.0].into());
         assert!(trace.is_none()); // can't simplify
     }
@@ -548,30 +626,27 @@ where
         let y = ctx.y();
         let v = ctx.or(x, y).unwrap();
 
-        let shape = Shape::<F>::new(&mut ctx, v).unwrap();
-        let tape = shape.ez_interval_tape();
-        let mut eval = Shape::<F>::new_interval_eval();
-        let (r, trace) = eval
-            .eval(&tape, [0.0, 0.0], [-1.0, 3.0], [0.0, 0.0])
-            .unwrap();
+        let shape = F::new(&ctx, v).unwrap();
+        let tape = shape.interval_tape(Default::default());
+        let vs = bind_xy(&tape);
+        let mut eval = F::new_interval_eval();
+        let (r, trace) =
+            eval.eval(&tape, &vs([0.0, 0.0], [-1.0, 3.0])).unwrap();
         assert_eq!(r, [-1.0, 3.0].into());
         assert_eq!(trace.unwrap().as_ref(), &[Choice::Right]);
 
-        let (r, trace) = eval
-            .eval(&tape, [-1.0, -0.2], [-1.0, 3.0], [0.0, 0.0])
-            .unwrap();
+        let (r, trace) =
+            eval.eval(&tape, &vs([-1.0, -0.2], [-1.0, 3.0])).unwrap();
         assert_eq!(r, [-1.0, -0.2].into());
         assert_eq!(trace.unwrap().as_ref(), &[Choice::Left]);
 
-        let (r, trace) = eval
-            .eval(&tape, [0.2, 1.3], [-1.0, 3.0], [0.0, 0.0])
-            .unwrap();
+        let (r, trace) =
+            eval.eval(&tape, &vs([0.2, 1.3], [-1.0, 3.0])).unwrap();
         assert_eq!(r, [0.2, 1.3].into());
         assert_eq!(trace.unwrap().as_ref(), &[Choice::Left]);
 
-        let (r, trace) = eval
-            .eval(&tape, [-0.2, 1.3], [1.0, 3.0], [0.0, 0.0])
-            .unwrap();
+        let (r, trace) =
+            eval.eval(&tape, &vs([-0.2, 1.3], [1.0, 3.0])).unwrap();
         assert_eq!(r, [-0.2, 3.0].into());
         assert!(trace.is_none());
     }
@@ -581,40 +656,34 @@ where
         let x = ctx.x();
         let min = ctx.min(x, 1.0).unwrap();
 
-        let shape = Shape::<F>::new(&mut ctx, min).unwrap();
-        let tape = shape.ez_interval_tape();
-        let mut eval = Shape::<F>::new_interval_eval();
-        let (out, data) =
-            eval.eval(&tape, [0.0, 2.0], [0.0; 2], [0.0; 2]).unwrap();
+        let shape = F::new(&ctx, min).unwrap();
+        let tape = shape.interval_tape(Default::default());
+        let mut eval = F::new_interval_eval();
+        let (out, data) = eval.eval(&tape, &[[0.0, 2.0].into()]).unwrap();
         assert_eq!(out, [0.0, 1.0].into());
         assert!(data.is_none());
 
-        let (out, data) =
-            eval.eval(&tape, [0.0, 0.5], [0.0; 2], [0.0; 2]).unwrap();
+        let (out, data) = eval.eval(&tape, &[[0.0, 0.5].into()]).unwrap();
         assert_eq!(out, [0.0, 0.5].into());
         assert_eq!(data.unwrap().as_ref(), &[Choice::Left]);
 
-        let (out, data) =
-            eval.eval(&tape, [1.5, 2.5], [0.0; 2], [0.0; 2]).unwrap();
+        let (out, data) = eval.eval(&tape, &[[1.5, 2.5].into()]).unwrap();
         assert_eq!(out, [1.0, 1.0].into());
         assert_eq!(data.unwrap().as_ref(), &[Choice::Right]);
 
         let max = ctx.max(x, 1.0).unwrap();
-        let shape = Shape::<F>::new(&mut ctx, max).unwrap();
-        let tape = shape.ez_interval_tape();
-        let mut eval = Shape::<F>::new_interval_eval();
-        let (out, data) =
-            eval.eval(&tape, [0.0, 2.0], [0.0; 2], [0.0; 2]).unwrap();
+        let shape = F::new(&ctx, max).unwrap();
+        let tape = shape.interval_tape(Default::default());
+        let mut eval = F::new_interval_eval();
+        let (out, data) = eval.eval(&tape, &[[0.0, 2.0].into()]).unwrap();
         assert_eq!(out, [1.0, 2.0].into());
         assert!(data.is_none());
 
-        let (out, data) =
-            eval.eval(&tape, [0.0, 0.5], [0.0; 2], [0.0; 2]).unwrap();
+        let (out, data) = eval.eval(&tape, &[[0.0, 0.5].into()]).unwrap();
         assert_eq!(out, [1.0, 1.0].into());
         assert_eq!(data.unwrap().as_ref(), &[Choice::Right]);
 
-        let (out, data) =
-            eval.eval(&tape, [1.5, 2.5], [0.0; 2], [0.0; 2]).unwrap();
+        let (out, data) = eval.eval(&tape, &[[1.5, 2.5].into()]).unwrap();
         assert_eq!(out, [1.5, 2.5].into());
         assert_eq!(data.unwrap().as_ref(), &[Choice::Left]);
     }
@@ -626,12 +695,13 @@ where
         let z = ctx.z();
 
         let if_else = ctx.if_nonzero_else(x, y, z).unwrap();
-        let shape = Shape::<F>::new(&mut ctx, if_else).unwrap();
+        let shape = F::new(&ctx, if_else).unwrap();
 
-        let tape = shape.ez_interval_tape();
-        let mut eval = Shape::<F>::new_interval_eval();
+        let tape = shape.interval_tape(Default::default());
+        let vs = bind_xyz(&tape);
+        let mut eval = F::new_interval_eval();
         let (out, data) = eval
-            .eval(&tape, [-1.0, 2.0], [1.0, 2.0], [3.0, 4.0])
+            .eval(&tape, &vs([-1.0, 2.0], [1.0, 2.0], [3.0, 4.0]))
             .unwrap();
 
         // Alas, we lose the information that the conditional is correlated, so
@@ -641,27 +711,39 @@ where
 
         // Confirm that simplification of the right side works
         let (out, data) = eval
-            .eval(&tape, [0.0, 0.0], [1.0, 2.0], [3.0, 4.0])
+            .eval(&tape, &vs([0.0, 0.0], [1.0, 2.0], [3.0, 4.0]))
             .unwrap();
         assert_eq!(out, [3.0, 4.0].into());
-        let s_z = shape.ez_simplify(data.expect("must have trace")).unwrap();
-        let t_z = s_z.ez_interval_tape();
+        let s_z = shape
+            .simplify(
+                data.expect("must have trace"),
+                Default::default(),
+                &mut Default::default(),
+            )
+            .unwrap();
+        let t_z = s_z.interval_tape(Default::default());
         let (out, data) = eval
-            .eval(&t_z, [-1.0, 1.0], [1.0, 2.0], [5.0, 6.0])
+            .eval(&t_z, &vs([-1.0, 1.0], [1.0, 2.0], [5.0, 6.0]))
             .unwrap();
         assert!(s_z.size() < shape.size());
         assert_eq!(out, [5.0, 6.0].into());
         assert!(data.is_none());
 
         let (out, data) = eval
-            .eval(&tape, [1.0, 3.0], [1.0, 2.0], [3.0, 4.0])
+            .eval(&tape, &vs([1.0, 3.0], [1.0, 2.0], [3.0, 4.0]))
             .unwrap();
         assert_eq!(out, [1.0, 2.0].into());
         assert!(data.is_some());
-        let s_y = shape.ez_simplify(data.expect("must have trace")).unwrap();
-        let t_y = s_y.ez_interval_tape();
+        let s_y = shape
+            .simplify(
+                data.expect("must have trace"),
+                Default::default(),
+                &mut Default::default(),
+            )
+            .unwrap();
+        let t_y = s_y.interval_tape(Default::default());
         let (out, data) = eval
-            .eval(&t_y, [-1.0, 1.0], [1.0, 4.0], [5.0, 6.0])
+            .eval(&t_y, &vs([-1.0, 1.0], [1.0, 4.0], [5.0, 6.0]))
             .unwrap();
         assert!(s_y.size() < shape.size());
         assert_eq!(out, [1.0, 4.0].into());
@@ -675,24 +757,18 @@ where
         let x = ctx.x();
         let max = ctx.max(x, 1.0).unwrap();
 
-        let shape = Shape::<F>::new(&mut ctx, max).unwrap();
-        let tape = shape.ez_interval_tape();
-        let mut eval = Shape::<F>::new_interval_eval();
-        let (r, data) = eval
-            .eval(&tape, [0.0, 2.0], [0.0, 0.0], [0.0, 0.0])
-            .unwrap();
+        let shape = F::new(&ctx, max).unwrap();
+        let tape = shape.interval_tape(Default::default());
+        let mut eval = F::new_interval_eval();
+        let (r, data) = eval.eval(&tape, &[[0.0, 2.0].into()]).unwrap();
         assert_eq!(r, [1.0, 2.0].into());
         assert!(data.is_none());
 
-        let (r, data) = eval
-            .eval(&tape, [-1.0, 0.0], [0.0, 0.0], [0.0, 0.0])
-            .unwrap();
+        let (r, data) = eval.eval(&tape, &[[-1.0, 0.0].into()]).unwrap();
         assert_eq!(r, [1.0, 1.0].into());
         assert_eq!(data.unwrap().as_ref(), &[Choice::Right]);
 
-        let (r, data) = eval
-            .eval(&tape, [2.0, 3.0], [0.0, 0.0], [0.0, 0.0])
-            .unwrap();
+        let (r, data) = eval.eval(&tape, &[[2.0, 3.0].into()]).unwrap();
         assert_eq!(r, [2.0, 3.0].into());
         assert_eq!(data.unwrap().as_ref(), &[Choice::Left]);
     }
@@ -703,10 +779,11 @@ where
         let y = ctx.y();
         let c = ctx.compare(x, y).unwrap();
 
-        let shape = Shape::<F>::new(&mut ctx, c).unwrap();
-        let tape = shape.ez_interval_tape();
-        let mut eval = Shape::<F>::new_interval_eval();
-        let (out, _trace) = eval.eval(&tape, -5.0, -6.0, 0.0).unwrap();
+        let shape = F::new(&ctx, c).unwrap();
+        let tape = shape.interval_tape(Default::default());
+        let vs = bind_xy(&tape);
+        let mut eval = F::new_interval_eval();
+        let (out, _trace) = eval.eval(&tape, &vs(-5.0, -6.0)).unwrap();
         assert_eq!(out, Interval::from(1f32));
     }
 
@@ -723,19 +800,19 @@ where
         let y: Vec<_> = x[1..].iter().chain(&x[0..1]).cloned().collect();
         let z: Vec<_> = x[2..].iter().chain(&x[0..2]).cloned().collect();
 
-        let shape = Shape::<F>::new(&mut ctx, node).unwrap();
-        let mut eval = Shape::<F>::new_interval_eval();
-        let tape = shape.ez_interval_tape();
+        let shape = F::new(&ctx, node).unwrap();
+        let mut eval = F::new_interval_eval();
+        let tape = shape.interval_tape(Default::default());
+        let vs = bind_xyz(&tape);
 
         let mut out = vec![];
         for i in 0..args.len() {
-            out.push(eval.eval(&tape, x[i], y[i], z[i]).unwrap().0);
+            out.push(eval.eval(&tape, &vs(x[i], y[i], z[i])).unwrap().0);
         }
 
         // Compare against the VmShape evaluator as a baseline.  It's possible
         // that S is also a VmShape, but this comparison isn't particularly
         // expensive, so we'll do it regardless.
-        use crate::vm::VmShape;
         let shape = VmShape::new(&mut ctx, node).unwrap();
         let mut eval = VmShape::new_interval_eval();
         let tape = shape.ez_interval_tape();
@@ -751,7 +828,7 @@ where
     }
 
     pub fn test_i_stress() {
-        for n in [1, 2, 4, 8, 12, 16, 32] {
+        for n in [4, 8, 12, 16, 32] {
             Self::test_i_stress_n(n);
         }
     }
@@ -774,50 +851,42 @@ where
         let args = Self::interval_test_args();
 
         let mut ctx = Context::new();
-        let mut tape_data = None;
-        let mut eval = Shape::<F>::new_interval_eval();
-        for (i, v) in [ctx.x(), ctx.y(), ctx.z()].into_iter().enumerate() {
-            let node = C::build(&mut ctx, v);
+        let mut eval = F::new_interval_eval();
 
-            let shape = Shape::<F>::new(&mut ctx, node).unwrap();
-            let tape = shape.interval_tape(tape_data.unwrap_or_default());
+        let v = ctx.var(Var::new());
+        let node = C::build(&mut ctx, v);
 
-            for &a in args.iter() {
-                let (o, trace) = match i {
-                    0 => eval.eval(&tape, a, 0.0.into(), 0.0.into()),
-                    1 => eval.eval(&tape, 0.0.into(), a, 0.0.into()),
-                    2 => eval.eval(&tape, 0.0.into(), 0.0.into(), a),
-                    _ => unreachable!(),
-                }
-                .unwrap();
-                assert!(trace.is_none());
+        let shape = F::new(&ctx, node).unwrap();
+        let tape = shape.interval_tape(Default::default());
+        assert_eq!(tape.vars().len(), 1);
 
-                for i in 0..32 {
-                    let pos = i as f32 / 31.0;
-                    let inside = (a.lower() * pos + a.upper() * (1.0 - pos))
-                        .min(a.upper())
-                        .max(a.lower());
-                    let inside_value = C::eval_f32(inside);
+        for &a in args.iter() {
+            let (o, trace) = eval.eval(&tape, &[a]).unwrap();
+            assert!(trace.is_none());
 
-                    if inside_value.is_nan() || inside_value.is_infinite() {
-                        assert!(
-                            o.has_nan(),
-                            "interval failure in '{}': {inside} in {a} => \
+            for i in 0..32 {
+                let pos = i as f32 / 31.0;
+                let inside = (a.lower() * pos + a.upper() * (1.0 - pos))
+                    .min(a.upper())
+                    .max(a.lower());
+                let inside_value = C::eval_f32(inside);
+
+                if inside_value.is_nan() || inside_value.is_infinite() {
+                    assert!(
+                        o.has_nan(),
+                        "interval failure in '{}': {inside} in {a} => \
                              {inside_value} not in {o} (should be [NaN, NaN])",
-                            C::NAME,
-                        );
-                    } else if !o.has_nan() {
-                        assert!(
-                            inside_value >= o.lower()
-                                && inside_value <= o.upper(),
-                            "interval failure in '{}': {inside} in {a} => \
+                        C::NAME,
+                    );
+                } else if !o.has_nan() {
+                    assert!(
+                        inside_value >= o.lower() && inside_value <= o.upper(),
+                        "interval failure in '{}': {inside} in {a} => \
                              {inside_value} not in {o}",
-                            C::NAME,
-                        );
-                    }
+                        C::NAME,
+                    );
                 }
             }
-            tape_data = Some(tape.recycle());
         }
     }
 
@@ -866,55 +935,80 @@ where
         let args = Self::interval_test_args();
 
         let mut ctx = Context::new();
-        let xyz = [ctx.x(), ctx.y(), ctx.z()];
+        let va = Var::new();
+        let vb = Var::new();
+        let a = ctx.var(va);
+        let b = ctx.var(vb);
 
         let name = format!("{}(reg, reg)", C::NAME);
-        let zero = Interval::new(0.0, 0.0);
         let mut tape_data = None;
-        let mut eval = Shape::<F>::new_interval_eval();
+        let mut eval = F::new_interval_eval();
         for &lhs in args.iter() {
             for &rhs in args.iter() {
-                for (i, &u) in xyz.iter().enumerate() {
-                    for (j, &v) in xyz.iter().enumerate() {
-                        let node = C::build(&mut ctx, u, v);
+                let node = C::build(&mut ctx, a, b);
 
-                        // Special-case for things like x * x, which get
-                        // optimized to x**2 (with a different interval result)
-                        let op = ctx.get_op(node).unwrap();
-                        if matches!(op, crate::context::Op::Unary(..)) {
-                            continue;
-                        }
-
-                        let shape = Shape::<F>::new(&mut ctx, node).unwrap();
-                        let tape =
-                            shape.interval_tape(tape_data.unwrap_or_default());
-
-                        let (out, _trace) = match (i, j) {
-                            (0, 0) => eval.eval(&tape, lhs, zero, zero),
-                            (0, 1) => eval.eval(&tape, lhs, rhs, zero),
-                            (0, 2) => eval.eval(&tape, lhs, zero, rhs),
-                            (1, 0) => eval.eval(&tape, rhs, lhs, zero),
-                            (1, 1) => eval.eval(&tape, zero, lhs, zero),
-                            (1, 2) => eval.eval(&tape, zero, lhs, rhs),
-                            (2, 0) => eval.eval(&tape, rhs, zero, lhs),
-                            (2, 1) => eval.eval(&tape, zero, rhs, lhs),
-                            (2, 2) => eval.eval(&tape, zero, zero, lhs),
-                            _ => unreachable!(),
-                        }
-                        .unwrap();
-                        tape_data = Some(tape.recycle());
-
-                        let rhs = if i == j { lhs } else { rhs };
-                        Self::compare_interval_results(
-                            lhs,
-                            rhs,
-                            out,
-                            C::eval_reg_reg_f32,
-                            &name,
-                        );
-                    }
+                // Special-case for things like x * x, which get
+                // optimized to x**2 (with a different interval result)
+                let op = ctx.get_op(node).unwrap();
+                if matches!(op, crate::context::Op::Unary(..)) {
+                    continue;
                 }
+
+                let shape = F::new(&ctx, node).unwrap();
+                let tape = shape.interval_tape(tape_data.unwrap_or_default());
+
+                let vars = tape.vars();
+
+                let i_index = vars[&va];
+                let j_index = vars[&vb];
+                assert_ne!(i_index, j_index);
+
+                let mut args = [0f32.into(); 2];
+                args[j_index] = rhs;
+                args[i_index] = lhs;
+
+                let (out, _trace) = eval.eval(&tape, &args).unwrap();
+                tape_data = Some(tape.recycle());
+
+                Self::compare_interval_results(
+                    lhs,
+                    rhs,
+                    out,
+                    C::eval_reg_reg_f32,
+                    &name,
+                );
             }
+        }
+
+        for &lhs in args.iter() {
+            let node = C::build(&mut ctx, a, a);
+
+            // Special-case for things like x * x, which get
+            // optimized to x**2 (with a different interval result)
+            let op = ctx.get_op(node).unwrap();
+            if matches!(op, crate::context::Op::Unary(..)) {
+                continue;
+            }
+
+            let shape = F::new(&ctx, node).unwrap();
+            let tape = shape.interval_tape(tape_data.unwrap_or_default());
+
+            let vars = tape.vars();
+
+            let i_index = vars[&va];
+            assert_eq!(i_index, 0);
+
+            let args = [lhs];
+            let (out, _trace) = eval.eval(&tape, &args).unwrap();
+            tape_data = Some(tape.recycle());
+
+            Self::compare_interval_results(
+                lhs,
+                lhs,
+                out,
+                C::eval_reg_reg_f32,
+                &name,
+            );
         }
     }
 
@@ -923,39 +1017,30 @@ where
         let args = Self::interval_test_args();
 
         let mut ctx = Context::new();
-        let xyz = [ctx.x(), ctx.y(), ctx.z()];
+        let va = Var::new();
+        let a = ctx.var(va);
 
         let name = format!("{}(reg, imm)", C::NAME);
-        let zero = Interval::new(0.0, 0.0);
         let mut tape_data = None;
-        let mut eval = Shape::<F>::new_interval_eval();
+        let mut eval = F::new_interval_eval();
         for &lhs in args.iter() {
             for &rhs in values.iter() {
-                for (i, &u) in xyz.iter().enumerate() {
-                    let c = ctx.constant(rhs as f64);
-                    let node = C::build(&mut ctx, u, c);
+                let c = ctx.constant(rhs as f64);
+                let node = C::build(&mut ctx, a, c);
 
-                    let shape = Shape::<F>::new(&mut ctx, node).unwrap();
-                    let tape =
-                        shape.interval_tape(tape_data.unwrap_or_default());
+                let shape = F::new(&ctx, node).unwrap();
+                let tape = shape.interval_tape(tape_data.unwrap_or_default());
 
-                    let (out, _trace) = match i {
-                        0 => eval.eval(&tape, lhs, zero, zero),
-                        1 => eval.eval(&tape, zero, lhs, zero),
-                        2 => eval.eval(&tape, zero, zero, lhs),
-                        _ => unreachable!(),
-                    }
-                    .unwrap();
-                    tape_data = Some(tape.recycle());
+                let (out, _trace) = eval.eval(&tape, &[lhs]).unwrap();
+                tape_data = Some(tape.recycle());
 
-                    Self::compare_interval_results(
-                        lhs,
-                        rhs.into(),
-                        out,
-                        C::eval_reg_imm_f32,
-                        &name,
-                    );
-                }
+                Self::compare_interval_results(
+                    lhs,
+                    rhs.into(),
+                    out,
+                    C::eval_reg_imm_f32,
+                    &name,
+                );
             }
         }
     }
@@ -965,39 +1050,30 @@ where
         let args = Self::interval_test_args();
 
         let mut ctx = Context::new();
-        let xyz = [ctx.x(), ctx.y(), ctx.z()];
+        let va = Var::new();
+        let a = ctx.var(va);
 
         let name = format!("{}(imm, reg)", C::NAME);
-        let zero = Interval::new(0.0, 0.0);
         let mut tape_data = None;
-        let mut eval = Shape::<F>::new_interval_eval();
+        let mut eval = F::new_interval_eval();
         for &lhs in values.iter() {
             for &rhs in args.iter() {
-                for (i, &u) in xyz.iter().enumerate() {
-                    let c = ctx.constant(lhs as f64);
-                    let node = C::build(&mut ctx, c, u);
+                let c = ctx.constant(lhs as f64);
+                let node = C::build(&mut ctx, c, a);
 
-                    let shape = Shape::<F>::new(&mut ctx, node).unwrap();
-                    let tape =
-                        shape.interval_tape(tape_data.unwrap_or_default());
+                let shape = F::new(&ctx, node).unwrap();
+                let tape = shape.interval_tape(tape_data.unwrap_or_default());
 
-                    let (out, _trace) = match i {
-                        0 => eval.eval(&tape, rhs, zero, zero),
-                        1 => eval.eval(&tape, zero, rhs, zero),
-                        2 => eval.eval(&tape, zero, zero, rhs),
-                        _ => unreachable!(),
-                    }
-                    .unwrap();
-                    tape_data = Some(tape.recycle());
+                let (out, _trace) = eval.eval(&tape, &[rhs]).unwrap();
+                tape_data = Some(tape.recycle());
 
-                    Self::compare_interval_results(
-                        lhs.into(),
-                        rhs,
-                        out,
-                        C::eval_imm_reg_f32,
-                        &name,
-                    );
-                }
+                Self::compare_interval_results(
+                    lhs.into(),
+                    rhs,
+                    out,
+                    C::eval_imm_reg_f32,
+                    &name,
+                );
             }
         }
     }

--- a/fidget/src/core/eval/test/mod.rs
+++ b/fidget/src/core/eval/test/mod.rs
@@ -4,7 +4,11 @@ pub mod grad_slice;
 pub mod interval;
 pub mod point;
 
-use crate::context::{Context, Node};
+use crate::{
+    context::{Context, Node},
+    eval::Tape,
+    var::Var,
+};
 
 /// Builds a function which stresses the register allocator and function caller
 pub fn build_stress_fn(n: usize) -> (Context, Node) {
@@ -54,6 +58,40 @@ fn test_args_n(n: i64) -> Vec<f32> {
 
 fn test_args() -> Vec<f32> {
     test_args_n(32)
+}
+
+fn bind_xy<T: Tape, V: From<f32> + Copy>(
+    tape: &T,
+) -> Box<dyn Fn(V, V) -> [V; 2]> {
+    let vars = tape.vars();
+    let ix = vars[&Var::X];
+    let iy = vars[&Var::Y];
+    assert_ne!(ix, iy);
+    Box::new(move |x, y| {
+        let mut out = [V::from(0f32); 2];
+        out[ix] = x;
+        out[iy] = y;
+        out
+    })
+}
+
+fn bind_xyz<T: Tape, V: From<f32> + Copy>(
+    tape: &T,
+) -> Box<dyn Fn(V, V, V) -> [V; 3]> {
+    let vars = tape.vars();
+    let ix = vars[&Var::X];
+    let iy = vars[&Var::Y];
+    let iz = vars[&Var::Z];
+    assert_ne!(ix, iy);
+    assert_ne!(iy, iz);
+    assert_ne!(ix, iz);
+    Box::new(move |x, y, z| {
+        let mut out = [V::from(0f32); 3];
+        out[ix] = x;
+        out[iy] = y;
+        out[iz] = z;
+        out
+    })
 }
 
 /// Trait for canonical evaluation testing of unary operations

--- a/fidget/src/core/eval/test/mod.rs
+++ b/fidget/src/core/eval/test/mod.rs
@@ -60,24 +60,24 @@ fn test_args() -> Vec<f32> {
     test_args_n(32)
 }
 
-fn bind_xy<T: Tape, V: From<f32> + Copy>(
+fn bind_xy<T: Tape, V: From<f32> + Copy, G: Into<V>>(
     tape: &T,
-) -> Box<dyn Fn(V, V) -> [V; 2]> {
+) -> Box<dyn Fn(G, G) -> [V; 2]> {
     let vars = tape.vars();
     let ix = vars[&Var::X];
     let iy = vars[&Var::Y];
     assert_ne!(ix, iy);
     Box::new(move |x, y| {
         let mut out = [V::from(0f32); 2];
-        out[ix] = x;
-        out[iy] = y;
+        out[ix] = x.into();
+        out[iy] = y.into();
         out
     })
 }
 
-fn bind_xyz<T: Tape, V: From<f32> + Copy>(
+fn bind_xyz<T: Tape, V: From<f32> + Copy, G: Into<V>>(
     tape: &T,
-) -> Box<dyn Fn(V, V, V) -> [V; 3]> {
+) -> Box<dyn Fn(G, G, G) -> [V; 3]> {
     let vars = tape.vars();
     let ix = vars[&Var::X];
     let iy = vars[&Var::Y];
@@ -87,9 +87,9 @@ fn bind_xyz<T: Tape, V: From<f32> + Copy>(
     assert_ne!(ix, iz);
     Box::new(move |x, y, z| {
         let mut out = [V::from(0f32); 3];
-        out[ix] = x;
-        out[iy] = y;
-        out[iz] = z;
+        out[ix] = x.into();
+        out[iy] = y.into();
+        out[iz] = z.into();
         out
     })
 }

--- a/fidget/src/core/eval/test/mod.rs
+++ b/fidget/src/core/eval/test/mod.rs
@@ -60,22 +60,20 @@ fn test_args() -> Vec<f32> {
     test_args_n(32)
 }
 
-fn bind_xy<T: Tape, V: From<f32> + Copy, G: Into<V>>(
-    tape: &T,
-) -> Box<dyn Fn(G, G) -> [V; 2]> {
+fn bind_xy<T: Tape, V, G: Into<V>>(tape: &T) -> Box<dyn Fn(G, G) -> [V; 2]> {
     let vars = tape.vars();
     let ix = vars[&Var::X];
     let iy = vars[&Var::Y];
     assert_ne!(ix, iy);
     Box::new(move |x, y| {
-        let mut out = [V::from(0f32); 2];
-        out[ix] = x.into();
-        out[iy] = y.into();
-        out
+        let mut out = [None, None];
+        out[ix] = Some(x.into());
+        out[iy] = Some(y.into());
+        out.map(Option::unwrap)
     })
 }
 
-fn bind_xyz<T: Tape, V: From<f32> + Copy, G: Into<V>>(
+fn bind_xyz<T: Tape, V, G: Into<V>>(
     tape: &T,
 ) -> Box<dyn Fn(G, G, G) -> [V; 3]> {
     let vars = tape.vars();
@@ -86,11 +84,11 @@ fn bind_xyz<T: Tape, V: From<f32> + Copy, G: Into<V>>(
     assert_ne!(iy, iz);
     assert_ne!(ix, iz);
     Box::new(move |x, y, z| {
-        let mut out = [V::from(0f32); 3];
-        out[ix] = x.into();
-        out[iy] = y.into();
-        out[iz] = z.into();
-        out
+        let mut out = [None, None, None];
+        out[ix] = Some(x.into());
+        out[iy] = Some(y.into());
+        out[iz] = Some(z.into());
+        out.map(Option::unwrap)
     })
 }
 

--- a/fidget/src/core/eval/test/point.rs
+++ b/fidget/src/core/eval/test/point.rs
@@ -366,7 +366,7 @@ where
         let a = ctx.add(x, y).unwrap();
         let a = ctx.add(a, v_).unwrap();
 
-        let s = Shape::<F>::new(&mut ctx, a).unwrap();
+        let s = Shape::<F>::new(&ctx, a).unwrap();
 
         let mut eval = Shape::<F>::new_point_eval();
         let tape = s.ez_point_tape();
@@ -383,7 +383,7 @@ where
     }
 
     pub fn test_p_stress_n(depth: usize) {
-        let (mut ctx, node) = build_stress_fn(depth);
+        let (ctx, node) = build_stress_fn(depth);
 
         // Pick an input slice that's guaranteed to be > 1 SIMD register
         let args = (0..32).map(|i| i as f32 / 32f32).collect::<Vec<f32>>();
@@ -420,7 +420,7 @@ where
         // that S is also a VmShape, but this comparison isn't particularly
         // expensive, so we'll do it regardless.
         use crate::vm::VmShape;
-        let shape = VmShape::new(&mut ctx, node).unwrap();
+        let shape = VmShape::new(&ctx, node).unwrap();
         let mut eval = VmShape::new_point_eval();
         let tape = shape.ez_point_tape();
 

--- a/fidget/src/core/eval/test/point.rs
+++ b/fidget/src/core/eval/test/point.rs
@@ -2,10 +2,13 @@
 //!
 //! If the `eval-tests` feature is set, then this exposes a standard test suite
 //! for point evaluators; otherwise, the module has no public exports.
-use super::{build_stress_fn, test_args, CanonicalBinaryOp, CanonicalUnaryOp};
+use super::{
+    bind_xy, bind_xyz, build_stress_fn, test_args, CanonicalBinaryOp,
+    CanonicalUnaryOp,
+};
 use crate::{
     context::Context,
-    eval::{Function, MathFunction},
+    eval::{Function, MathFunction, Tape, TracingEvaluator},
     shape::{EzShape, Shape},
     var::Var,
     vm::Choice,
@@ -23,10 +26,10 @@ where
     pub fn test_constant() {
         let mut ctx = Context::new();
         let p = ctx.constant(1.5);
-        let shape = Shape::<F>::new(&mut ctx, p).unwrap();
-        let tape = shape.ez_point_tape();
-        let mut eval = Shape::<F>::new_point_eval();
-        assert_eq!(eval.eval(&tape, 0.0, 0.0, 0.0).unwrap().0, 1.5);
+        let shape = F::new(&ctx, p).unwrap();
+        let tape = shape.point_tape(Default::default());
+        let mut eval = F::new_point_eval();
+        assert_eq!(eval.eval(&tape, &[]).unwrap().0, 1.5);
     }
 
     pub fn test_constant_push() {
@@ -34,18 +37,25 @@ where
         let a = ctx.constant(1.5);
         let x = ctx.x();
         let min = ctx.min(a, x).unwrap();
-        let shape = Shape::<F>::new(&mut ctx, min).unwrap();
-        let tape = shape.ez_point_tape();
-        let mut eval = Shape::<F>::new_point_eval();
-        let (r, trace) = eval.eval(&tape, 2.0, 0.0, 0.0).unwrap();
+        let shape = F::new(&ctx, min).unwrap();
+        let tape = shape.point_tape(Default::default());
+        let mut eval = F::new_point_eval();
+        let (r, trace) = eval.eval(&tape, &[2.0]).unwrap();
         assert_eq!(r, 1.5);
 
-        let next = shape.ez_simplify(trace.unwrap()).unwrap();
+        let next = shape
+            .simplify(
+                trace.unwrap(),
+                Default::default(),
+                &mut Default::default(),
+            )
+            .unwrap();
         assert_eq!(next.size(), 1);
 
-        let tape = next.ez_point_tape();
-        assert_eq!(eval.eval(&tape, 2.0, 0.0, 0.0).unwrap().0, 1.5);
-        assert_eq!(eval.eval(&tape, 1.0, 0.0, 0.0).unwrap().0, 1.5);
+        let tape = next.point_tape(Default::default());
+        assert_eq!(eval.eval(&tape, &[2.0]).unwrap().0, 1.5);
+        assert_eq!(eval.eval(&tape, &[1.0]).unwrap().0, 1.5);
+        assert!(eval.eval(&tape, &[]).is_err());
     }
 
     pub fn test_circle() {
@@ -57,11 +67,11 @@ where
         let radius = ctx.add(x_squared, y_squared).unwrap();
         let circle = ctx.sub(radius, 1.0).unwrap();
 
-        let shape = Shape::<F>::new(&mut ctx, circle).unwrap();
-        let tape = shape.ez_point_tape();
-        let mut eval = Shape::<F>::new_point_eval();
-        assert_eq!(eval.eval(&tape, 0.0, 0.0, 0.0).unwrap().0, -1.0);
-        assert_eq!(eval.eval(&tape, 1.0, 0.0, 0.0).unwrap().0, 0.0);
+        let shape = F::new(&ctx, circle).unwrap();
+        let tape = shape.point_tape(Default::default());
+        let mut eval = F::new_point_eval();
+        assert_eq!(eval.eval(&tape, &[0.0, 0.0]).unwrap().0, -1.0);
+        assert_eq!(eval.eval(&tape, &[1.0, 0.0]).unwrap().0, 0.0);
     }
 
     pub fn test_p_min() {
@@ -70,26 +80,28 @@ where
         let y = ctx.y();
         let min = ctx.min(x, y).unwrap();
 
-        let shape = Shape::<F>::new(&mut ctx, min).unwrap();
-        let tape = shape.ez_point_tape();
-        let mut eval = Shape::<F>::new_point_eval();
-        let (r, trace) = eval.eval(&tape, 0.0, 0.0, 0.0).unwrap();
+        let shape = F::new(&ctx, min).unwrap();
+        let tape = shape.point_tape(Default::default());
+        let vs = bind_xy(&tape);
+        let mut eval = F::new_point_eval();
+
+        let (r, trace) = eval.eval(&tape, &vs(0.0, 0.0)).unwrap();
         assert_eq!(r, 0.0);
         assert!(trace.is_none());
 
-        let (r, trace) = eval.eval(&tape, 0.0, 1.0, 0.0).unwrap();
+        let (r, trace) = eval.eval(&tape, &vs(0.0, 1.0)).unwrap();
         assert_eq!(r, 0.0);
         assert_eq!(trace.unwrap().as_ref(), &[Choice::Left]);
 
-        let (r, trace) = eval.eval(&tape, 2.0, 0.0, 0.0).unwrap();
+        let (r, trace) = eval.eval(&tape, &vs(2.0, 0.0)).unwrap();
         assert_eq!(r, 0.0);
         assert_eq!(trace.unwrap().as_ref(), &[Choice::Right]);
 
-        let (r, trace) = eval.eval(&tape, f32::NAN, 0.0, 0.0).unwrap();
+        let (r, trace) = eval.eval(&tape, &vs(f32::NAN, 0.0)).unwrap();
         assert!(r.is_nan());
         assert!(trace.is_none());
 
-        let (r, trace) = eval.eval(&tape, 0.0, f32::NAN, 0.0).unwrap();
+        let (r, trace) = eval.eval(&tape, &vs(0.0, f32::NAN)).unwrap();
         assert!(r.is_nan());
         assert!(trace.is_none());
     }
@@ -100,27 +112,28 @@ where
         let y = ctx.y();
         let max = ctx.max(x, y).unwrap();
 
-        let shape = Shape::<F>::new(&mut ctx, max).unwrap();
-        let tape = shape.ez_point_tape();
-        let mut eval = Shape::<F>::new_point_eval();
+        let shape = F::new(&ctx, max).unwrap();
+        let tape = shape.point_tape(Default::default());
+        let vs = bind_xy(&tape);
+        let mut eval = F::new_point_eval();
 
-        let (r, trace) = eval.eval(&tape, 0.0, 0.0, 0.0).unwrap();
+        let (r, trace) = eval.eval(&tape, &vs(0.0, 0.0)).unwrap();
         assert_eq!(r, 0.0);
         assert!(trace.is_none());
 
-        let (r, trace) = eval.eval(&tape, 0.0, 1.0, 0.0).unwrap();
+        let (r, trace) = eval.eval(&tape, &vs(0.0, 1.0)).unwrap();
         assert_eq!(r, 1.0);
         assert_eq!(trace.unwrap().as_ref(), &[Choice::Right]);
 
-        let (r, trace) = eval.eval(&tape, 2.0, 0.0, 0.0).unwrap();
+        let (r, trace) = eval.eval(&tape, &vs(2.0, 0.0)).unwrap();
         assert_eq!(r, 2.0);
         assert_eq!(trace.unwrap().as_ref(), &[Choice::Left]);
 
-        let (r, trace) = eval.eval(&tape, f32::NAN, 0.0, 0.0).unwrap();
+        let (r, trace) = eval.eval(&tape, &vs(f32::NAN, 0.0)).unwrap();
         assert!(r.is_nan());
         assert!(trace.is_none());
 
-        let (r, trace) = eval.eval(&tape, 0.0, f32::NAN, 0.0).unwrap();
+        let (r, trace) = eval.eval(&tape, &vs(0.0, f32::NAN)).unwrap();
         assert!(r.is_nan());
         assert!(trace.is_none());
     }
@@ -131,30 +144,32 @@ where
         let y = ctx.y();
         let v = ctx.and(x, y).unwrap();
 
-        let shape = Shape::<F>::new(&mut ctx, v).unwrap();
-        let tape = shape.ez_point_tape();
-        let mut eval = Shape::<F>::new_point_eval();
-        let (r, trace) = eval.eval(&tape, 0.0, 0.0, 0.0).unwrap();
+        let shape = F::new(&ctx, v).unwrap();
+        let tape = shape.point_tape(Default::default());
+        let vs = bind_xy(&tape);
+        let mut eval = F::new_point_eval();
+
+        let (r, trace) = eval.eval(&tape, &vs(0.0, 0.0)).unwrap();
         assert_eq!(r, 0.0);
         assert_eq!(trace.unwrap().as_ref(), &[Choice::Left]);
 
-        let (r, trace) = eval.eval(&tape, 0.0, 1.0, 0.0).unwrap();
+        let (r, trace) = eval.eval(&tape, &vs(0.0, 1.0)).unwrap();
         assert_eq!(r, 0.0);
         assert_eq!(trace.unwrap().as_ref(), &[Choice::Left]);
 
-        let (r, trace) = eval.eval(&tape, 0.0, f32::NAN, 0.0).unwrap();
+        let (r, trace) = eval.eval(&tape, &vs(0.0, f32::NAN)).unwrap();
         assert_eq!(r, 0.0);
         assert_eq!(trace.unwrap().as_ref(), &[Choice::Left]);
 
-        let (r, trace) = eval.eval(&tape, 0.1, 1.0, 0.0).unwrap();
+        let (r, trace) = eval.eval(&tape, &vs(0.1, 1.0)).unwrap();
         assert_eq!(r, 1.0);
         assert_eq!(trace.unwrap().as_ref(), &[Choice::Right]);
 
-        let (r, trace) = eval.eval(&tape, 0.1, 0.0, 0.0).unwrap();
+        let (r, trace) = eval.eval(&tape, &vs(0.1, 0.0)).unwrap();
         assert_eq!(r, 0.0);
         assert_eq!(trace.unwrap().as_ref(), &[Choice::Right]);
 
-        let (r, trace) = eval.eval(&tape, f32::NAN, 1.2, 0.0).unwrap();
+        let (r, trace) = eval.eval(&tape, &vs(f32::NAN, 1.2)).unwrap();
         assert_eq!(r, 1.2);
         assert_eq!(trace.unwrap().as_ref(), &[Choice::Right]);
     }
@@ -165,30 +180,32 @@ where
         let y = ctx.y();
         let v = ctx.or(x, y).unwrap();
 
-        let shape = Shape::<F>::new(&mut ctx, v).unwrap();
-        let tape = shape.ez_point_tape();
-        let mut eval = Shape::<F>::new_point_eval();
-        let (r, trace) = eval.eval(&tape, 0.0, 0.0, 0.0).unwrap();
+        let shape = F::new(&ctx, v).unwrap();
+        let tape = shape.point_tape(Default::default());
+        let vs = bind_xy(&tape);
+
+        let mut eval = F::new_point_eval();
+        let (r, trace) = eval.eval(&tape, &vs(0.0, 0.0)).unwrap();
         assert_eq!(r, 0.0);
         assert_eq!(trace.unwrap().as_ref(), &[Choice::Right]);
 
-        let (r, trace) = eval.eval(&tape, 0.0, 1.0, 0.0).unwrap();
+        let (r, trace) = eval.eval(&tape, &vs(0.0, 1.0)).unwrap();
         assert_eq!(r, 1.0);
         assert_eq!(trace.unwrap().as_ref(), &[Choice::Right]);
 
-        let (r, trace) = eval.eval(&tape, 0.0, f32::NAN, 0.0).unwrap();
+        let (r, trace) = eval.eval(&tape, &vs(0.0, f32::NAN)).unwrap();
         assert!(r.is_nan());
         assert_eq!(trace.unwrap().as_ref(), &[Choice::Right]);
 
-        let (r, trace) = eval.eval(&tape, 0.1, 1.0, 0.0).unwrap();
+        let (r, trace) = eval.eval(&tape, &vs(0.1, 1.0)).unwrap();
         assert_eq!(r, 0.1);
         assert_eq!(trace.unwrap().as_ref(), &[Choice::Left]);
 
-        let (r, trace) = eval.eval(&tape, 0.1, 0.0, 0.0).unwrap();
+        let (r, trace) = eval.eval(&tape, &vs(0.1, 0.0)).unwrap();
         assert_eq!(r, 0.1);
         assert_eq!(trace.unwrap().as_ref(), &[Choice::Left]);
 
-        let (r, trace) = eval.eval(&tape, f32::NAN, 1.2, 0.0).unwrap();
+        let (r, trace) = eval.eval(&tape, &vs(f32::NAN, 1.2)).unwrap();
         assert!(r.is_nan());
         assert_eq!(trace.unwrap().as_ref(), &[Choice::Left]);
     }
@@ -198,31 +215,32 @@ where
         let x = ctx.x();
         let s = ctx.sin(x).unwrap();
 
-        let shape = Shape::<F>::new(&mut ctx, s).unwrap();
-        let tape = shape.ez_point_tape();
-        let mut eval = Shape::<F>::new_point_eval();
+        let shape = F::new(&ctx, s).unwrap();
+        let tape = shape.point_tape(Default::default());
+        let mut eval = F::new_point_eval();
 
         for x in [0.0, 1.0, 2.0] {
-            let (r, trace) = eval.eval(&tape, x, 0.0, 0.0).unwrap();
+            let (r, trace) = eval.eval(&tape, &[x]).unwrap();
             assert_eq!(r, x.sin());
             assert!(trace.is_none());
 
-            let (r, trace) = eval.eval(&tape, x, 0.0, 0.0).unwrap();
+            let (r, trace) = eval.eval(&tape, &[x]).unwrap();
             assert_eq!(r, x.sin());
             assert!(trace.is_none());
 
-            let (r, trace) = eval.eval(&tape, x, 0.0, 0.0).unwrap();
+            let (r, trace) = eval.eval(&tape, &[x]).unwrap();
             assert_eq!(r, x.sin());
             assert!(trace.is_none());
         }
 
         let y = ctx.y();
         let s = ctx.add(s, y).unwrap();
-        let shape = Shape::<F>::new(&mut ctx, s).unwrap();
-        let tape = shape.ez_point_tape();
+        let shape = F::new(&ctx, s).unwrap();
+        let tape = shape.point_tape(Default::default());
+        let vs = bind_xy(&tape);
 
         for (x, y) in [(0.0, 1.0), (1.0, 3.0), (2.0, 8.0)] {
-            let (r, trace) = eval.eval(&tape, x, y, 0.0).unwrap();
+            let (r, trace) = eval.eval(&tape, &vs(x, y)).unwrap();
             assert_eq!(r, x.sin() + y);
             assert!(trace.is_none());
         }
@@ -234,12 +252,13 @@ where
         let y = ctx.y();
         let sum = ctx.add(x, 1.0).unwrap();
         let min = ctx.min(sum, y).unwrap();
-        let shape = Shape::<F>::new(&mut ctx, min).unwrap();
-        let tape = shape.ez_point_tape();
-        let mut eval = Shape::<F>::new_point_eval();
-        assert_eq!(eval.eval(&tape, 1.0, 2.0, 0.0).unwrap().0, 2.0);
-        assert_eq!(eval.eval(&tape, 1.0, 3.0, 0.0).unwrap().0, 2.0);
-        assert_eq!(eval.eval(&tape, 3.0, 3.5, 0.0).unwrap().0, 3.5);
+        let shape = F::new(&ctx, min).unwrap();
+        let tape = shape.point_tape(Default::default());
+        let vs = bind_xy(&tape);
+        let mut eval = F::new_point_eval();
+        assert_eq!(eval.eval(&tape, &vs(1.0, 2.0)).unwrap().0, 2.0);
+        assert_eq!(eval.eval(&tape, &vs(1.0, 3.0)).unwrap().0, 2.0);
+        assert_eq!(eval.eval(&tape, &vs(3.0, 3.5)).unwrap().0, 3.5);
     }
 
     pub fn test_push() {
@@ -248,38 +267,68 @@ where
         let y = ctx.y();
         let min = ctx.min(x, y).unwrap();
 
-        let shape = Shape::<F>::new(&mut ctx, min).unwrap();
-        let tape = shape.ez_point_tape();
-        let mut eval = Shape::<F>::new_point_eval();
-        assert_eq!(eval.eval(&tape, 1.0, 2.0, 0.0).unwrap().0, 1.0);
-        assert_eq!(eval.eval(&tape, 3.0, 2.0, 0.0).unwrap().0, 2.0);
+        let shape = F::new(&ctx, min).unwrap();
+        let tape = shape.point_tape(Default::default());
+        let vs = bind_xy(&tape);
+        let mut eval = F::new_point_eval();
+        assert_eq!(eval.eval(&tape, &vs(1.0, 2.0)).unwrap().0, 1.0);
+        assert_eq!(eval.eval(&tape, &vs(3.0, 2.0)).unwrap().0, 2.0);
 
-        let next = shape.ez_simplify(&vec![Choice::Left].into()).unwrap();
-        let tape = next.ez_point_tape();
-        assert_eq!(eval.eval(&tape, 1.0, 2.0, 0.0).unwrap().0, 1.0);
-        assert_eq!(eval.eval(&tape, 3.0, 2.0, 0.0).unwrap().0, 3.0);
+        let next = shape
+            .simplify(
+                &vec![Choice::Left].into(),
+                Default::default(),
+                &mut Default::default(),
+            )
+            .unwrap();
+        let tape = next.point_tape(Default::default());
+        let vs = bind_xy(&tape);
+        assert_eq!(eval.eval(&tape, &vs(1.0, 2.0)).unwrap().0, 1.0);
+        assert_eq!(eval.eval(&tape, &vs(3.0, 2.0)).unwrap().0, 3.0);
 
-        let next = shape.ez_simplify(&vec![Choice::Right].into()).unwrap();
-        let tape = next.ez_point_tape();
-        assert_eq!(eval.eval(&tape, 1.0, 2.0, 0.0).unwrap().0, 2.0);
-        assert_eq!(eval.eval(&tape, 3.0, 2.0, 0.0).unwrap().0, 2.0);
+        let next = shape
+            .simplify(
+                &vec![Choice::Right].into(),
+                Default::default(),
+                &mut Default::default(),
+            )
+            .unwrap();
+        let tape = next.point_tape(Default::default());
+        let vs = bind_xy(&tape);
+        assert_eq!(eval.eval(&tape, &vs(1.0, 2.0)).unwrap().0, 2.0);
+        assert_eq!(eval.eval(&tape, &vs(3.0, 2.0)).unwrap().0, 2.0);
 
         let min = ctx.min(x, 1.0).unwrap();
-        let shape = Shape::<F>::new(&mut ctx, min).unwrap();
-        let tape = shape.ez_point_tape();
-        let mut eval = Shape::<F>::new_point_eval();
-        assert_eq!(eval.eval(&tape, 0.5, 0.0, 0.0).unwrap().0, 0.5);
-        assert_eq!(eval.eval(&tape, 3.0, 0.0, 0.0).unwrap().0, 1.0);
+        let shape = F::new(&ctx, min).unwrap();
+        let tape = shape.point_tape(Default::default());
+        let vs = bind_xy(&tape);
+        let mut eval = F::new_point_eval();
+        assert_eq!(eval.eval(&tape, &vs(0.5, 0.0)).unwrap().0, 0.5);
+        assert_eq!(eval.eval(&tape, &vs(3.0, 0.0)).unwrap().0, 1.0);
 
-        let next = shape.ez_simplify(&vec![Choice::Left].into()).unwrap();
-        let tape = next.ez_point_tape();
-        assert_eq!(eval.eval(&tape, 0.5, 0.0, 0.0).unwrap().0, 0.5);
-        assert_eq!(eval.eval(&tape, 3.0, 0.0, 0.0).unwrap().0, 3.0);
+        let next = shape
+            .simplify(
+                &vec![Choice::Left].into(),
+                Default::default(),
+                &mut Default::default(),
+            )
+            .unwrap();
+        let tape = next.point_tape(Default::default());
+        let vs = bind_xy(&tape);
+        assert_eq!(eval.eval(&tape, &vs(0.5, 0.0)).unwrap().0, 0.5);
+        assert_eq!(eval.eval(&tape, &vs(3.0, 0.0)).unwrap().0, 3.0);
 
-        let next = shape.ez_simplify(&vec![Choice::Right].into()).unwrap();
-        let tape = next.ez_point_tape();
-        assert_eq!(eval.eval(&tape, 0.5, 0.0, 0.0).unwrap().0, 1.0);
-        assert_eq!(eval.eval(&tape, 3.0, 0.0, 0.0).unwrap().0, 1.0);
+        let next = shape
+            .simplify(
+                &vec![Choice::Right].into(),
+                Default::default(),
+                &mut Default::default(),
+            )
+            .unwrap();
+        let tape = next.point_tape(Default::default());
+        let vs = bind_xy(&tape);
+        assert_eq!(eval.eval(&tape, &vs(0.5, 0.0)).unwrap().0, 1.0);
+        assert_eq!(eval.eval(&tape, &vs(3.0, 0.0)).unwrap().0, 1.0);
     }
 
     pub fn test_basic() {
@@ -287,28 +336,31 @@ where
         let x = ctx.x();
         let y = ctx.y();
 
-        let shape = Shape::<F>::new(&mut ctx, x).unwrap();
-        let tape = shape.ez_point_tape();
-        let mut eval = Shape::<F>::new_point_eval();
-        assert_eq!(eval.eval(&tape, 1.0, 2.0, 0.0).unwrap().0, 1.0);
-        assert_eq!(eval.eval(&tape, 3.0, 4.0, 0.0).unwrap().0, 3.0);
+        let shape = F::new(&ctx, x).unwrap();
+        let tape = shape.point_tape(Default::default());
+        let vs = bind_xy(&tape);
+        let mut eval = F::new_point_eval();
+        assert_eq!(eval.eval(&tape, &vs(1.0, 2.0)).unwrap().0, 1.0);
+        assert_eq!(eval.eval(&tape, &vs(3.0, 4.0)).unwrap().0, 3.0);
 
-        let shape = Shape::<F>::new(&mut ctx, y).unwrap();
-        let tape = shape.ez_point_tape();
-        let mut eval = Shape::<F>::new_point_eval();
-        assert_eq!(eval.eval(&tape, 1.0, 2.0, 0.0).unwrap().0, 2.0);
-        assert_eq!(eval.eval(&tape, 3.0, 4.0, 0.0).unwrap().0, 4.0);
+        let shape = F::new(&ctx, y).unwrap();
+        let tape = shape.point_tape(Default::default());
+        let vs = bind_xy(&tape);
+        let mut eval = F::new_point_eval();
+        assert_eq!(eval.eval(&tape, &vs(1.0, 2.0)).unwrap().0, 2.0);
+        assert_eq!(eval.eval(&tape, &vs(3.0, 4.0)).unwrap().0, 4.0);
 
         let y2 = ctx.mul(y, 2.5).unwrap();
         let sum = ctx.add(x, y2).unwrap();
 
-        let shape = Shape::<F>::new(&mut ctx, sum).unwrap();
-        let tape = shape.ez_point_tape();
-        let mut eval = Shape::<F>::new_point_eval();
-        assert_eq!(eval.eval(&tape, 1.0, 2.0, 0.0).unwrap().0, 6.0);
+        let shape = F::new(&ctx, sum).unwrap();
+        let tape = shape.point_tape(Default::default());
+        let vs = bind_xy(&tape);
+        let mut eval = F::new_point_eval();
+        assert_eq!(eval.eval(&tape, &vs(1.0, 2.0)).unwrap().0, 6.0);
     }
 
-    pub fn test_p_var() {
+    pub fn test_p_shape_var() {
         let v = Var::new();
         let mut ctx = Context::new();
 
@@ -344,13 +396,14 @@ where
         let y: Vec<_> = x[1..].iter().chain(&x[0..1]).cloned().collect();
         let z: Vec<_> = x[2..].iter().chain(&x[0..2]).cloned().collect();
 
-        let shape = Shape::<F>::new(&mut ctx, node).unwrap();
-        let mut eval = Shape::<F>::new_point_eval();
-        let tape = shape.ez_point_tape();
+        let shape = F::new(&ctx, node).unwrap();
+        let mut eval = F::new_point_eval();
+        let tape = shape.point_tape(Default::default());
+        let vs = bind_xyz(&tape);
 
         let mut out = vec![];
         for i in 0..args.len() {
-            out.push(eval.eval(&tape, x[i], y[i], z[i]).unwrap().0);
+            out.push(eval.eval(&tape, &vs(x[i], y[i], z[i])).unwrap().0);
         }
 
         for (i, v) in out.iter().cloned().enumerate() {
@@ -387,7 +440,7 @@ where
     }
 
     pub fn test_p_stress() {
-        for n in [1, 2, 4, 8, 12, 16, 32] {
+        for n in [4, 8, 12, 16, 32] {
             Self::test_p_stress_n(n);
         }
     }
@@ -397,21 +450,15 @@ where
         let args = test_args();
 
         let mut ctx = Context::new();
-        for (i, v) in [ctx.x(), ctx.y(), ctx.z()].into_iter().enumerate() {
+        for v in [ctx.x(), ctx.y(), ctx.z(), ctx.var(Var::new())].into_iter() {
             let node = C::build(&mut ctx, v);
 
-            let shape = Shape::<F>::new(&mut ctx, node).unwrap();
-            let mut eval = Shape::<F>::new_point_eval();
-            let tape = shape.ez_point_tape();
+            let shape = F::new(&ctx, node).unwrap();
+            let mut eval = F::new_point_eval();
+            let tape = shape.point_tape(Default::default());
 
             for &a in args.iter() {
-                let (o, trace) = match i {
-                    0 => eval.eval(&tape, a, 0.0, 0.0),
-                    1 => eval.eval(&tape, 0.0, a, 0.0),
-                    2 => eval.eval(&tape, 0.0, 0.0, a),
-                    _ => unreachable!(),
-                }
-                .unwrap();
+                let (o, trace) = eval.eval(&tape, &[a]).unwrap();
                 assert!(trace.is_none());
                 let v = C::eval_f32(a);
                 let err = (v - o).abs();
@@ -447,44 +494,62 @@ where
         let args = test_args();
 
         let mut ctx = Context::new();
-        let xyz = [ctx.x(), ctx.y(), ctx.z()];
+        let va = Var::new();
+        let vb = Var::new();
+        let a = ctx.var(va);
+        let b = ctx.var(vb);
 
         let name = format!("{}(reg, reg)", C::NAME);
         for &lhs in args.iter() {
             for &rhs in args.iter() {
-                for (i, &u) in xyz.iter().enumerate() {
-                    for (j, &v) in xyz.iter().enumerate() {
-                        let node = C::build(&mut ctx, u, v);
+                let node = C::build(&mut ctx, a, b);
 
-                        let shape = Shape::<F>::new(&mut ctx, node).unwrap();
-                        let mut eval = Shape::<F>::new_point_eval();
-                        let tape = shape.ez_point_tape();
+                let shape = F::new(&ctx, node).unwrap();
+                let mut eval = F::new_point_eval();
+                let tape = shape.point_tape(Default::default());
+                let vars = tape.vars();
 
-                        let (out, _trace) = match (i, j) {
-                            (0, 0) => eval.eval(&tape, lhs, 0.0, 0.0),
-                            (0, 1) => eval.eval(&tape, lhs, rhs, 0.0),
-                            (0, 2) => eval.eval(&tape, lhs, 0.0, rhs),
-                            (1, 0) => eval.eval(&tape, rhs, lhs, 0.0),
-                            (1, 1) => eval.eval(&tape, 0.0, lhs, 0.0),
-                            (1, 2) => eval.eval(&tape, 0.0, lhs, rhs),
-                            (2, 0) => eval.eval(&tape, rhs, 0.0, lhs),
-                            (2, 1) => eval.eval(&tape, 0.0, rhs, lhs),
-                            (2, 2) => eval.eval(&tape, 0.0, 0.0, lhs),
-                            _ => unreachable!(),
-                        }
-                        .unwrap();
+                let i_index = vars[&va];
+                let j_index = vars[&vb];
+                assert_ne!(i_index, j_index);
 
-                        let rhs = if i == j { lhs } else { rhs };
-                        Self::compare_point_results::<C>(
-                            lhs,
-                            rhs,
-                            out,
-                            C::eval_reg_reg_f32,
-                            &name,
-                        );
-                    }
-                }
+                let mut args = [0.0; 2];
+                args[j_index] = rhs;
+                args[i_index] = lhs;
+
+                let (out, _trace) = eval.eval(&tape, &args).unwrap();
+
+                Self::compare_point_results::<C>(
+                    lhs,
+                    rhs,
+                    out,
+                    C::eval_reg_reg_f32,
+                    &name,
+                );
             }
+        }
+
+        for &lhs in args.iter() {
+            let node = C::build(&mut ctx, a, a);
+
+            let shape = F::new(&ctx, node).unwrap();
+            let mut eval = F::new_point_eval();
+            let tape = shape.point_tape(Default::default());
+            let vars = tape.vars();
+
+            let i_index = vars[&va];
+            assert_eq!(i_index, 0);
+
+            let args = [lhs];
+            let (out, _trace) = eval.eval(&tape, &args).unwrap();
+
+            Self::compare_point_results::<C>(
+                lhs,
+                lhs,
+                out,
+                C::eval_reg_reg_f32,
+                &name,
+            );
         }
     }
 
@@ -492,35 +557,28 @@ where
         let args = test_args();
 
         let mut ctx = Context::new();
-        let xyz = [ctx.x(), ctx.y(), ctx.z()];
+        let va = Var::new();
+        let a = ctx.var(va);
 
         let name = format!("{}(reg, imm)", C::NAME);
         for &lhs in args.iter() {
             for &rhs in args.iter() {
-                for (i, &u) in xyz.iter().enumerate() {
-                    let c = ctx.constant(rhs as f64);
-                    let node = C::build(&mut ctx, u, c);
+                let c = ctx.constant(rhs as f64);
+                let node = C::build(&mut ctx, a, c);
 
-                    let shape = Shape::<F>::new(&mut ctx, node).unwrap();
-                    let mut eval = Shape::<F>::new_point_eval();
-                    let tape = shape.ez_point_tape();
+                let shape = F::new(&ctx, node).unwrap();
+                let mut eval = F::new_point_eval();
+                let tape = shape.point_tape(Default::default());
 
-                    let (out, _trace) = match i {
-                        0 => eval.eval(&tape, lhs, 0.0, 0.0),
-                        1 => eval.eval(&tape, 0.0, lhs, 0.0),
-                        2 => eval.eval(&tape, 0.0, 0.0, lhs),
-                        _ => unreachable!(),
-                    }
-                    .unwrap();
+                let (out, _trace) = eval.eval(&tape, &[lhs]).unwrap();
 
-                    Self::compare_point_results::<C>(
-                        lhs,
-                        rhs,
-                        out,
-                        C::eval_reg_imm_f32,
-                        &name,
-                    );
-                }
+                Self::compare_point_results::<C>(
+                    lhs,
+                    rhs,
+                    out,
+                    C::eval_reg_imm_f32,
+                    &name,
+                );
             }
         }
     }
@@ -529,35 +587,28 @@ where
         let args = test_args();
 
         let mut ctx = Context::new();
-        let xyz = [ctx.x(), ctx.y(), ctx.z()];
+        let va = Var::new();
+        let a = ctx.var(va);
 
         let name = format!("{}(imm, reg)", C::NAME);
         for &lhs in args.iter() {
             for &rhs in args.iter() {
-                for (i, &u) in xyz.iter().enumerate() {
-                    let c = ctx.constant(lhs as f64);
-                    let node = C::build(&mut ctx, c, u);
+                let c = ctx.constant(lhs as f64);
+                let node = C::build(&mut ctx, c, a);
 
-                    let shape = Shape::<F>::new(&mut ctx, node).unwrap();
-                    let mut eval = Shape::<F>::new_point_eval();
-                    let tape = shape.ez_point_tape();
+                let shape = F::new(&ctx, node).unwrap();
+                let mut eval = F::new_point_eval();
+                let tape = shape.point_tape(Default::default());
 
-                    let (out, _trace) = match i {
-                        0 => eval.eval(&tape, rhs, 0.0, 0.0),
-                        1 => eval.eval(&tape, 0.0, rhs, 0.0),
-                        2 => eval.eval(&tape, 0.0, 0.0, rhs),
-                        _ => unreachable!(),
-                    }
-                    .unwrap();
+                let (out, _trace) = eval.eval(&tape, &[rhs]).unwrap();
 
-                    Self::compare_point_results::<C>(
-                        lhs,
-                        rhs,
-                        out,
-                        C::eval_imm_reg_f32,
-                        &name,
-                    );
-                }
+                Self::compare_point_results::<C>(
+                    lhs,
+                    rhs,
+                    out,
+                    C::eval_imm_reg_f32,
+                    &name,
+                );
             }
         }
     }
@@ -593,7 +644,7 @@ macro_rules! point_tests {
         $crate::point_test!(basic_interpreter, $t);
         $crate::point_test!(test_push, $t);
         $crate::point_test!(test_basic, $t);
-        $crate::point_test!(test_p_var, $t);
+        $crate::point_test!(test_p_shape_var, $t);
         $crate::point_test!(test_p_stress, $t);
 
         mod p_unary {

--- a/fidget/src/core/eval/test/point.rs
+++ b/fidget/src/core/eval/test/point.rs
@@ -301,10 +301,9 @@ where
         let min = ctx.min(x, 1.0).unwrap();
         let shape = F::new(&ctx, min).unwrap();
         let tape = shape.point_tape(Default::default());
-        let vs = bind_xy(&tape);
         let mut eval = F::new_point_eval();
-        assert_eq!(eval.eval(&tape, &vs(0.5, 0.0)).unwrap().0, 0.5);
-        assert_eq!(eval.eval(&tape, &vs(3.0, 0.0)).unwrap().0, 1.0);
+        assert_eq!(eval.eval(&tape, &[0.5]).unwrap().0, 0.5);
+        assert_eq!(eval.eval(&tape, &[3.0]).unwrap().0, 1.0);
 
         let next = shape
             .simplify(
@@ -314,9 +313,8 @@ where
             )
             .unwrap();
         let tape = next.point_tape(Default::default());
-        let vs = bind_xy(&tape);
-        assert_eq!(eval.eval(&tape, &vs(0.5, 0.0)).unwrap().0, 0.5);
-        assert_eq!(eval.eval(&tape, &vs(3.0, 0.0)).unwrap().0, 3.0);
+        assert_eq!(eval.eval(&tape, &[0.5]).unwrap().0, 0.5);
+        assert_eq!(eval.eval(&tape, &[3.0]).unwrap().0, 3.0);
 
         let next = shape
             .simplify(
@@ -326,9 +324,8 @@ where
             )
             .unwrap();
         let tape = next.point_tape(Default::default());
-        let vs = bind_xy(&tape);
-        assert_eq!(eval.eval(&tape, &vs(0.5, 0.0)).unwrap().0, 1.0);
-        assert_eq!(eval.eval(&tape, &vs(3.0, 0.0)).unwrap().0, 1.0);
+        assert_eq!(eval.eval(&tape, &[0.5]).unwrap().0, 1.0);
+        assert_eq!(eval.eval(&tape, &[3.0]).unwrap().0, 1.0);
     }
 
     pub fn test_basic() {
@@ -338,17 +335,15 @@ where
 
         let shape = F::new(&ctx, x).unwrap();
         let tape = shape.point_tape(Default::default());
-        let vs = bind_xy(&tape);
         let mut eval = F::new_point_eval();
-        assert_eq!(eval.eval(&tape, &vs(1.0, 2.0)).unwrap().0, 1.0);
-        assert_eq!(eval.eval(&tape, &vs(3.0, 4.0)).unwrap().0, 3.0);
+        assert_eq!(eval.eval(&tape, &[1.0]).unwrap().0, 1.0);
+        assert_eq!(eval.eval(&tape, &[3.0]).unwrap().0, 3.0);
 
         let shape = F::new(&ctx, y).unwrap();
         let tape = shape.point_tape(Default::default());
-        let vs = bind_xy(&tape);
         let mut eval = F::new_point_eval();
-        assert_eq!(eval.eval(&tape, &vs(1.0, 2.0)).unwrap().0, 2.0);
-        assert_eq!(eval.eval(&tape, &vs(3.0, 4.0)).unwrap().0, 4.0);
+        assert_eq!(eval.eval(&tape, &[2.0]).unwrap().0, 2.0);
+        assert_eq!(eval.eval(&tape, &[4.0]).unwrap().0, 4.0);
 
         let y2 = ctx.mul(y, 2.5).unwrap();
         let sum = ctx.add(x, y2).unwrap();

--- a/fidget/src/core/eval/tracing.rs
+++ b/fidget/src/core/eval/tracing.rs
@@ -51,7 +51,9 @@ pub trait TracingEvaluator: Default {
         vars: &[Self::Data],
         var_count: usize,
     ) -> Result<(), Error> {
-        if vars.len() != var_count {
+        if vars.len() < var_count {
+            // It's okay to be passed extra vars, because expressions may have
+            // been simplified.
             Err(Error::BadVarSlice(vars.len(), var_count))
         } else {
             Ok(())

--- a/fidget/src/core/mod.rs
+++ b/fidget/src/core/mod.rs
@@ -14,7 +14,7 @@
 //! let radius = ctx.add(x_squared, y_squared)?;
 //! let circle = ctx.sub(radius, 1.0)?;
 //!
-//! let shape = VmShape::new(&mut ctx, circle)?;
+//! let shape = VmShape::new(&ctx, circle)?;
 //! let mut eval = VmShape::new_point_eval();
 //! let tape = shape.ez_point_tape();
 //!

--- a/fidget/src/core/shape/mod.rs
+++ b/fidget/src/core/shape/mod.rs
@@ -16,7 +16,7 @@
 //!
 //! let mut ctx = Context::new();
 //! let x = ctx.x();
-//! let shape = VmShape::new(&mut ctx, x)?;
+//! let shape = VmShape::new(&ctx, x)?;
 //!
 //! // Let's build a single point evaluator:
 //! let mut eval = VmShape::new_point_eval();
@@ -318,7 +318,7 @@ impl<F: MathFunction> Shape<F> {
     }
 
     /// Builds a new shape from the given node with default (X, Y, Z) axes
-    pub fn new(ctx: &mut Context, node: Node) -> Result<Self, Error>
+    pub fn new(ctx: &Context, node: Node) -> Result<Self, Error>
     where
         Self: Sized,
     {
@@ -331,7 +331,7 @@ impl<F: MathFunction> From<Tree> for Shape<F> {
     fn from(t: Tree) -> Self {
         let mut ctx = Context::new();
         let node = ctx.import(&t);
-        Self::new(&mut ctx, node).unwrap()
+        Self::new(&ctx, node).unwrap()
     }
 }
 
@@ -625,7 +625,7 @@ mod test {
         let mut ctx = Context::new();
         let s = ctx.import(&s);
 
-        let s = VmShape::new(&mut ctx, s).unwrap();
+        let s = VmShape::new(&ctx, s).unwrap();
         let vs = s.inner().vars();
         assert_eq!(vs.len(), 3);
 

--- a/fidget/src/core/shape/mod.rs
+++ b/fidget/src/core/shape/mod.rs
@@ -451,28 +451,6 @@ where
 
         self.eval.eval(&tape.tape, &self.scratch)
     }
-
-    #[cfg(test)]
-    pub fn eval_x<J: Into<E::Data>>(
-        &mut self,
-        tape: &ShapeTape<E::Tape>,
-        x: J,
-    ) -> E::Data {
-        self.eval(tape, x.into(), E::Data::from(0.0), E::Data::from(0.0))
-            .unwrap()
-            .0
-    }
-    #[cfg(test)]
-    pub fn eval_xy<J: Into<E::Data>>(
-        &mut self,
-        tape: &ShapeTape<E::Tape>,
-        x: J,
-        y: J,
-    ) -> E::Data {
-        self.eval(tape, x.into(), y.into(), E::Data::from(0.0))
-            .unwrap()
-            .0
-    }
 }
 
 /// Wrapper around a [`BulkEvaluator`]

--- a/fidget/src/jit/aarch64/interval.rs
+++ b/fidget/src/jit/aarch64/interval.rs
@@ -76,7 +76,7 @@ use dynasmrt::{dynasm, DynasmApi};
 /// | 0x18     | `d9`         |                                             |
 /// | 0x10     | `d8`         |                                             |
 /// |----------|--------------|---------------------------------------------|
-/// | 0x8      | `sp` (`x30`) | Stack frame                                 |
+/// | 0x8      | `lr` (`x30`) | Link register                               |
 /// | 0x0      | `fp` (`x29`) | [current value for sp]                      |
 /// ```
 const STACK_SIZE: u32 = 0xf0;

--- a/fidget/src/jit/mod.rs
+++ b/fidget/src/jit/mod.rs
@@ -1001,6 +1001,7 @@ impl JitTracingEval {
                 &mut simplify,
             )
         };
+
         (
             out,
             if simplify != 0 {
@@ -1026,6 +1027,7 @@ impl TracingEvaluator for JitIntervalEval {
         tape: &Self::Tape,
         vars: &[Self::Data],
     ) -> Result<(Self::Data, Option<&Self::Trace>), Error> {
+        self.check_arguments(vars, tape.vars().len())?;
         Ok(self.0.eval(tape, vars))
     }
 }
@@ -1044,6 +1046,7 @@ impl TracingEvaluator for JitPointEval {
         tape: &Self::Tape,
         vars: &[Self::Data],
     ) -> Result<(Self::Data, Option<&Self::Trace>), Error> {
+        self.check_arguments(vars, tape.vars().len())?;
         Ok(self.0.eval(tape, vars))
     }
 }

--- a/fidget/src/mesh/octree.rs
+++ b/fidget/src/mesh/octree.rs
@@ -1587,9 +1587,9 @@ mod test {
     #[test]
     fn test_colonnade_manifold() {
         const COLONNADE: &str = include_str!("../../../models/colonnade.vm");
-        let (mut ctx, root) =
+        let (ctx, root) =
             crate::Context::from_text(COLONNADE.as_bytes()).unwrap();
-        let tape = VmShape::new(&mut ctx, root).unwrap();
+        let tape = VmShape::new(&ctx, root).unwrap();
         for threads in [1, 8] {
             let settings = Settings {
                 depth: 5,

--- a/fidget/src/render/render2d.rs
+++ b/fidget/src/render/render2d.rs
@@ -518,8 +518,8 @@ mod test {
     }
 
     fn check_hi<F: Function + MathFunction>() {
-        let (mut ctx, root) = Context::from_text(HI.as_bytes()).unwrap();
-        let shape = Shape::<F>::new(&mut ctx, root).unwrap();
+        let (ctx, root) = Context::from_text(HI.as_bytes()).unwrap();
+        let shape = Shape::<F>::new(&ctx, root).unwrap();
         const EXPECTED: &str = "
             .................X..............
             .................X..............
@@ -557,8 +557,8 @@ mod test {
     }
 
     fn check_hi_transformed<F: Function + MathFunction>() {
-        let (mut ctx, root) = Context::from_text(HI.as_bytes()).unwrap();
-        let shape = Shape::<F>::new(&mut ctx, root).unwrap();
+        let (ctx, root) = Context::from_text(HI.as_bytes()).unwrap();
+        let shape = Shape::<F>::new(&ctx, root).unwrap();
         let mut mat = nalgebra::Matrix4::<f32>::identity();
         mat.prepend_translation_mut(&nalgebra::Vector3::new(0.5, 0.5, 0.0));
         mat.prepend_scaling_mut(0.5);
@@ -600,8 +600,8 @@ mod test {
     }
 
     fn check_hi_bounded<F: Function + MathFunction>() {
-        let (mut ctx, root) = Context::from_text(HI.as_bytes()).unwrap();
-        let shape = Shape::<F>::new(&mut ctx, root).unwrap();
+        let (ctx, root) = Context::from_text(HI.as_bytes()).unwrap();
+        let shape = Shape::<F>::new(&ctx, root).unwrap();
         const EXPECTED: &str = "
             .XXX............................
             .XXX............................
@@ -646,8 +646,8 @@ mod test {
     }
 
     fn check_quarter<F: Function + MathFunction>() {
-        let (mut ctx, root) = Context::from_text(QUARTER.as_bytes()).unwrap();
-        let shape = Shape::<F>::new(&mut ctx, root).unwrap();
+        let (ctx, root) = Context::from_text(QUARTER.as_bytes()).unwrap();
+        let shape = Shape::<F>::new(&ctx, root).unwrap();
         const EXPECTED: &str = "
             ................................
             ................................

--- a/fidget/src/render/render3d.rs
+++ b/fidget/src/render/render3d.rs
@@ -456,7 +456,7 @@ mod test {
     fn test_tile_queues() {
         let mut ctx = Context::new();
         let x = ctx.x();
-        let shape = VmShape::new(&mut ctx, x).unwrap();
+        let shape = VmShape::new(&ctx, x).unwrap();
 
         let cfg = RenderConfig::<3> {
             image_size: 128, // very small!

--- a/wasm-demo/src/lib.rs
+++ b/wasm-demo/src/lib.rs
@@ -29,7 +29,7 @@ pub fn eval_script(s: &str) -> Result<JsTree, String> {
 pub fn serialize_into_tape(t: JsTree) -> Result<Vec<u8>, String> {
     let mut ctx = Context::new();
     let root = ctx.import(&t.0);
-    let shape = VmShape::new(&mut ctx, root).map_err(|e| format!("{e}"))?;
+    let shape = VmShape::new(&ctx, root).map_err(|e| format!("{e}"))?;
     let vm_data = shape.inner().data();
     let axes = shape.axes();
     bincode::serialize(&(vm_data, axes)).map_err(|e| format!("{e}"))


### PR DESCRIPTION
Previously, tests of the `Function` trait went through the `Shape` interface and checked all combinations of X, Y, Z arguments.  However, X/Y/Z are simply variables now, so we don't need to be so exhaustive (and can significantly speed up CI).