### PR TITLE
Remove `simplify_inner`

### DIFF
--- a/fidget/src/core/vm/mod.rs
+++ b/fidget/src/core/vm/mod.rs
@@ -116,15 +116,6 @@ impl<const N: usize> From<VmData<N>> for GenericVmFunction<N> {
 }
 
 impl<const N: usize> GenericVmFunction<N> {
-    pub(crate) fn simplify_inner(
-        &self,
-        choices: &[Choice],
-        storage: VmData<N>,
-        workspace: &mut VmWorkspace<N>,
-    ) -> Result<Self, Error> {
-        let d = self.0.simplify(choices, workspace, storage)?;
-        Ok(Self(Arc::new(d)))
-    }
     /// Returns a characteristic size (the length of the inner assembly tape)
     pub fn size(&self) -> usize {
         self.0.len()
@@ -175,7 +166,8 @@ impl<const N: usize> Function for GenericVmFunction<N> {
         storage: VmData<N>,
         workspace: &mut Self::Workspace,
     ) -> Result<Self, Error> {
-        self.simplify_inner(trace.as_slice(), storage, workspace)
+        let d = self.0.simplify(trace.as_slice(), workspace, storage)?;
+        Ok(Self(Arc::new(d)))
     }
 
     fn recycle(self) -> Option<Self::Storage> {

--- a/fidget/src/core/vm/mod.rs
+++ b/fidget/src/core/vm/mod.rs
@@ -162,8 +162,8 @@ impl<const N: usize> Function for GenericVmFunction<N> {
     type Trace = VmTrace;
     fn simplify(
         &self,
-        trace: &VmTrace,
-        storage: VmData<N>,
+        trace: &Self::Trace,
+        storage: Self::Storage,
         workspace: &mut Self::Workspace,
     ) -> Result<Self, Error> {
         let d = self.0.simplify(trace.as_slice(), workspace, storage)?;

--- a/fidget/src/jit/mod.rs
+++ b/fidget/src/jit/mod.rs
@@ -899,9 +899,7 @@ impl Function for JitFunction {
         storage: Self::Storage,
         workspace: &mut Self::Workspace,
     ) -> Result<Self, Error> {
-        self.0
-            .simplify_inner(trace.as_slice(), storage, workspace)
-            .map(JitFunction)
+        self.0.simplify(trace, storage, workspace).map(JitFunction)
     }
 
     fn recycle(self) -> Option<Self::Storage> {


### PR DESCRIPTION
This doesn't appear to be used anywhere else, so we can inline it into `simplify`