### PR TITLE
Make rendering cancelleable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Make `translate` and `rotate` functions borrow their respective handle,
   instead of taking it by value.
 - Fix docstring for `AndRegImm`, `AndRegReg`, `OrRegImm`, and `OrRegReg`
+- Add `cancel: CancelToken` to 2D and 3D rendering configuration objects; this
+  is a shared `Arc<AtomicBool>` which can be used to stop rendering.  The
+  returned type is now an `Option<...>`, where `None` indicates that rendering
+  was cancelled.
 
 # 0.3.4
 - Add `GenericVmFunction::simplify_with` to simultaneously simplify a function

--- a/demos/cli/src/main.rs
+++ b/demos/cli/src/main.rs
@@ -144,7 +144,7 @@ fn run3d<F: fidget::eval::Function + fidget::render::RenderHints>(
     let mut depth = vec![];
     let mut color = vec![];
     for _ in 0..settings.n {
-        (depth, color) = cfg.run(shape.clone());
+        (depth, color) = cfg.run(shape.clone()).unwrap();
     }
 
     let out = if mode_color {
@@ -234,8 +234,9 @@ fn run2d<F: fidget::eval::Function + fidget::render::RenderHints>(
         if sdf {
             let mut image = vec![];
             for _ in 0..settings.n {
-                image =
-                    cfg.run::<_, fidget::render::SdfRenderMode>(shape.clone());
+                image = cfg
+                    .run::<_, fidget::render::SdfRenderMode>(shape.clone())
+                    .unwrap();
             }
             image
                 .into_iter()
@@ -245,7 +246,8 @@ fn run2d<F: fidget::eval::Function + fidget::render::RenderHints>(
             let mut image = vec![];
             for _ in 0..settings.n {
                 image = cfg
-                    .run::<_, fidget::render::DebugRenderMode>(shape.clone());
+                    .run::<_, fidget::render::DebugRenderMode>(shape.clone())
+                    .unwrap();
             }
             image
                 .into_iter()

--- a/demos/viewer/src/main.rs
+++ b/demos/viewer/src/main.rs
@@ -175,8 +175,9 @@ fn render<F: fidget::eval::Function + fidget::render::RenderHints>(
 
             match mode {
                 Mode2D::Color => {
-                    let image =
-                        config.run::<_, fidget::render::BitRenderMode>(shape);
+                    let image = config
+                        .run::<_, fidget::render::BitRenderMode>(shape)
+                        .unwrap();
                     let c = egui::Color32::from_rgba_unmultiplied(
                         color[0],
                         color[1],
@@ -191,16 +192,18 @@ fn render<F: fidget::eval::Function + fidget::render::RenderHints>(
                 }
 
                 Mode2D::Sdf => {
-                    let image =
-                        config.run::<_, fidget::render::SdfRenderMode>(shape);
+                    let image = config
+                        .run::<_, fidget::render::SdfRenderMode>(shape)
+                        .unwrap();
                     for (p, i) in pixels.iter_mut().zip(&image) {
                         *p = egui::Color32::from_rgb(i[0], i[1], i[2]);
                     }
                 }
 
                 Mode2D::Debug => {
-                    let image =
-                        config.run::<_, fidget::render::DebugRenderMode>(shape);
+                    let image = config
+                        .run::<_, fidget::render::DebugRenderMode>(shape)
+                        .unwrap();
                     for (p, i) in pixels.iter_mut().zip(&image) {
                         let c = i.as_debug_color();
                         *p = egui::Color32::from_rgb(c[0], c[1], c[2]);
@@ -220,7 +223,7 @@ fn render<F: fidget::eval::Function + fidget::render::RenderHints>(
                 view: *view,
                 ..Default::default()
             };
-            let (depth, color) = config.run(shape);
+            let (depth, color) = config.run(shape).unwrap();
             match mode {
                 Mode3D::Color => {
                     for (p, (&d, &c)) in

--- a/demos/web-editor/crate/src/lib.rs
+++ b/demos/web-editor/crate/src/lib.rs
@@ -272,11 +272,6 @@ impl JsCancelToken {
     pub unsafe fn from_ptr(ptr: *const std::sync::atomic::AtomicBool) -> Self {
         Self(CancelToken::from_raw(ptr))
     }
-
-    #[wasm_bindgen]
-    pub fn is_cancelled(&self) -> bool {
-        self.0.is_cancelled()
-    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/demos/web-editor/crate/src/lib.rs
+++ b/demos/web-editor/crate/src/lib.rs
@@ -134,7 +134,7 @@ fn render_3d_inner(
     let cfg = VoxelRenderConfig {
         image_size: VoxelSize::from(image_size as u32),
         threads: Some(ThreadPool::Global),
-        tile_sizes: TileSizes::new(&[64, 32, 16, 8]).unwrap(),
+        tile_sizes: TileSizes::new(&[128, 64, 32, 16, 8]).unwrap(),
         view,
         cancel,
     };

--- a/demos/web-editor/web/src/index.ts
+++ b/demos/web-editor/web/src/index.ts
@@ -15,7 +15,6 @@ import {
   ScriptRequest,
   ScriptResponse,
   StartRequest,
-  CancelTestRequest,
   ShapeRequest,
   WorkerRequest,
   WorkerResponse,
@@ -183,15 +182,6 @@ class App {
         // Once the worker has started, do an initial render
         const text = this.editor.view.state.doc.toString();
         this.onScriptChanged(text);
-
-        let cancel_token = new fidget.JsCancelToken();
-        console.log("cancel:");
-        console.log(cancel_token);
-        console.log(cancel_token.is_cancelled());
-        let ptr = cancel_token.get_ptr();
-        console.log(ptr);
-        cancel_token.cancel();
-        this.worker.postMessage(new CancelTestRequest(ptr));
         break;
       }
       case ResponseKind.Image: {

--- a/demos/web-editor/web/src/message.ts
+++ b/demos/web-editor/web/src/message.ts
@@ -5,7 +5,6 @@ export enum RequestKind {
   Start,
   Script,
   Shape,
-  CancelTest,
 }
 
 export class ScriptRequest {
@@ -55,21 +54,10 @@ export class StartRequest {
   }
 }
 
-export class CancelTestRequest {
-  kind: RequestKind.CancelTest;
-  token_ptr: number;
-
-  constructor(ptr: number) {
-    this.token_ptr = ptr;
-    this.kind = RequestKind.CancelTest;
-  }
-}
-
 export type WorkerRequest =
   | StartRequest
   | ScriptRequest
-  | ShapeRequest
-  | CancelTestRequest;
+  | ShapeRequest;
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/demos/web-editor/web/src/message.ts
+++ b/demos/web-editor/web/src/message.ts
@@ -2,9 +2,10 @@ import * as fidget from "../../crate/pkg/fidget_wasm_demo";
 import { Camera } from "./camera";
 
 export enum RequestKind {
-  Script,
   Start,
+  Script,
   Shape,
+  CancelTest,
 }
 
 export class ScriptRequest {
@@ -44,7 +45,31 @@ export class ShapeRequest {
   }
 }
 
-export type WorkerRequest = ScriptRequest | ShapeRequest;
+export class StartRequest {
+  kind: RequestKind.Start;
+  init: object;
+
+  constructor(init: object) {
+    this.init = init;
+    this.kind = RequestKind.Start;
+  }
+}
+
+export class CancelTestRequest {
+  kind: RequestKind.CancelTest;
+  token_ptr: number;
+
+  constructor(ptr: number) {
+    this.token_ptr = ptr;
+    this.kind = RequestKind.CancelTest;
+  }
+}
+
+export type WorkerRequest =
+  | StartRequest
+  | ScriptRequest
+  | ShapeRequest
+  | CancelTestRequest;
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/demos/web-editor/web/src/message.ts
+++ b/demos/web-editor/web/src/message.ts
@@ -23,24 +23,27 @@ export enum RenderMode {
   Normals,
 }
 
-export class ShapeRequest {
+export class RenderRequest {
   kind: RequestKind.Shape;
   tape: Uint8Array;
   camera: Uint8Array;
   depth: number;
   mode: RenderMode;
+  cancel_token_ptr: number; // pointer
 
   constructor(
     tape: Uint8Array,
     camera: Camera,
     depth: number,
     mode: RenderMode,
+    cancel_token_ptr: number,
   ) {
     this.tape = tape;
     this.kind = RequestKind.Shape;
     this.camera = camera.camera.serialize();
     this.depth = depth;
     this.mode = mode;
+    this.cancel_token_ptr = cancel_token_ptr;
   }
 }
 
@@ -54,10 +57,7 @@ export class StartRequest {
   }
 }
 
-export type WorkerRequest =
-  | StartRequest
-  | ScriptRequest
-  | ShapeRequest;
+export type WorkerRequest = StartRequest | ScriptRequest | RenderRequest;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -65,6 +65,7 @@ export enum ResponseKind {
   Started,
   Script,
   Image,
+  Cancelled,
 }
 
 export class StartedResponse {
@@ -99,4 +100,16 @@ export class ImageResponse {
   }
 }
 
-export type WorkerResponse = StartedResponse | ScriptResponse | ImageResponse;
+export class CancelledResponse {
+  kind: ResponseKind.Cancelled;
+
+  constructor() {
+    this.kind = ResponseKind.Cancelled;
+  }
+}
+
+export type WorkerResponse =
+  | StartedResponse
+  | ScriptResponse
+  | ImageResponse
+  | CancelledResponse;

--- a/demos/web-editor/web/src/worker.ts
+++ b/demos/web-editor/web/src/worker.ts
@@ -1,6 +1,5 @@
 import {
   ImageResponse,
-  CancelTestRequest,
   RenderMode,
   RequestKind,
   StartRequest,
@@ -83,16 +82,6 @@ async function run() {
       }
       case RequestKind.Script: {
         worker!.run(req as ScriptRequest);
-        break;
-      }
-      case RequestKind.CancelTest: {
-        let token = fidget.JsCancelToken.from_ptr(
-          (req as CancelTestRequest).token_ptr,
-        );
-        console.log("NEW TOKEN");
-        console.log((req as CancelTestRequest).token_ptr);
-        console.log(token);
-        console.log(token.is_cancelled());
         break;
       }
       default:

--- a/demos/web-editor/web/src/worker.ts
+++ b/demos/web-editor/web/src/worker.ts
@@ -67,12 +67,11 @@ class Worker {
 
 async function run() {
   let worker = new Worker();
-  onmessage = async function (e: any) {
+  onmessage = function (e: any) {
     let req = e.data as WorkerRequest;
     switch (req.kind) {
       case RequestKind.Start: {
         fidget.initSync((req as StartRequest).init);
-        await fidget.initThreadPool(navigator.hardwareConcurrency);
         postMessage(new StartedResponse());
         break;
       }

--- a/fidget/src/lib.rs
+++ b/fidget/src/lib.rs
@@ -221,7 +221,7 @@
 //!     ..Default::default()
 //! };
 //! let shape = VmShape::from(tree);
-//! let out = cfg.run::<_, BitRenderMode>(shape);
+//! let out = cfg.run::<_, BitRenderMode>(shape).unwrap();
 //! let mut iter = out.iter();
 //! for y in 0..cfg.image_size.height() {
 //!     for x in 0..cfg.image_size.width() {

--- a/fidget/src/render/config.rs
+++ b/fidget/src/render/config.rs
@@ -39,7 +39,7 @@ impl CancelToken {
     }
 
     /// Check if the token is cancelled
-    pub fn is_cancelled(&self) -> bool {
+    pub(crate) fn is_cancelled(&self) -> bool {
         self.0.load(Ordering::Relaxed)
     }
 

--- a/fidget/src/render/config.rs
+++ b/fidget/src/render/config.rs
@@ -6,6 +6,10 @@ use crate::{
     shape::{Shape, ShapeVars},
 };
 use nalgebra::{Const, Matrix3, Matrix4, OPoint, Point2, Vector2};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 
 /// Thread pool to use for multithreaded rendering
 ///
@@ -17,6 +21,27 @@ pub enum ThreadPool<'a> {
     Custom(&'a rayon::ThreadPool),
     /// Global Rayon pool
     Global,
+}
+
+/// Token to cancel an in-progress operation
+#[derive(Clone, Default)]
+pub struct CancelToken(Arc<AtomicBool>);
+
+impl CancelToken {
+    /// Build a new token, which is not cancelled
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Mark this token as cancelled
+    pub fn cancel(&self) {
+        self.0.store(true, Ordering::Relaxed);
+    }
+
+    /// Check if the token is cancelled
+    pub(crate) fn is_cancelled(&self) -> bool {
+        self.0.load(Ordering::Relaxed)
+    }
 }
 
 /// Settings for 2D rendering
@@ -39,6 +64,9 @@ pub struct ImageRenderConfig<'a> {
     /// If this is `None`, then rendering is done in a single thread; otherwise,
     /// the provided pool is used.
     pub threads: Option<ThreadPool<'a>>,
+
+    /// Token to cancel rendering
+    pub cancel: CancelToken,
 }
 
 impl Default for ImageRenderConfig<'_> {
@@ -48,6 +76,7 @@ impl Default for ImageRenderConfig<'_> {
             tile_sizes: TileSizes::new(&[128, 32, 8]).unwrap(),
             view: View2::default(),
             threads: Some(ThreadPool::Global),
+            cancel: CancelToken::new(),
         }
     }
 }
@@ -65,6 +94,9 @@ impl RenderConfig for ImageRenderConfig<'_> {
     fn tile_sizes(&self) -> &TileSizes {
         &self.tile_sizes
     }
+    fn is_cancelled(&self) -> bool {
+        self.cancel.is_cancelled()
+    }
 }
 
 impl ImageRenderConfig<'_> {
@@ -72,7 +104,7 @@ impl ImageRenderConfig<'_> {
     pub fn run<F: Function, M: RenderMode + Sync>(
         &self,
         shape: Shape<F>,
-    ) -> Vec<<M as RenderMode>::Output> {
+    ) -> Option<Vec<<M as RenderMode>::Output>> {
         self.run_with_vars::<F, M>(shape, &ShapeVars::new())
     }
 
@@ -81,7 +113,7 @@ impl ImageRenderConfig<'_> {
         &self,
         shape: Shape<F>,
         vars: &ShapeVars<f32>,
-    ) -> Vec<<M as RenderMode>::Output> {
+    ) -> Option<Vec<<M as RenderMode>::Output>> {
         crate::render::render2d::<F, M>(shape, vars, self)
     }
 
@@ -115,6 +147,9 @@ pub struct VoxelRenderConfig<'a> {
     /// If this is `None`, then rendering is done in a single thread; otherwise,
     /// the provided pool is used.
     pub threads: Option<ThreadPool<'a>>,
+
+    /// Token to cancel rendering
+    pub cancel: CancelToken,
 }
 
 impl Default for VoxelRenderConfig<'_> {
@@ -125,6 +160,7 @@ impl Default for VoxelRenderConfig<'_> {
             view: View3::default(),
 
             threads: Some(ThreadPool::Global),
+            cancel: CancelToken::new(),
         }
     }
 }
@@ -142,25 +178,29 @@ impl RenderConfig for VoxelRenderConfig<'_> {
     fn tile_sizes(&self) -> &TileSizes {
         &self.tile_sizes
     }
+    fn is_cancelled(&self) -> bool {
+        self.cancel.is_cancelled()
+    }
 }
 
 impl VoxelRenderConfig<'_> {
     /// Render a shape in 3D using this configuration
     ///
-    /// Returns a tuple of heightmap, RGB image.
+    /// Returns a tuple of `(heightmap, RGB image)` or `None` if rendering was
+    /// cancelled.
     pub fn run<F: Function>(
         &self,
         shape: Shape<F>,
-    ) -> (Vec<u32>, Vec<[u8; 3]>) {
+    ) -> Option<(Vec<u32>, Vec<[u8; 3]>)> {
         self.run_with_vars::<F>(shape, &ShapeVars::new())
     }
 
-    /// Render a shape in 2D using this configuration and variables
+    /// Render a shape in 3D using this configuration and variables
     pub fn run_with_vars<F: Function>(
         &self,
         shape: Shape<F>,
         vars: &ShapeVars<f32>,
-    ) -> (Vec<u32>, Vec<[u8; 3]>) {
+    ) -> Option<(Vec<u32>, Vec<[u8; 3]>)> {
         crate::render::render3d::<F>(shape, vars, self)
     }
 

--- a/fidget/src/render/config.rs
+++ b/fidget/src/render/config.rs
@@ -39,8 +39,25 @@ impl CancelToken {
     }
 
     /// Check if the token is cancelled
-    pub(crate) fn is_cancelled(&self) -> bool {
+    pub fn is_cancelled(&self) -> bool {
         self.0.load(Ordering::Relaxed)
+    }
+
+    /// Returns a raw pointer to the inner flag
+    ///
+    /// To avoid a memory leak the pointer must be converted back to an
+    /// `CancelToken` using [`CancelToken::from_raw`].
+    pub fn into_raw(self) -> *const AtomicBool {
+        Arc::into_raw(self.0)
+    }
+
+    /// Reclaims a pointer released by [`CancelToken::into_raw`]
+    ///
+    /// # Safety
+    /// The pointer must have been previously returned by a call to
+    /// [`CancelToken::into_raw`].
+    pub unsafe fn from_raw(ptr: *const AtomicBool) -> Self {
+        Self(Arc::from_raw(ptr))
     }
 }
 

--- a/fidget/src/render/config.rs
+++ b/fidget/src/render/config.rs
@@ -50,7 +50,8 @@ impl CancelToken {
     /// a web worker.
     ///
     /// To avoid a memory leak, the pointer must be converted back to a
-    /// `CancelToken` using [`CancelToken::from_raw`].
+    /// `CancelToken` using [`CancelToken::from_raw`].  In the meantime, users
+    /// should refrain from writing to the raw pointer.
     #[doc(hidden)]
     pub fn into_raw(self) -> *const AtomicBool {
         Arc::into_raw(self.0)

--- a/fidget/src/render/config.rs
+++ b/fidget/src/render/config.rs
@@ -28,7 +28,7 @@ pub enum ThreadPool<'a> {
 pub struct CancelToken(Arc<AtomicBool>);
 
 impl CancelToken {
-    /// Build a new token, which is not cancelled
+    /// Build a new token, which is initialize as "not cancelled"
     pub fn new() -> Self {
         Self::default()
     }
@@ -45,17 +45,23 @@ impl CancelToken {
 
     /// Returns a raw pointer to the inner flag
     ///
-    /// To avoid a memory leak the pointer must be converted back to an
+    /// This is used in shared memory environments where the `CancelToken`
+    /// itself cannot be passed between threads, i.e. to send a cancel token to
+    /// a web worker.
+    ///
+    /// To avoid a memory leak, the pointer must be converted back to a
     /// `CancelToken` using [`CancelToken::from_raw`].
+    #[doc(hidden)]
     pub fn into_raw(self) -> *const AtomicBool {
         Arc::into_raw(self.0)
     }
 
-    /// Reclaims a pointer released by [`CancelToken::into_raw`]
+    /// Reclaims a released cancel token pointer
     ///
     /// # Safety
     /// The pointer must have been previously returned by a call to
     /// [`CancelToken::into_raw`].
+    #[doc(hidden)]
     pub unsafe fn from_raw(ptr: *const AtomicBool) -> Self {
         Self(Arc::from_raw(ptr))
     }

--- a/fidget/src/render/mod.rs
+++ b/fidget/src/render/mod.rs
@@ -16,7 +16,9 @@ mod render3d;
 mod view;
 
 use config::Tile;
-pub use config::{ImageRenderConfig, ThreadPool, VoxelRenderConfig};
+pub use config::{
+    CancelToken, ImageRenderConfig, ThreadPool, VoxelRenderConfig,
+};
 pub use region::{ImageSize, RegionSize, VoxelSize};
 pub use view::{RotateHandle, TranslateHandle, View2, View3};
 

--- a/fidget/src/render/mod.rs
+++ b/fidget/src/render/mod.rs
@@ -280,12 +280,12 @@ pub trait RenderHints {
 /// This handles tile generation and building + calling render workers in
 /// parallel (using [`rayon`] for parallelism at the tile level).
 ///
-/// It returns a set of output tiles
+/// It returns a set of output tiles, or `None` if rendering has been cancelled
 pub(crate) fn render_tiles<'a, F: Function, W: RenderWorker<'a, F>>(
     shape: Shape<F>,
     vars: &ShapeVars<f32>,
     config: &'a W::Config,
-) -> Vec<(Tile<2>, W::Output)>
+) -> Option<Vec<(Tile<2>, W::Output)>>
 where
     W::Config: Send + Sync,
 {
@@ -315,16 +315,21 @@ where
         (worker, rh)
     };
 
-    let out: Vec<_> = match config.threads() {
+    let out = match config.threads() {
         None => {
             let mut worker = W::new(config);
             tiles
                 .into_iter()
                 .map(|tile| {
-                    let pixels = worker.render_tile(&mut rh, vars, tile);
-                    (tile, pixels)
+                    if config.is_cancelled() {
+                        Err(())
+                    } else {
+                        let pixels = worker.render_tile(&mut rh, vars, tile);
+                        Ok((tile, pixels))
+                    }
                 })
-                .collect()
+                .collect::<Result<Vec<_>, ()>>()
+                .ok()
         }
 
         Some(p) => {
@@ -332,10 +337,15 @@ where
                 tiles
                     .into_par_iter()
                     .map_init(init, |(w, rh), tile| {
-                        let pixels = w.render_tile(rh, vars, tile);
-                        (tile, pixels)
+                        if config.is_cancelled() {
+                            Err(())
+                        } else {
+                            let pixels = w.render_tile(rh, vars, tile);
+                            Ok((tile, pixels))
+                        }
                     })
-                    .collect()
+                    .collect::<Result<Vec<_>, ()>>()
+                    .ok()
             };
             match p {
                 ThreadPool::Custom(p) => p.install(run),
@@ -353,6 +363,7 @@ pub(crate) trait RenderConfig {
     fn height(&self) -> u32;
     fn tile_sizes(&self) -> &TileSizes;
     fn threads(&self) -> Option<&ThreadPool>;
+    fn is_cancelled(&self) -> bool;
 }
 
 /// Helper trait for a tiled renderer worker


### PR DESCRIPTION
- Add a new `cancel: CancelToken` member to `ImageRenderConfig` and `VoxelRenderConfig`
- Use this in the web editor, with more Javascript shenanigans