### PR TITLE
Remove default binding of register 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
       multiple output nodes
     - Evaluation now returns a slice of outputs, one for each root node (ordered
       based on order in the `&[Node]` slice passed  to `MathFunction::new`)
+- `RegisterAllocator` no longer binds SSA register 0 to physical register 0 by
+  default. If you don't know what this means, don't worry about it.
 
 # 0.3.2
 - Added `impl IntoNode for Var`, to make handling `Var` values in a context

--- a/fidget/src/core/compiler/alloc.rs
+++ b/fidget/src/core/compiler/alloc.rs
@@ -47,12 +47,9 @@ pub struct RegisterAllocator<const N: usize> {
 
 impl<const N: usize> RegisterAllocator<N> {
     /// Builds a new `RegisterAllocator`.
-    ///
-    /// Upon construction, SSA register 0 is bound to local register 0; you
-    /// would be well advised to use it as the output of your function.
     pub fn new(size: usize) -> Self {
         assert!(N <= u8::MAX as usize);
-        let mut out = Self {
+        Self {
             allocations: vec![UNASSIGNED; size],
 
             registers: [UNASSIGNED; N],
@@ -62,9 +59,7 @@ impl<const N: usize> RegisterAllocator<N> {
             spare_memory: Vec::with_capacity(1024),
 
             out: RegTape::empty(),
-        };
-        out.bind_register(0, 0);
-        out
+        }
     }
 
     /// Build a new empty register allocator
@@ -93,7 +88,6 @@ impl<const N: usize> RegisterAllocator<N> {
         self.spare_memory.clear();
         self.out = tape;
         self.out.reset();
-        self.bind_register(0, 0);
     }
 
     /// Claims the internal `Vec<RegOp>`, leaving it empty

--- a/fidget/src/core/compiler/reg_tape.rs
+++ b/fidget/src/core/compiler/reg_tape.rs
@@ -27,18 +27,18 @@ impl RegTape {
         alloc.finalize()
     }
 
-    /// Builds a new empty tape, with one allocated slot
+    /// Builds a new empty tape
     pub(crate) fn empty() -> Self {
         Self {
             tape: vec![],
-            slot_count: 1,
+            slot_count: 0,
         }
     }
 
     /// Resets this tape, retaining its allocations
     pub fn reset(&mut self) {
         self.tape.clear();
-        self.slot_count = 1;
+        self.slot_count = 0;
     }
     /// Returns the number of unique register and memory locations that are used
     /// by this tape.


### PR DESCRIPTION
This is superfluous in a multi-output world