### PR TITLE
Add `vars` to `Function`; split `VmFunction/Tape`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@
   `z` vary but each variable has a constant value across the whole slice).  Add
   `ShapeBulkEval::eval_vs` if `x`, `y`, `z` and variables are _all_ changing
   through the slices.
+- Add a new `GenericVmTape<N>` type, and use it for VM evaluation.  Previously,
+  the `GenericVmFunction<N>` type implemented both `Tape` and `Function`.
+- Add `vars()` to `Function` trait, because there are cases where we want to get
+  the variable map without building a tape (and it must always be the same).
 
 # 0.3.3
 - `Function` and evaluator types now produce multiple outputs

--- a/fidget/src/core/eval/mod.rs
+++ b/fidget/src/core/eval/mod.rs
@@ -31,6 +31,9 @@ pub trait Tape {
     fn recycle(self) -> Self::Storage;
 
     /// Returns a mapping from [`Var`](crate::var::Var) to evaluation index
+    ///
+    /// This must be identical to [`Function::vars`] on the `Function` which
+    /// produced this tape.
     fn vars(&self) -> &VarMap;
 
     /// Returns the number of outputs written by this tape
@@ -63,6 +66,10 @@ impl<T: Copy + Clone + Default> Trace for Vec<T> {
 ///
 /// It is mostly agnostic to _how_ that something is represented; we simply
 /// require that it can generate evaluators of various kinds.
+///
+/// Inputs to the function should be represented as [`Var`](crate::var::Var)
+/// values; the [`vars()`](Function::vars) function returns the mapping from
+/// `Var` to position in the input slice.
 ///
 /// Functions are shared between threads, so they should be cheap to clone.  In
 /// most cases, they're a thin wrapper around an `Arc<..>`.
@@ -177,6 +184,9 @@ pub trait Function: Send + Sync + Clone {
     /// This is underspecified and only used for unit testing; for tape-based
     /// functions, it's typically the length of the tape,
     fn size(&self) -> usize;
+
+    /// Returns the map from [`Var`](crate::var::Var) to input index
+    fn vars(&self) -> &VarMap;
 }
 
 /// A [`Function`] which can be built from a math expression

--- a/fidget/src/core/eval/test/symbolic_deriv.rs
+++ b/fidget/src/core/eval/test/symbolic_deriv.rs
@@ -1,7 +1,7 @@
 use super::{test_args, CanonicalBinaryOp, CanonicalUnaryOp};
 use crate::{
     context::Context,
-    eval::{BulkEvaluator, Function, MathFunction, Tape},
+    eval::{BulkEvaluator, Function, MathFunction},
     types::Grad,
     var::Var,
     vm::VmFunction,

--- a/fidget/src/jit/mod.rs
+++ b/fidget/src/jit/mod.rs
@@ -920,6 +920,10 @@ impl Function for JitFunction {
     fn size(&self) -> usize {
         self.0.size()
     }
+
+    fn vars(&self) -> &VarMap {
+        self.0.vars()
+    }
 }
 
 impl RenderHints for JitFunction {


### PR DESCRIPTION
We want to be able to get `vars` from a `Function` without building a tape.  However, upon adding it to `trait Function`, there's ambiguity about whether to call `Function::vars` or `Tape::vars` on a `GenericVmFunction`, which implements both traits.  To fix this ambiguity, we add a new `GenericVmTape` type.