### PR TITLE
Add bulk outputs to Function type

### DIFF
--- a/fidget/src/core/eval/mod.rs
+++ b/fidget/src/core/eval/mod.rs
@@ -13,7 +13,7 @@ mod bulk;
 mod tracing;
 
 // Reexport a few types
-pub use bulk::BulkEvaluator;
+pub use bulk::{BulkEvaluator, BulkOutput};
 pub use tracing::TracingEvaluator;
 
 /// A tape represents something that can be evaluated by an evaluator

--- a/fidget/src/core/eval/test/float_slice.rs
+++ b/fidget/src/core/eval/test/float_slice.rs
@@ -34,7 +34,7 @@ impl<F: Function + MathFunction> TestFloatSlice<F> {
             let out = eval
                 .eval(&tape, &[[0.0, 1.0, 2.0, 3.0].as_slice()])
                 .unwrap();
-            assert_eq!(out, [0.0, 1.0, 2.0, 3.0]);
+            assert_eq!(&out[0], [0.0, 1.0, 2.0, 3.0]);
 
             // TODO: reuse tape data here
             let t = tape.recycle();
@@ -43,7 +43,7 @@ impl<F: Function + MathFunction> TestFloatSlice<F> {
             let out = eval
                 .eval(&tape, &[[0.0, 1.0, 2.0, 3.0].as_slice()])
                 .unwrap();
-            assert_eq!(out, [1.0, 2.0, 3.0, 4.0]);
+            assert_eq!(&out[0], [1.0, 2.0, 3.0, 4.0]);
         }
     }
 
@@ -58,7 +58,7 @@ impl<F: Function + MathFunction> TestFloatSlice<F> {
         let out = eval
             .eval(&tape, &[[0.0, 1.0, 2.0, 3.0].as_slice()])
             .unwrap();
-        assert_eq!(out, [0.0, 1.0, 2.0, 3.0]);
+        assert_eq!(&out[0], [0.0, 1.0, 2.0, 3.0]);
 
         let out = eval
             .eval(
@@ -66,7 +66,7 @@ impl<F: Function + MathFunction> TestFloatSlice<F> {
                 &[[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0].as_slice()],
             )
             .unwrap();
-        assert_eq!(out, [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]);
+        assert_eq!(&out[0], [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]);
 
         let out = eval
             .eval(
@@ -74,7 +74,7 @@ impl<F: Function + MathFunction> TestFloatSlice<F> {
                 &[[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0].as_slice()],
             )
             .unwrap();
-        assert_eq!(out, [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]);
+        assert_eq!(&out[0], [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]);
 
         let mul = ctx.mul(y, 2.0).unwrap();
         let shape = F::new(&ctx, mul).unwrap();
@@ -82,15 +82,15 @@ impl<F: Function + MathFunction> TestFloatSlice<F> {
         let out = eval
             .eval(&tape, &[[3.0, 2.0, 1.0, 0.0].as_slice()])
             .unwrap();
-        assert_eq!(out, [6.0, 4.0, 2.0, 0.0]);
+        assert_eq!(&out[0], [6.0, 4.0, 2.0, 0.0]);
 
         let out = eval.eval(&tape, &[[1.0, 4.0, 8.0].as_slice()]).unwrap();
-        assert_eq!(&out[0..3], &[2.0, 8.0, 16.0]);
+        assert_eq!(&out[0][0..3], &[2.0, 8.0, 16.0]);
 
         let out = eval
             .eval(&tape, &[[1.0, 4.0, 4.0, -1.0, -2.0, -3.0, 0.0].as_slice()])
             .unwrap();
-        assert_eq!(out, [2.0, 8.0, 8.0, -2.0, -4.0, -6.0, 0.0]);
+        assert_eq!(&out[0], [2.0, 8.0, 8.0, -2.0, -4.0, -6.0, 0.0]);
     }
 
     pub fn test_f_sin() {
@@ -104,7 +104,7 @@ impl<F: Function + MathFunction> TestFloatSlice<F> {
 
         let args = [0.0, 1.0, 2.0, std::f32::consts::PI / 2.0];
         assert_eq!(
-            eval.eval(&tape, &[args.as_slice()]).unwrap(),
+            &eval.eval(&tape, &[args.as_slice()]).unwrap()[0],
             args.map(f32::sin),
         );
     }
@@ -171,7 +171,7 @@ impl<F: Function + MathFunction> TestFloatSlice<F> {
         let vs = bind_xyz::<_, &[f32], &[f32]>(&tape);
         let out = eval.eval(&tape, &vs(&x, &y, &z)).unwrap();
 
-        for (i, v) in out.iter().cloned().enumerate() {
+        for (i, v) in out[0].iter().cloned().enumerate() {
             let q = ctx
                 .eval_xyz(node, x[i] as f64, y[i] as f64, z[i] as f64)
                 .unwrap();
@@ -195,7 +195,7 @@ impl<F: Function + MathFunction> TestFloatSlice<F> {
         let tape = shape.ez_float_slice_tape();
 
         let cmp = eval.eval(&tape, &x, &y, &z).unwrap();
-        for (i, (a, b)) in out.iter().zip(cmp.iter()).enumerate() {
+        for (i, (a, b)) in out[0].iter().zip(cmp.iter()).enumerate() {
             let err = (a - b).abs();
             assert!(
                 err < 1e-6,
@@ -227,7 +227,7 @@ impl<F: Function + MathFunction> TestFloatSlice<F> {
         let tape = shape.float_slice_tape(Default::default());
 
         let out = eval.eval(&tape, &[args.as_slice()]).unwrap();
-        for (a, &o) in args.iter().zip(out.iter()) {
+        for (a, &o) in args.iter().zip(out[0].iter()) {
             let v = C::eval_f32(*a);
             let err = (v - o).abs();
             assert!(
@@ -289,7 +289,7 @@ impl<F: Function + MathFunction> TestFloatSlice<F> {
             Self::compare_float_results::<C>(
                 &args,
                 &rgsa,
-                out,
+                &out[0],
                 C::eval_reg_reg_f32,
                 &name,
             );
@@ -315,11 +315,11 @@ impl<F: Function + MathFunction> TestFloatSlice<F> {
 
                 let out = eval.eval(&tape, &[args.as_slice()]).unwrap();
 
-                let rhs = vec![*rhs; out.len()];
+                let rhs = vec![*rhs; out[0].len()];
                 Self::compare_float_results::<C>(
                     &args,
                     &rhs,
-                    out,
+                    &out[0],
                     C::eval_reg_imm_f32,
                     &name,
                 );
@@ -346,11 +346,11 @@ impl<F: Function + MathFunction> TestFloatSlice<F> {
 
                 let out = eval.eval(&tape, &[args.as_slice()]).unwrap();
 
-                let lhs = vec![*lhs; out.len()];
+                let lhs = vec![*lhs; out[0].len()];
                 Self::compare_float_results::<C>(
                     &lhs,
                     &args,
-                    out,
+                    &out[0],
                     C::eval_imm_reg_f32,
                     &name,
                 );

--- a/fidget/src/core/eval/test/grad_slice.rs
+++ b/fidget/src/core/eval/test/grad_slice.rs
@@ -50,7 +50,7 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         }
 
         let mut eval = F::new_grad_slice_eval();
-        eval.eval(tape, &out).unwrap().to_owned()
+        eval.eval(tape, &out).unwrap()[0].to_owned()
     }
 
     pub fn test_g_x() {
@@ -402,7 +402,7 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
                 })
                 .collect::<Vec<Grad>>();
             let out = eval.eval(&tape, &[args.as_slice()]).unwrap();
-            for (a, &o) in args.iter().zip(out.iter()) {
+            for (a, &o) in args.iter().zip(out[0].iter()) {
                 let v = C::eval_f64(a.v as f64);
                 let err = (v as f32 - o.v).abs();
                 let err_frac = err / (v.abs() as f32).max(o.v.abs());

--- a/fidget/src/core/eval/test/symbolic_deriv.rs
+++ b/fidget/src/core/eval/test/symbolic_deriv.rs
@@ -35,7 +35,7 @@ impl TestSymbolicDerivs {
         // Check symbolic differentiation results
         let out_deriv =
             eval_deriv.eval(&tape_deriv, &[args.as_slice()]).unwrap();
-        for (v, (a, b)) in args.iter().zip(out.iter().zip(out_deriv)) {
+        for (v, (a, b)) in args.iter().zip(out[0].iter().zip(&out_deriv[0])) {
             let a = a.dx;
             let err = a - b;
             let err_frac = err / a.abs().max(b.abs());
@@ -104,7 +104,7 @@ impl TestSymbolicDerivs {
                 vs[ib] = rgsa.as_slice();
             }
             let out_a_deriv =
-                eval_deriv.eval(&tape_a_deriv, &vs).unwrap().to_vec();
+                eval_deriv.eval(&tape_a_deriv, &vs).unwrap()[0].to_vec();
 
             let mut vs = [args.as_slice(), args.as_slice()];
             if let Some(ia) = shape_b_deriv.vars().get(&va) {
@@ -113,10 +113,10 @@ impl TestSymbolicDerivs {
             if let Some(ib) = shape_b_deriv.vars().get(&vb) {
                 vs[ib] = rgsa.as_slice();
             }
-            let out_b_deriv = eval_deriv.eval(&tape_b_deriv, &vs).unwrap();
+            let out_b_deriv = &eval_deriv.eval(&tape_b_deriv, &vs).unwrap()[0];
 
-            for i in 0..out.len() {
-                let v = out[i];
+            for i in 0..out[0].len() {
+                let v = out[0][i];
                 let da = out_a_deriv[i];
 
                 let a = args[i];

--- a/fidget/src/core/shape/mod.rs
+++ b/fidget/src/core/shape/mod.rs
@@ -560,7 +560,8 @@ where
             }
         }
 
-        self.eval.eval(&tape.tape, &self.scratch)
+        let out = self.eval.eval(&tape.tape, &self.scratch)?;
+        Ok(out.borrow(0))
     }
 }
 

--- a/fidget/src/jit/aarch64/interval.rs
+++ b/fidget/src/jit/aarch64/interval.rs
@@ -13,12 +13,12 @@ use dynasmrt::{dynasm, DynasmApi};
 ///
 /// Registers as pased in as follows:
 ///
-/// | Variable   | Register   | Type                    |
-/// |------------|------------|-------------------------|
-/// | `vars`     | `x0`       | `*const (f32, f32)`     |
-/// | `choices`  | `x1`       | `*mut u8` (array)       |
-/// | `simplify` | `x2`       | `*mut u8` (single)      |
-/// | `output`   | `x3`       | `*mut (f32, f32)`       |
+/// | Variable   | Register   | Type                      |
+/// |------------|------------|---------------------------|
+/// | `vars`     | `x0`       | `*const (f32, f32)`       |
+/// | `choices`  | `x1`       | `*mut u8` (array)         |
+/// | `simplify` | `x2`       | `*mut u8` (single)        |
+/// | `output`   | `x3`       | `*mut (f32, f32)` (array) |
 ///
 /// During evaluation, `x0-2` maintain their meaning.  Intervals are stored in
 /// the lower two float of a SIMD register `Vx` `s[0]` is the lower bound of the
@@ -130,9 +130,9 @@ impl Assembler for IntervalAssembler {
     }
     /// Copies the register to the output
     fn build_output(&mut self, arg_reg: u8, output_index: u32) {
-        assert_eq!(output_index, 0);
+        assert!(output_index < 16384 / 8);
         dynasm!(self.0.ops
-            ; str D(reg(arg_reg)), [x3]
+            ; str D(reg(arg_reg)), [x3, output_index * 8]
         );
     }
     fn build_sin(&mut self, out_reg: u8, lhs_reg: u8) {

--- a/fidget/src/jit/aarch64/point.rs
+++ b/fidget/src/jit/aarch64/point.rs
@@ -17,7 +17,7 @@ use dynasmrt::{dynasm, DynasmApi};
 /// | `vars`     | `x0`     | `*const f32` (array)  |
 /// | `choices`  | `x1`     | `*mut u8` (array)     |
 /// | `simplify` | `x2`     | `*mut u8` (single)    |
-/// | `output`   | `x3`     | `*mut f32` (single)   |
+/// | `output`   | `x3`     | `*mut f32` (array)    |
 ///
 /// During evaluation, registers are identical.  In addition, we use the
 /// following registers during evaluation:
@@ -126,9 +126,9 @@ impl Assembler for PointAssembler {
     }
     /// Copies the register to the output
     fn build_output(&mut self, arg_reg: u8, output_index: u32) {
-        assert_eq!(output_index, 0);
+        assert!(output_index < 16384 / 4);
         dynasm!(self.0.ops
-            ; str S(reg(arg_reg)), [x3]
+            ; str S(reg(arg_reg)), [x3, output_index * 4]
         );
     }
     fn build_copy(&mut self, out_reg: u8, lhs_reg: u8) {

--- a/fidget/src/jit/x86_64/float_slice.rs
+++ b/fidget/src/jit/x86_64/float_slice.rs
@@ -13,7 +13,7 @@ pub const SIMD_WIDTH: usize = 8;
 /// | Argument | Register | Type                       |
 /// | ---------|----------|----------------------------|
 /// | vars     | `rdi`    | `*const *const [f32; 8]`   |
-/// | out      | `rsi`    | `*mut [f32; 8]`            |
+/// | out      | `rsi`    | `*const *mut [f32; 8]`     |
 /// | size     | `rdx`    | `u64`                      |
 ///
 /// The arrays must be an even multiple of 8 floats, since we're using AVX2 and
@@ -109,9 +109,10 @@ impl Assembler for FloatSliceAssembler {
     }
 
     fn build_output(&mut self, arg_reg: u8, out_index: u32) {
-        assert_eq!(out_index, 0);
+        let pos = 8 * i32::try_from(out_index).unwrap();
         dynasm!(self.0.ops
-            ; vmovups [rsi + rcx], Ry(reg(arg_reg))
+            ; mov r8, [rsi + pos]   // read the *mut float from the array
+            ; vmovups [r8 + rcx], Ry(reg(arg_reg))
         );
     }
 

--- a/fidget/src/jit/x86_64/interval.rs
+++ b/fidget/src/jit/x86_64/interval.rs
@@ -18,7 +18,7 @@ use dynasmrt::{dynasm, DynasmApi, DynasmLabelApi};
 /// | `vars`     | `rdi`    | `*const [f32; 2]`             |
 /// | `choices`  | `rsi`    | `*mut u8` (array)             |
 /// | `simplify` | `rdx`    | `*mut u8` (single)            |
-/// | `output`   | `rcx`    | `*mut [f32; 2]` (single)      |
+/// | `output`   | `rcx`    | `*mut [f32; 2]` (array)       |
 ///
 /// The stack is configured as follows
 ///
@@ -94,9 +94,9 @@ impl Assembler for IntervalAssembler {
         );
     }
     fn build_output(&mut self, arg_reg: u8, out_index: u32) {
-        assert_eq!(out_index, 0);
+        let pos = 8 * i32::try_from(out_index).unwrap();
         dynasm!(self.0.ops
-            ; vmovq [rcx], Rx(reg(arg_reg))
+            ; vmovq [rcx + pos], Rx(reg(arg_reg))
         );
     }
     fn build_sin(&mut self, out_reg: u8, lhs_reg: u8) {

--- a/fidget/src/jit/x86_64/point.rs
+++ b/fidget/src/jit/x86_64/point.rs
@@ -17,7 +17,7 @@ use dynasmrt::{dynasm, DynasmApi, DynasmLabelApi};
 /// | `vars`     | `rdi`    | `*const f32`          |
 /// | `choices`  | `rsi`    | `*mut u8` (array)     |
 /// | `simplify` | `rdx`    | `*mut u8` (single)    |
-/// | `output`   | `rcx`    | `*mut f32` (single)   |
+/// | `output`   | `rcx`    | `*mut f32` (array)    |
 ///
 /// The stack is configured as follows
 ///
@@ -93,9 +93,9 @@ impl Assembler for PointAssembler {
         );
     }
     fn build_output(&mut self, arg_reg: u8, out_index: u32) {
-        assert_eq!(out_index, 0);
+        let pos = 4 * i32::try_from(out_index).unwrap();
         dynasm!(self.0.ops
-            ; vmovss [rcx], Rx(reg(arg_reg))
+            ; vmovss [rcx + pos], Rx(reg(arg_reg))
         );
     }
     fn build_copy(&mut self, out_reg: u8, lhs_reg: u8) {

--- a/fidget/src/solver/mod.rs
+++ b/fidget/src/solver/mod.rs
@@ -135,9 +135,9 @@ impl<'a, F: Function> Solver<'a, F> {
 
             // Populate this row of the Jacobian
             for gi in 0..self.grad_index.len() {
-                *jacobian.get_mut((ti, gi)).unwrap() = out[gi / 3].d(gi % 3);
+                *jacobian.get_mut((ti, gi)).unwrap() = out[0][gi / 3].d(gi % 3);
             }
-            result[ti] = out[0].v;
+            result[ti] = out[0][0].v;
         }
         Ok(())
     }


### PR DESCRIPTION
Follow-up to #155, this changes our `Function` interface to support bulk outputs.

Having only 1 output is still hard-coded in other places, so we're not actually using bulk outputs yet; _gradatim._