### PR TITLE
Fix NAN propagation through interval and / or opcodes

### DIFF
--- a/fidget/src/core/eval/test/interval.rs
+++ b/fidget/src/core/eval/test/interval.rs
@@ -633,6 +633,24 @@ where
             eval.eval(&tape, &vs([-0.2, 1.3], [1.0, 3.0])).unwrap();
         assert_eq!(r[0], [0.0, 3.0].into());
         assert!(trace.is_none()); // can't simplify
+
+        let (r, trace) =
+            eval.eval(&tape, &vs([f32::NAN; 2], [f32::NAN; 2])).unwrap();
+        assert!(r[0].lower().is_nan());
+        assert!(r[0].upper().is_nan());
+        assert!(trace.is_none());
+
+        let (r, trace) =
+            eval.eval(&tape, &vs([f32::NAN; 2], [0.0, 1.0])).unwrap();
+        assert!(r[0].lower().is_nan());
+        assert!(r[0].upper().is_nan());
+        assert!(trace.is_none());
+
+        let (r, trace) =
+            eval.eval(&tape, &vs([0.0, 1.0], [f32::NAN; 2])).unwrap();
+        assert!(r[0].lower().is_nan());
+        assert!(r[0].upper().is_nan());
+        assert!(trace.is_none());
     }
 
     pub fn test_i_or() {
@@ -663,6 +681,24 @@ where
         let (r, trace) =
             eval.eval(&tape, &vs([-0.2, 1.3], [1.0, 3.0])).unwrap();
         assert_eq!(r[0], [-0.2, 3.0].into());
+        assert!(trace.is_none());
+
+        let (r, trace) =
+            eval.eval(&tape, &vs([f32::NAN; 2], [f32::NAN; 2])).unwrap();
+        assert!(r[0].lower().is_nan());
+        assert!(r[0].upper().is_nan());
+        assert!(trace.is_none());
+
+        let (r, trace) =
+            eval.eval(&tape, &vs([f32::NAN; 2], [0.0, 1.0])).unwrap();
+        assert!(r[0].lower().is_nan());
+        assert!(r[0].upper().is_nan());
+        assert!(trace.is_none());
+
+        let (r, trace) =
+            eval.eval(&tape, &vs([0.0, 1.0], [f32::NAN; 2])).unwrap();
+        assert!(r[0].lower().is_nan());
+        assert!(r[0].upper().is_nan());
         assert!(trace.is_none());
     }
 

--- a/fidget/src/core/types/interval.rs
+++ b/fidget/src/core/types/interval.rs
@@ -235,7 +235,9 @@ impl Interval {
     /// always selected.  An unambiguous 0 in `self` selects itself; an
     /// unambiguous 1 selects the opposite branch.
     pub fn and_choice(self, rhs: Self) -> (Self, Choice) {
-        if self.lower == 0.0 && self.upper == 0.0 {
+        if self.has_nan() || rhs.has_nan() {
+            (f32::NAN.into(), Choice::Both)
+        } else if self.lower == 0.0 && self.upper == 0.0 {
             (0.0.into(), Choice::Left)
         } else if !self.contains(0.0) {
             (rhs, Choice::Right)
@@ -243,11 +245,7 @@ impl Interval {
             // The output will either be the RHS or zero, so extend the interval
             // to include zero in it.
             (
-                if rhs.has_nan() {
-                    f32::NAN.into()
-                } else {
-                    Interval::new(rhs.lower.min(0.0), rhs.upper.max(0.0))
-                },
+                Interval::new(rhs.lower.min(0.0), rhs.upper.max(0.0)),
                 Choice::Both,
             )
         }
@@ -259,21 +257,19 @@ impl Interval {
     /// always selected.  An unambiguous 0 in `self` selects the opposite
     /// branch; an unambiguous 1 selects itself.
     pub fn or_choice(self, rhs: Self) -> (Self, Choice) {
-        if !self.contains(0.0) {
+        if self.has_nan() || rhs.has_nan() {
+            (f32::NAN.into(), Choice::Both)
+        } else if !self.contains(0.0) {
             (self, Choice::Left)
         } else if self.lower == 0.0 && self.upper == 0.0 {
             (rhs, Choice::Right)
         } else {
             // The output could be anywhere in either interval
             (
-                if rhs.has_nan() {
-                    f32::NAN.into()
-                } else {
-                    Interval::new(
-                        self.lower.min(rhs.lower),
-                        self.upper.max(rhs.upper),
-                    )
-                },
+                Interval::new(
+                    self.lower.min(rhs.lower),
+                    self.upper.max(rhs.upper),
+                ),
                 Choice::Both,
             )
         }


### PR DESCRIPTION
`[NaN, NaN]` does not mean "this interval is guaranteed to be NaN"; instead it means "this interval may have any value".  As such, we can't short-circuit when doing interval evaluation of `And` and `Or` opcodes.  A `NaN` in either argument must be 
propagated, and we must set the `Choice::Both` flag.

Fixes #240 (for real this time)