### PR TITLE
add `npm run deploy` target

### DIFF
--- a/demos/web-editor/web/package.json
+++ b/demos/web-editor/web/package.json
@@ -2,10 +2,11 @@
   "scripts": {
     "build-wasm": "cd ../crate && wasm-pack build --target web --release",
     "build-web": "webpack --mode production",
-    "build-static": "cp src/index.html serve.json dist/",
+    "build-static": "sed \"s/VERSION/$(git log --pretty=format:'%h' -n 1)/g;s/MOD/$(git diff --quiet --exit-code || echo +)/g\" src/index.html > dist/index.html && grep 'Header add' ../README.md > dist/.htaccess",
     "dist": "npm run build-wasm && npm run build-web && npm run build-static",
-    "serve": "npm run dist && serve -c serve.json dist",
-    "format": "prettier . --write"
+    "serve": "npm run dist && serve -c ../serve.json dist",
+    "format": "prettier . --write",
+    "deploy": "rm dist/* && npm run dist && rsync -avz --delete -e ssh ./dist/ mkeeter@mattkeeter.com:mattkeeter.com/projects/fidget/demo"
   },
   "dependencies": {
     "@lezer/lr": "^1.0.0",

--- a/demos/web-editor/web/src/index.html
+++ b/demos/web-editor/web/src/index.html
@@ -39,6 +39,9 @@
         flex: 50%;
         max-width: calc(min(100%, 512px));
       }
+      div#version {
+        font-family: monospace;
+      }
     </style>
   </head>
   <body>
@@ -56,6 +59,13 @@
           <option value="heightmap">3D (heightmap)</option>
         </select>
       </div>
+    </div>
+    <div id="version">
+        <p>
+          <a href="https://github.com/mkeeter/fidget">Github</a> |
+          <a href="https://mattkeeter.com/projects/fidget">Writeup</a>
+        <p>Version: <a href="https://github.com/mkeeter/fidget/commit/VERSION">
+        VERSIONMOD</a>
     </div>
     <script src="index.js"></script>
   </body>

--- a/demos/web-editor/web/src/index.html
+++ b/demos/web-editor/web/src/index.html
@@ -61,11 +61,17 @@
       </div>
     </div>
     <div id="version">
-        <p>
-          <a href="https://github.com/mkeeter/fidget">Github</a> |
-          <a href="https://mattkeeter.com/projects/fidget">Writeup</a>
-        <p>Version: <a href="https://github.com/mkeeter/fidget/commit/VERSION">
-        VERSIONMOD</a>
+      <p>
+        <a href="https://github.com/mkeeter/fidget">Github</a> |
+        <a href="https://mattkeeter.com/projects/fidget">Writeup</a>
+      </p>
+
+      <p>
+        Version:
+        <a href="https://github.com/mkeeter/fidget/commit/VERSION">
+          VERSIONMOD</a
+        >
+      </p>
     </div>
     <script src="index.js"></script>
   </body>


### PR DESCRIPTION
This only works for folks with SSH access to my website, i.e. me.

Perhaps in the future we could deploy with a Github action!