### PR TITLE
Fix `-t` argument collision in `fidget-cli`

### DIFF
--- a/demos/cli/src/main.rs
+++ b/demos/cli/src/main.rs
@@ -130,7 +130,7 @@ struct ScriptSettings {
     input: PathBuf,
 
     /// Input file type
-    #[clap(short, long, default_value_t, value_enum)]
+    #[clap(long, default_value_t, value_enum)]
     r#type: ScriptType,
 }
 


### PR DESCRIPTION
`Short option names must be unique for each argument, but '-t' is in use by both 'type' and 'threads'`