### PR TITLE
Fix mmap soundness bug (not user-visible)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
   the `GenericVmFunction<N>` type implemented both `Tape` and `Function`.
 - Add `vars()` to `Function` trait, because there are cases where we want to get
   the variable map without building a tape (and it must always be the same).
+- Fix soundness bug in `Mmap` (probably not user-visible)
 
 # 0.3.3
 - `Function` and evaluator types now produce multiple outputs


### PR DESCRIPTION
It was previously to create an uninitialized slice by calling `Mmap::new(0).as_slice()`.

The `Mmap` type isn't exported to users, but it's the principle of the thing!

Also, none of our unit tests actually wrote more than 4K to a single `Mmap`, so I added a unit test to do that.