### PR TITLE
Allow missing docs in test module

### DIFF
--- a/fidget/src/core/eval/mod.rs
+++ b/fidget/src/core/eval/mod.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 
 #[cfg(any(test, feature = "eval-tests"))]
+#[allow(missing_docs)]
 pub mod test;
 
 mod bulk;


### PR DESCRIPTION
This suppresses warnings with newer `rustc` versions