### PR TITLE
Update `View2` and `View3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
     - `ThreadCount` is moved to `fidget::mesh`, because that's the only place
       it's now used
         - The plan is to switch to Rayon for meshing as well, eventually
+- Tweak `View2` and `View3` APIs to make them more useful as camera types
 
 # 0.3.3
 - `Function` and evaluator types now produce multiple outputs

--- a/demos/viewer/src/main.rs
+++ b/demos/viewer/src/main.rs
@@ -642,8 +642,9 @@ impl eframe::App for ViewerApp {
                     rect.height() as u32,
                 );
 
-                let mat = view.world_to_model() * image_size.screen_to_world();
                 if let Some(pos) = r.interact_pointer_pos() {
+                    let mat =
+                        view.world_to_model() * image_size.screen_to_world();
                     let pos = mat.transform_point(&Point2::new(pos.x, pos.y));
                     if let Some(prev) = *drag_start {
                         view.translate(prev - pos);
@@ -657,9 +658,10 @@ impl eframe::App for ViewerApp {
 
                 if r.hovered() {
                     let scroll = ctx.input(|i| i.smooth_scroll_delta.y);
-                    let mouse_pos = ctx
-                        .input(|i| i.pointer.hover_pos())
-                        .map(|p| mat.transform_point(&Point2::new(p.x, p.y)));
+                    let mouse_pos =
+                        ctx.input(|i| i.pointer.hover_pos()).map(|p| {
+                            image_size.transform_point(Point2::new(p.x, p.y))
+                        });
                     if scroll != 0.0 {
                         view.zoom((scroll / 100.0).exp2(), mouse_pos);
                         render_changed = true;
@@ -677,10 +679,8 @@ impl eframe::App for ViewerApp {
 
                 if let Some(pos) = r.interact_pointer_pos() {
                     let pos_world = image_size
-                        .screen_to_world()
-                        .transform_point(&Point3::new(pos.x, pos.y, 0.0));
-                    let pos_model =
-                        view.world_to_model().transform_point(&pos_world);
+                        .transform_point(Point3::new(pos.x, pos.y, 0.0));
+                    let pos_model = view.transform_point(&pos_world);
                     match *drag_start {
                         Some(Drag3D::Pan(prev)) => {
                             view.translate(prev - pos_model);
@@ -706,12 +706,11 @@ impl eframe::App for ViewerApp {
                 }
 
                 if r.hovered() {
-                    let mat =
-                        view.world_to_model() * image_size.screen_to_world();
                     let scroll = ctx.input(|i| i.smooth_scroll_delta.y);
                     let mouse_pos =
                         ctx.input(|i| i.pointer.hover_pos()).map(|p| {
-                            mat.transform_point(&Point3::new(p.x, p.y, 0.0))
+                            image_size
+                                .transform_point(Point3::new(p.x, p.y, 0.0))
                         });
                     if scroll != 0.0 {
                         view.zoom((scroll / 100.0).exp2(), mouse_pos);

--- a/demos/viewer/src/main.rs
+++ b/demos/viewer/src/main.rs
@@ -343,7 +343,7 @@ enum Mode3D {
 
 #[derive(Copy, Clone)]
 enum Drag3D {
-    Pan(Point3<f32>),
+    Pan(fidget::render::TranslateHandle),
     Rotate(fidget::render::RotateHandle),
 }
 
@@ -678,23 +678,23 @@ impl eframe::App for ViewerApp {
                 if let Some(pos) = r.interact_pointer_pos() {
                     let pos_world = image_size
                         .transform_point(Point3::new(pos.x, pos.y, 0.0));
-                    let pos_model = view.transform_point(&pos_world);
                     match *drag_start {
                         Some(Drag3D::Pan(prev)) => {
-                            view.translate(prev - pos_model);
-                            render_changed |= prev != pos_model;
+                            render_changed |= view.translate(prev, pos_world);
                         }
                         Some(Drag3D::Rotate(prev)) => {
-                            render_changed |= view.rotate(prev, pos_world.xy());
+                            render_changed |= view.rotate(prev, pos_world);
                         }
                         None => {
                             if r.dragged_by(egui::PointerButton::Primary) {
-                                *drag_start = Some(Drag3D::Pan(pos_model));
+                                *drag_start = Some(Drag3D::Pan(
+                                    view.begin_translate(pos_world),
+                                ));
                             } else if r
                                 .dragged_by(egui::PointerButton::Secondary)
                             {
                                 *drag_start = Some(Drag3D::Rotate(
-                                    view.begin_rotate(pos_world.xy()),
+                                    view.begin_rotate(pos_world),
                                 ));
                             }
                         }

--- a/demos/viewer/src/main.rs
+++ b/demos/viewer/src/main.rs
@@ -658,14 +658,12 @@ impl eframe::App for ViewerApp {
 
                 if r.hovered() {
                     let scroll = ctx.input(|i| i.smooth_scroll_delta.y);
-                    let mouse_pos =
-                        ctx.input(|i| i.pointer.hover_pos()).map(|p| {
-                            image_size.transform_point(Point2::new(p.x, p.y))
-                        });
-                    if scroll != 0.0 {
+                    let mouse_pos = r.hover_pos().map(|p| {
+                        let p = p - rect.min;
+                        image_size.transform_point(Point2::new(p.x, p.y))
+                    });
+                    render_changed |=
                         view.zoom((scroll / 100.0).exp2(), mouse_pos);
-                        render_changed = true;
-                    }
                 }
             }
             RenderMode::ThreeD {
@@ -709,6 +707,7 @@ impl eframe::App for ViewerApp {
                     let scroll = ctx.input(|i| i.smooth_scroll_delta.y);
                     let mouse_pos =
                         ctx.input(|i| i.pointer.hover_pos()).map(|p| {
+                            let p = p - rect.min;
                             image_size
                                 .transform_point(Point3::new(p.x, p.y, 0.0))
                         });

--- a/demos/viewer/src/main.rs
+++ b/demos/viewer/src/main.rs
@@ -211,7 +211,7 @@ fn render<F: fidget::eval::Function + fidget::render::RenderHints>(
                 image_size: fidget::render::VoxelSize::new(
                     image_size.width(),
                     image_size.height(),
-                    image_size.width().max(image_size.height()) as u32,
+                    image_size.width().max(image_size.height()),
                 ),
                 tile_sizes: F::tile_sizes_3d(),
                 view: *view,

--- a/fidget/src/render/mod.rs
+++ b/fidget/src/render/mod.rs
@@ -18,7 +18,7 @@ mod view;
 use config::Tile;
 pub use config::{ImageRenderConfig, ThreadPool, VoxelRenderConfig};
 pub use region::{ImageSize, RegionSize, VoxelSize};
-pub use view::{RotateHandle, View2, View3};
+pub use view::{RotateHandle, TranslateHandle, View2, View3};
 
 use render2d::render as render2d;
 use render3d::render as render3d;

--- a/fidget/src/render/mod.rs
+++ b/fidget/src/render/mod.rs
@@ -18,7 +18,7 @@ mod view;
 use config::Tile;
 pub use config::{ImageRenderConfig, ThreadPool, VoxelRenderConfig};
 pub use region::{ImageSize, RegionSize, VoxelSize};
-pub use view::{View2, View3};
+pub use view::{RotateHandle, View2, View3};
 
 use render2d::render as render2d;
 use render3d::render as render3d;

--- a/fidget/src/render/region.rs
+++ b/fidget/src/render/region.rs
@@ -1,6 +1,6 @@
 use nalgebra::{
     allocator::Allocator, Const, DefaultAllocator, DimNameAdd, DimNameSub,
-    DimNameSum, OMatrix, OVector, Vector2, Vector3, U1,
+    DimNameSum, OMatrix, OVector, Point2, Point3, Vector2, Vector3, U1,
 };
 
 /// Image size in pixels, used to generate a screen-to-world matrix
@@ -133,6 +133,11 @@ impl ImageSize {
             size: Vector2::new(width, height),
         }
     }
+
+    /// Transforms a point from screen to world coordinates
+    pub fn transform_point(&self, p: Point2<f32>) -> Point2<f32> {
+        self.screen_to_world().transform_point(&p)
+    }
 }
 
 /// Size for 3D rendering of an image
@@ -148,6 +153,11 @@ impl VoxelSize {
     /// Returns the depth of the image (in voxels)
     pub fn depth(&self) -> u32 {
         self.size.z
+    }
+
+    /// Transforms a point from screen to world coordinates
+    pub fn transform_point(&self, p: Point3<f32>) -> Point3<f32> {
+        self.screen_to_world().transform_point(&p)
     }
 }
 

--- a/fidget/src/render/view.rs
+++ b/fidget/src/render/view.rs
@@ -86,7 +86,9 @@ impl View2 {
     }
 
     /// Zooms the camera about a particular position (in world space)
-    pub fn zoom(&mut self, amount: f32, pos: Option<Point2<f32>>) {
+    ///
+    /// Returns `true` if the view has changed, `false` otherwise
+    pub fn zoom(&mut self, amount: f32, pos: Option<Point2<f32>>) -> bool {
         match pos {
             Some(before) => {
                 let pos_before = self.transform_point(&before);
@@ -99,6 +101,7 @@ impl View2 {
                 self.mat.append_scaling_mut(amount);
             }
         }
+        amount != 1.0
     }
 }
 
@@ -165,8 +168,10 @@ impl View3 {
         self.center += dt;
     }
 
-    /// Zooms the camera about a particular position (in screen space)
-    pub fn zoom(&mut self, amount: f32, pos: Option<Point3<f32>>) {
+    /// Zooms the camera about a particular position (in world space)
+    ///
+    /// Returns `true` if the view has changed, `false` otherwise
+    pub fn zoom(&mut self, amount: f32, pos: Option<Point3<f32>>) -> bool {
         match pos {
             Some(before) => {
                 let pos_before = self.transform_point(&before);
@@ -178,6 +183,7 @@ impl View3 {
                 self.scale *= amount;
             }
         }
+        amount != 1.0
     }
 
     /// Begins a rotation operation, given a point in world space

--- a/fidget/src/render/view.rs
+++ b/fidget/src/render/view.rs
@@ -215,12 +215,16 @@ pub struct RotateHandle {
     initial_pitch: f32,
 }
 
+/// Eyeballed for pleasant UI
+const ROTATE_SPEED: f32 = 2.0;
+
 impl RotateHandle {
     fn yaw(&self, x: f32) -> f32 {
-        (self.initial_yaw + (self.start.x - x) * 2.0) % std::f32::consts::TAU
+        (self.initial_yaw + (self.start.x - x) * ROTATE_SPEED)
+            % std::f32::consts::TAU
     }
     fn pitch(&self, y: f32) -> f32 {
-        (self.initial_pitch + (y - self.start.y) * 2.0)
+        (self.initial_pitch + (y - self.start.y) * ROTATE_SPEED)
             .clamp(0.0, std::f32::consts::PI)
     }
 }

--- a/fidget/src/render/view.rs
+++ b/fidget/src/render/view.rs
@@ -81,19 +81,19 @@ impl View2 {
 
     /// Applies a translation (in model units) to the current camera position
     pub fn translate(&mut self, dt: Vector2<f32>) {
+        // TODO make this world space for consistency?
         self.mat.append_translation_mut(&dt.into());
     }
 
-    /// Zooms the camera about a particular position (in model space)
+    /// Zooms the camera about a particular position (in world space)
     pub fn zoom(&mut self, amount: f32, pos: Option<Point2<f32>>) {
         match pos {
             Some(before) => {
-                // Convert to world space before scaling
-                let p = self.mat.inverse_transform_point(&before);
+                let pos_before = self.transform_point(&before);
                 self.mat.append_scaling_mut(amount);
-                let pos_after = self.transform_point(&p);
+                let pos_after = self.transform_point(&before);
                 self.mat
-                    .append_translation_mut(&(before - pos_after).into());
+                    .append_translation_mut(&(pos_before - pos_after).into());
             }
             None => {
                 self.mat.append_scaling_mut(amount);
@@ -161,22 +161,18 @@ impl View3 {
 
     /// Applies a translation (in model units) to the current camera position
     pub fn translate(&mut self, dt: Vector3<f32>) {
+        // TODO for consistency, make this screen units?
         self.center += dt;
     }
 
-    /// Zooms the camera about a particular position (in model space)
+    /// Zooms the camera about a particular position (in screen space)
     pub fn zoom(&mut self, amount: f32, pos: Option<Point3<f32>>) {
         match pos {
             Some(before) => {
-                // Convert to world space before scaling
-                let p = self
-                    .world_to_model()
-                    .try_inverse()
-                    .unwrap()
-                    .transform_point(&before);
+                let pos_before = self.transform_point(&before);
                 self.scale *= amount;
-                let pos_after = self.transform_point(&p);
-                self.center += before - pos_after;
+                let pos_after = self.transform_point(&before);
+                self.center += pos_before - pos_after;
             }
             None => {
                 self.scale *= amount;

--- a/fidget/src/render/view.rs
+++ b/fidget/src/render/view.rs
@@ -74,6 +74,7 @@ impl View2 {
     pub fn world_to_model(&self) -> Matrix3<f32> {
         self.mat.into()
     }
+
     /// Transform a point from world to model space
     pub fn transform_point(&self, p: &Point2<f32>) -> Point2<f32> {
         self.mat.transform_point(p)

--- a/fidget/src/render/view.rs
+++ b/fidget/src/render/view.rs
@@ -184,10 +184,43 @@ impl View3 {
         }
     }
 
-    /// Rotates the camera, given a start and end drag (in world space)
-    pub fn rotate(&mut self, start: Point2<f32>, end: Point2<f32>) {
-        let d = end - start;
-        self.yaw = d.x;
-        self.pitch = d.y;
+    /// Begins a rotation operation, given a point in world space
+    pub fn begin_rotate(&self, start: Point2<f32>) -> RotateHandle {
+        RotateHandle {
+            start,
+            initial_yaw: self.yaw,
+            initial_pitch: self.pitch,
+        }
+    }
+
+    /// Rotates the camera, given a cursor end position in world space
+    ///
+    /// Returns `true` if the view has changed, `false` otherwise
+    pub fn rotate(&mut self, h: RotateHandle, pos: Point2<f32>) -> bool {
+        let next_yaw = h.yaw(pos.x);
+        let next_pitch = h.pitch(pos.y);
+        let changed = (next_yaw != self.yaw) || (next_pitch != self.pitch);
+        self.yaw = next_yaw;
+        self.pitch = next_pitch;
+        changed
+    }
+}
+
+/// Handle to perform rotations on a [`View3`]
+#[derive(Copy, Clone)]
+pub struct RotateHandle {
+    /// Position of the initial click in world space
+    start: Point2<f32>,
+    initial_yaw: f32,
+    initial_pitch: f32,
+}
+
+impl RotateHandle {
+    fn yaw(&self, x: f32) -> f32 {
+        (self.initial_yaw + (self.start.x - x) * 2.0) % std::f32::consts::TAU
+    }
+    fn pitch(&self, y: f32) -> f32 {
+        (self.initial_pitch + (y - self.start.y) * 2.0)
+            .clamp(0.0, std::f32::consts::PI)
     }
 }


### PR DESCRIPTION
This PR makes `View2` and `View3` more useful as camera types, and implements proper 3D rendering in the `fidget-viewer` demo app.