### PR TITLE
Fix a typo, workaround 1, add typos config

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,27 @@
+# See the configuration reference at
+# https://github.com/crate-ci/typos/blob/master/docs/reference.md
+
+# Corrections take the form of a key/value pair. The key is the incorrect word
+# and the value is the correct word. If the key and value are the same, the
+# word is treated as always correct. If the value is an empty string, the word
+# is treated as always incorrect.
+
+# Match Identifier - Case Sensitive
+[default.extend-identifiers]
+ba = "ba"
+iy = "iy"
+
+# Match Inside a Word - Case Insensitive
+[default.extend-words]
+leafs = "leafs"
+subtile = "subtile"
+
+[files]
+# Include .github, .cargo, etc.
+ignore-hidden = false
+extend-exclude = [
+    "/models",
+    # /.git isn't in .gitignore, because git never tracks it.
+    # Typos doesn't know that, though.
+    "/.git"
+]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,7 +225,7 @@ fn intersection(a, b) {
 - Move `Interval` and `Grad` to `fidget::types` module, instead of
   `fidget::eval::types`.
 - Fix an edge case in meshing where nearly-planar surfaces could produce
-  vertexes far from the desired position.
+  vertices far from the desired position.
 - Add the `modulo` (Euclidean remainder) operation
 - Add logical operations (`and`, `or`, `not`), which can be used to build
   pseudo-conditionals which are simplified by the `TracingEvaluator`.

--- a/demos/README.md
+++ b/demos/README.md
@@ -3,9 +3,9 @@
 
 Bitmap rendering and meshing from the command line
 ```shell
-$ cargo run -pfidget-cli --release -- -i models/prospero.vm render2d -s512 --eval=vm -oout.png
+$ cargo run -pfidget-cli --release -- -i models/prospero.vm render2d -s 512 --eval=vm -o out.png
     Finished release [optimized + debuginfo] target(s) in 0.07s
-     Running `target/release/fidget-cli -i models/prospero.vm render2d -s512 --eval=vm -oout.png`
+     Running `target/release/fidget-cli -i models/prospero.vm render2d -s 512 --eval=vm -o out.png`
 [2024-06-06T16:08:12Z INFO  fidget_cli] Loaded file in 4.528208ms
 [2024-06-06T16:08:12Z INFO  fidget_cli] Built shape in 2.375208ms
 [2024-06-06T16:08:12Z INFO  fidget_cli] Rendered 1x at 14.489 ms/frame


### PR DESCRIPTION
With this, you can run `typos` and have it report a clean state.

We could add CI to validate this in the future.