### PR TITLE
Switch to workspace deps; remove `num_derive`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,6 @@ dependencies = [
  "ieee754",
  "libc",
  "nalgebra",
- "num-derive",
  "num-traits",
  "ordered-float",
  "rand",
@@ -1541,17 +1540,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "num-derive"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,33 @@ opt-level = 1
 [profile.fast-test]
 inherits = "test"
 opt-level = 0
+
+[workspace.dependencies]
+anyhow = "1"
+arrayvec = "0.7"
+bimap = "0.6.3"
+bincode = "1.3.3"
+clap = { version = "4", features = ["derive"] }
+crossbeam-channel = "0.5"
+crossbeam-deque = "0.8"
+document-features = "0.2"
+dynasmrt = { version = "2.0" }
+eframe = { version = "0.27", default-features = false, features = [ "default_fonts", "glow"] }
+env_logger = "0.11.2"
+getrandom = { version = "0.2", features = ["js"] }
+ieee754 = "0.2"
+image = { version = "0.24", default-features = false, features = ["png"] }
+libc = "0.2"
+log = "0.4"
+nalgebra = "0.32"
+notify = "5.0"
+num-traits = "0.2"
+ordered-float = "3"
+rand = "0.8.5"
+rhai = { version = "1.17", features = ["sync"] }
+serde = { version = "1.0", features = ["derive", "rc"] }
+static_assertions = "1"
+thiserror = "1"
+wasm-bindgen = "0.2.92"
+wasm-bindgen-futures = "0.4"
+windows = { version = "0.54.0", features = ["Win32_Foundation", "Win32_System_Memory"] }

--- a/demos/cli/Cargo.toml
+++ b/demos/cli/Cargo.toml
@@ -4,14 +4,14 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-fidget = { path = "../../fidget", default-features = false, features = ["render", "mesh"] }
+anyhow.workspace = true
+clap.workspace = true
+env_logger.workspace = true
+image.workspace = true
+log.workspace = true
+nalgebra.workspace = true
 
-anyhow = "1"
-clap = { version = "4", features = ["derive"] }
-env_logger = "0.11.2"
-image = { version = "0.24", default-features = false, features = ["png"] }
-log = "0.4"
-nalgebra = "0.32"
+fidget = { path = "../../fidget", default-features = false, features = ["render", "mesh"] }
 workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 
 [features]

--- a/demos/constraints/Cargo.toml
+++ b/demos/constraints/Cargo.toml
@@ -4,18 +4,15 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0"
-eframe = { version = "0.27", default-features = false, features = [
-    "default_fonts", # Embed the default egui fonts.
-    "glow",          # Use the glow rendering backend. Alternative: "wgpu".
-] }
+anyhow.workspace = true
+eframe.workspace = true
+log.workspace = true
 
 fidget = { path = "../../fidget", default-features = false, features = ["solver"] }
-log = "0.4"
 workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-env_logger = "0.11.2"
+env_logger.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen-futures = "0.4"
+wasm-bindgen-futures.workspace = true

--- a/demos/viewer/Cargo.toml
+++ b/demos/viewer/Cargo.toml
@@ -4,22 +4,17 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0"
-clap = { version = "4.1.6", features = ["derive"] }
-crossbeam-channel = "0.5"
-eframe = { version = "0.27", default-features = false, features = [
-    #"accesskit",     # Make egui comptaible with screen readers. NOTE: adds a lot of dependencies.
-    "default_fonts", # Embed the default egui fonts.
-    "glow",          # Use the glow rendering backend. Alternative: "wgpu".
-    #"wgpu"
-] }
-env_logger = "0.11.2"
+anyhow.workspace = true
+clap.workspace = true
+crossbeam-channel.workspace = true
+eframe.workspace = true
+env_logger.workspace = true
+log.workspace = true
+nalgebra.workspace = true
+notify.workspace = true
+rhai.workspace = true
 
 fidget = { path = "../../fidget", default-features = false, features = ["render", "rhai"] }
-log = "0.4"
-nalgebra = "0.32"
-notify = "5.0"
-rhai = "1.10"
 workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 
 [features]

--- a/demos/web-editor/Cargo.lock
+++ b/demos/web-editor/Cargo.lock
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "fidget"
-version = "0.3.0"
+version = "0.3.2"
 dependencies = [
  "arrayvec",
  "bimap",
@@ -264,7 +264,6 @@ dependencies = [
  "getrandom",
  "ieee754",
  "nalgebra",
- "num-derive",
  "num-traits",
  "ordered-float",
  "rand",
@@ -401,17 +400,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "num-derive"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -921,6 +909,8 @@ name = "workspace-hack"
 version = "0.1.0"
 dependencies = [
  "ahash",
+ "anstream",
+ "approx",
  "bitflags",
  "bytemuck",
  "clap",
@@ -930,12 +920,14 @@ dependencies = [
  "libc",
  "log",
  "memchr",
+ "num-traits",
  "once_cell",
  "proc-macro2",
  "quote",
  "regex",
  "regex-automata",
  "serde",
+ "smallvec",
  "syn 1.0.109",
  "syn 2.0.59",
 ]

--- a/demos/web-editor/Cargo.toml
+++ b/demos/web-editor/Cargo.toml
@@ -8,9 +8,10 @@ crate-type = ["cdylib"]
 
 [dependencies]
 bincode = "1.3.3"
-fidget = {path = "../../fidget", default-features = false, features = ["rhai", "mesh", "render"]}
 wasm-bindgen = "0.2.92"
 nalgebra = "0.32"
+
+fidget = {path = "../../fidget", default-features = false, features = ["rhai", "mesh", "render"]}
 
 # Take advantage of feature unification to turn on wasm-bindgen here
 rhai = { version = "*", features = ["wasm-bindgen"] }

--- a/demos/web-editor/package-lock.json
+++ b/demos/web-editor/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "wasm-demo",
+  "name": "web-editor",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/fidget/Cargo.toml
+++ b/fidget/Cargo.toml
@@ -9,35 +9,35 @@ authors = ["Matt Keeter <matt.j.keeter@gmail.com"]
 readme = "../README.md"
 
 [dependencies]
-arrayvec = "0.7"
-bimap = "0.6.3"
-document-features = "0.2"
-ieee754 = "0.2"
-nalgebra = "0.32"
-num-derive = "0.3"
-num-traits = "0.2"
-ordered-float = "3"
-rand = "0.8.5"
-static_assertions = "1"
-thiserror = "1"
+arrayvec.workspace = true
+bimap.workspace = true
+document-features.workspace = true
+ieee754.workspace = true
+nalgebra.workspace = true
+num-traits.workspace = true
+ordered-float.workspace = true
+rand.workspace = true
+static_assertions.workspace = true
+thiserror.workspace = true
+serde.workspace = true
+
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
-serde = { version = "1.0", features = ["derive", "rc"] }
 
 # JIT
-dynasmrt = { version = "2.0", optional = true }
-libc = { version = "0.2", optional = true }
+dynasmrt = { workspace = true, optional = true }
+libc = { workspace = true, optional = true }
 
 # Rhai
-rhai = { version = "1.17", optional = true, features = ["sync"] }
+rhai = { workspace = true, optional = true }
 
 # Meshing
-crossbeam-deque = { version = "0.8", optional = true }
+crossbeam-deque = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.54.0", features = ["Win32_Foundation", "Win32_System_Memory"] }
+windows.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.2", features = ["js"] }
+getrandom.workspace = true
 
 [features]
 default = ["jit", "rhai", "render", "mesh", "solver"]


### PR DESCRIPTION
This makes it easier to update dependencies in a single place.

Closes #139