### PR TITLE
Fix Mobile Touch Events

### DIFF
--- a/demos/web-editor/web/src/index.html
+++ b/demos/web-editor/web/src/index.html
@@ -26,6 +26,9 @@
         max-height: 512px;
         outline: 1px solid #bbb;
         margin-bottom: 12px;
+        user-select: none;
+        pointer-events: none;
+        touch-action: none;
       }
       span#status {
         display: block;

--- a/demos/web-editor/web/src/index.html
+++ b/demos/web-editor/web/src/index.html
@@ -27,7 +27,6 @@
         outline: 1px solid #bbb;
         margin-bottom: 12px;
         user-select: none;
-        pointer-events: none;
         touch-action: none;
       }
       span#status {

--- a/demos/web-editor/web/src/index.ts
+++ b/demos/web-editor/web/src/index.ts
@@ -76,21 +76,24 @@ class App {
     scene.canvas.addEventListener("contextmenu", (event) => {
       event.preventDefault();
     });
-    scene.canvas.addEventListener("mousedown", (event) => {
+    scene.canvas.addEventListener("pointerdown", (event) => {
+      event.preventDefault();
       if (event.button === 0) {
         scene.beginTranslate(event);
       } else if (event.button === 2) {
         scene.beginRotate(event);
       }
-    });
-    window.addEventListener("mouseup", (event) => {
+    }, { passive: false });
+    window.addEventListener("pointerup", (event) => {
+      event.preventDefault();
       scene.endDrag();
-    });
-    window.addEventListener("mousemove", (event) => {
+    }, { passive: false });
+    window.addEventListener("pointermove", (event) => {
+      event.preventDefault();
       if (scene.drag(event)) {
         requestRedraw();
       }
-    });
+    }, { passive: false });
     this.scene = scene;
 
     // Hot-patch the gyroid script to be eval (instead of exec) flavored


### PR DESCRIPTION
Switches `Mouse` events for `Pointer` events, which should automagically make them work on both desktop and mobile browsers.

The rest of the changes are voodoo to prevent the default events browsers associate with dragging, double tapping, and other unsavory touch gestures 💀 