### PR TITLE
Remove fine-grained features

### DIFF
--- a/.github/workflows/check-wasm.yml
+++ b/.github/workflows/check-wasm.yml
@@ -26,6 +26,6 @@ jobs:
     - name: Check
       # cargo check doesn't find MIR diagnostics, so we use cargo build instead
       # (https://github.com/rust-lang/rust/issues/49292)
-      run: cargo build --target=${{ matrix.target }} -pfidget --no-default-features --features="rhai,render,mesh"
+      run: cargo build --target=${{ matrix.target }} -pfidget --no-default-features --features="rhai"
     - name: Clippy
-      run: cargo clippy --target=${{ matrix.target }} -pfidget --no-default-features --features="rhai,render,mesh"
+      run: cargo clippy --target=${{ matrix.target }} -pfidget --no-default-features --features="rhai"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
     - Remove `fidget::render::render2d/3d` from the public API, as they're
       equivalent to the functions on `ImageRenderConfig` / `VoxelRenderConfig`
 - Move `RenderHints` into `fidget::render`
+- Remove fine-grained features from `fidget` crate, because we aren't actually
+  testing the power-set of feature combinations in CI (and some were breaking!).
+  The only remaining features are `rhai`, `jit` and `eval-tests`.
 
 # 0.3.3
 - `Function` and evaluator types now produce multiple outputs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2939,7 +2939,6 @@ dependencies = [
  "regex",
  "regex-automata",
  "serde",
- "smallvec",
  "syn 2.0.48",
 ]
 

--- a/demos/cli/Cargo.toml
+++ b/demos/cli/Cargo.toml
@@ -12,7 +12,7 @@ image.workspace = true
 log.workspace = true
 nalgebra.workspace = true
 
-fidget = { path = "../../fidget", default-features = false, features = ["render", "mesh"] }
+fidget.path = "../../fidget"
 workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 
 [features]

--- a/demos/constraints/Cargo.toml
+++ b/demos/constraints/Cargo.toml
@@ -9,7 +9,7 @@ anyhow.workspace = true
 eframe.workspace = true
 log.workspace = true
 
-fidget = { path = "../../fidget", default-features = false, features = ["solver"] }
+fidget.path = "../../fidget"
 workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/demos/viewer/Cargo.toml
+++ b/demos/viewer/Cargo.toml
@@ -15,7 +15,7 @@ nalgebra.workspace = true
 notify.workspace = true
 rhai.workspace = true
 
-fidget = { path = "../../fidget", default-features = false, features = ["render", "rhai"] }
+fidget.path = "../../fidget"
 workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 
 [features]

--- a/demos/web-editor/crate/Cargo.lock
+++ b/demos/web-editor/crate/Cargo.lock
@@ -111,6 +111,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
@@ -138,8 +144,14 @@ checksum = "4da9a32f3fed317401fa3c862968128267c3106685286e15d5aaa3d7389c2f60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.59",
 ]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cfg-if"
@@ -178,7 +190,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -254,6 +266,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "dynasm"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33dc03612f42465a8ed7f5e354bc2b79ba54cedefa81d5bd3a064f1835adaba8"
+dependencies = [
+ "bitflags 1.3.2",
+ "byteorder",
+ "lazy_static",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "dynasmrt"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7dccc31a678058996aef614f6bd418ced384da70f284e83e2b7bf29b27b6a28"
+dependencies = [
+ "byteorder",
+ "dynasm",
+ "fnv",
+ "memmap2",
+]
+
+[[package]]
 name = "fidget"
 version = "0.3.4"
 dependencies = [
@@ -261,8 +300,10 @@ dependencies = [
  "bimap",
  "crossbeam-deque",
  "document-features",
+ "dynasmrt",
  "getrandom",
  "ieee754",
+ "libc",
  "nalgebra",
  "num-traits",
  "ordered-float",
@@ -285,6 +326,12 @@ dependencies = [
  "rhai",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "getrandom"
@@ -333,6 +380,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,6 +420,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
+name = "memmap2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "nalgebra"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,7 +452,7 @@ checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -457,6 +519,30 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -548,7 +634,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61797318be89b1a268a018a92a7657096d83f3ecb31418b9e9c16dcbb043b702"
 dependencies = [
  "ahash",
- "bitflags",
+ "bitflags 2.5.0",
  "getrandom",
  "instant",
  "num-traits",
@@ -567,7 +653,7 @@ checksum = "59aecf17969c04b9c0c5d21f6bc9da9fec9dd4980e64d1871443a476589d8c86"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -596,7 +682,7 @@ checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -643,6 +729,17 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a6531ffc7b071655e4ce2e04bd464c4830bb585a61cabb96cf808f05172615a"
@@ -675,7 +772,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -738,7 +835,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.59",
  "wasm-bindgen-shared",
 ]
 
@@ -760,7 +857,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.59",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -900,7 +997,7 @@ dependencies = [
  "ahash",
  "anstream",
  "approx",
- "bitflags",
+ "bitflags 2.5.0",
  "bytemuck",
  "clap",
  "clap_builder",
@@ -917,7 +1014,7 @@ dependencies = [
  "regex-automata",
  "serde",
  "smallvec",
- "syn",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -937,5 +1034,5 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.59",
 ]

--- a/demos/web-editor/crate/Cargo.toml
+++ b/demos/web-editor/crate/Cargo.toml
@@ -12,7 +12,7 @@ bincode = "1.3.3"
 wasm-bindgen = "0.2.92"
 nalgebra = "0.33"
 
-fidget = {path = "../../../fidget", default-features = false, features = ["rhai", "mesh", "render"]}
+fidget.path = "../../../fidget"
 
 # Take advantage of feature unification to turn on wasm-bindgen here
 rhai = { version = "*", features = ["wasm-bindgen"] }

--- a/fidget/Cargo.toml
+++ b/fidget/Cargo.toml
@@ -11,27 +11,24 @@ readme = "../README.md"
 [dependencies]
 arrayvec.workspace = true
 bimap.workspace = true
+crossbeam-deque.workspace = true
 document-features.workspace = true
 ieee754.workspace = true
 nalgebra.workspace = true
 num-traits.workspace = true
 ordered-float.workspace = true
 rand.workspace = true
+serde.workspace = true
 static_assertions.workspace = true
 thiserror.workspace = true
-serde.workspace = true
+
+rhai = { workspace = true, optional = true }
 
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 # JIT
 dynasmrt = { workspace = true, optional = true }
 libc = { workspace = true, optional = true }
-
-# Rhai
-rhai = { workspace = true, optional = true }
-
-# Meshing
-crossbeam-deque = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows.workspace = true
@@ -40,7 +37,7 @@ windows.workspace = true
 getrandom.workspace = true
 
 [features]
-default = ["jit", "rhai", "render", "mesh", "solver"]
+default = ["jit", "rhai"]
 
 ## Enables fast evaluation via a JIT compiler.  This is exposed in the
 ## [`fidget::jit`](crate::jit) module, and is supported on macOS, Linux, and
@@ -53,16 +50,6 @@ jit = ["dep:dynasmrt", "dep:libc"]
 ## Enable [Rhai](https://rhai.rs/) bindings, in the
 ## [`fidget::rhai`](crate::rhai) module
 rhai = ["dep:rhai"]
-
-## Enable 2D and 3D rendering, in the [`fidget::render`](crate::render) module
-render = []
-
-## Enable 3D meshing, in the [`fidget::mesh`](crate::mesh) module
-mesh = ["dep:crossbeam-deque"]
-
-## Enable a system-of-equations solver, in the [`fidget::solver`](crate::solver)
-## module
-solver = []
 
 ## Enable `eval-tests` if you're writing your own evaluators and want to
 ## unit-test them.  When enabled, the crate exports a set of macros to test each

--- a/fidget/build.rs
+++ b/fidget/build.rs
@@ -46,9 +46,7 @@ fn main() {
         }
     }
 
-    if std::env::var("CARGO_FEATURE_MESH").is_ok() {
-        build_mdc_table().unwrap();
-    }
+    build_mdc_table().unwrap();
 }
 
 /// Builds a table for Manifold Dual Contouring connectivity.

--- a/fidget/src/core/vm/mod.rs
+++ b/fidget/src/core/vm/mod.rs
@@ -6,15 +6,13 @@ use crate::{
         BulkEvaluator, BulkOutput, Function, MathFunction, Tape, Trace,
         TracingEvaluator,
     },
+    render::{RenderHints, TileSizes},
     shape::Shape,
     types::{Grad, Interval},
     var::VarMap,
     Context, Error,
 };
 use std::sync::Arc;
-
-#[cfg(feature = "render")]
-use crate::render::{RenderHints, TileSizes};
 
 mod choice;
 mod data;
@@ -192,7 +190,6 @@ impl<const N: usize> Function for GenericVmFunction<N> {
     }
 }
 
-#[cfg(feature = "render")]
 impl<const N: usize> RenderHints for GenericVmFunction<N> {
     fn tile_sizes_3d() -> TileSizes {
         TileSizes::new(&[256, 128, 64, 32, 16, 8]).unwrap()

--- a/fidget/src/error.rs
+++ b/fidget/src/error.rs
@@ -81,13 +81,13 @@ pub enum Error {
     #[error("tile size list must not be empty")]
     EmptyTileSizes,
 
-    #[cfg(feature = "rhai")]
     /// Rhai error; see inner code for details
+    #[cfg(feature = "rhai")]
     #[error("Rhai evaluation error: {0}")]
     RhaiParseError(#[from] rhai::ParseError),
 
-    #[cfg(feature = "rhai")]
     /// Rhai error; see inner code for details
+    #[cfg(feature = "rhai")]
     #[error("Rhai evaluation error: {0}")]
     RhaiEvalError(#[from] rhai::EvalAltResult),
 
@@ -97,7 +97,6 @@ pub enum Error {
     DynasmError(#[from] dynasmrt::DynasmError),
 }
 
-#[cfg(feature = "rhai")]
 impl From<Box<rhai::EvalAltResult>> for Error {
     fn from(e: Box<rhai::EvalAltResult>) -> Self {
         Error::RhaiEvalError(*e)

--- a/fidget/src/jit/mod.rs
+++ b/fidget/src/jit/mod.rs
@@ -31,14 +31,12 @@ use crate::{
         TracingEvaluator,
     },
     jit::mmap::Mmap,
+    render::{RenderHints, TileSizes},
     types::{Grad, Interval},
     var::VarMap,
     vm::{Choice, GenericVmFunction, VmData, VmTrace, VmWorkspace},
     Error,
 };
-
-#[cfg(feature = "render")]
-use crate::render::{RenderHints, TileSizes};
 
 use dynasmrt::{
     components::PatchLoc, dynasm, AssemblyOffset, DynamicLabel, DynasmApi,
@@ -924,7 +922,6 @@ impl Function for JitFunction {
     }
 }
 
-#[cfg(feature = "render")]
 impl RenderHints for JitFunction {
     fn tile_sizes_3d() -> TileSizes {
         TileSizes::new(&[64, 16, 8]).unwrap()

--- a/fidget/src/lib.rs
+++ b/fidget/src/lib.rs
@@ -271,18 +271,10 @@ pub use crate::core::*;
 
 mod error;
 pub use error::Error;
-
-#[cfg(feature = "render")]
+pub mod mesh;
 pub mod render;
-
-#[cfg(feature = "rhai")]
 pub mod rhai;
+pub mod solver;
 
 #[cfg(all(feature = "jit", not(target_arch = "wasm32")))]
 pub mod jit;
-
-#[cfg(feature = "mesh")]
-pub mod mesh;
-
-#[cfg(feature = "solver")]
-pub mod solver;

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -27,7 +27,6 @@ once_cell = { version = "1" }
 regex = { version = "1", default-features = false, features = ["perf", "std"] }
 regex-automata = { version = "0.4", default-features = false, features = ["dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal"] }
 serde = { version = "1", features = ["alloc", "derive", "rc"] }
-smallvec = { version = "1", default-features = false, features = ["const_new", "union"] }
 
 [build-dependencies]
 getrandom = { version = "0.2", default-features = false, features = ["std"] }


### PR DESCRIPTION
We aren't automatically testing the power-set of features in CI, so it may be possible for users to create invalid combinations.  The crate isn't particularly large; let's just remove the fine-grained features.