### PR TITLE
Add shaded rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
     - Define `DepthImage`, `NormalImage`, and `ColorImage` specializations
     - Use these types in 2D and 3D rendering
 - Remove `Grad::to_rgb` in favor of handling it at the image level
+- Add `fidget::render::effects` module for post-processing rendered images
 
 # 0.3.4
 - Add `GenericVmFunction::simplify_with` to simultaneously simplify a function

--- a/fidget/src/render/effects.rs
+++ b/fidget/src/render/effects.rs
@@ -1,0 +1,60 @@
+//! Post-processing effects for rendered images
+
+use super::{ColorImage, DepthImage, NormalImage};
+use nalgebra::{Vector3, Vector4};
+
+/// Combines two images with shading
+///
+/// # Panics
+/// If the images have different widths or heights
+pub fn apply_shading(depth: &DepthImage, norm: &NormalImage) -> ColorImage {
+    assert_eq!(depth.width(), norm.width());
+    assert_eq!(depth.height(), norm.height());
+
+    let mut out = ColorImage::new(depth.width(), depth.height());
+    for y in 0..depth.height() {
+        for x in 0..depth.width() {
+            let pos = (y, x);
+            if depth[pos] > 0 {
+                out[pos] = shade_pixel(depth, norm, pos);
+            }
+        }
+    }
+    out
+}
+
+/// Compute shading for a single pixel
+fn shade_pixel(
+    depth: &DepthImage,
+    norm: &NormalImage,
+    pos: (usize, usize),
+) -> [u8; 3] {
+    let [nx, ny, nz] = norm[pos];
+    let n = Vector3::new(nx, ny, nz).normalize();
+
+    // Convert from pixel to world coordinates
+    // XXX we're missing the actual depth scale
+    let p = Vector3::new(
+        2.0 * (pos.1 as f32 / depth.width() as f32 - 0.5),
+        2.0 * (pos.0 as f32 / depth.height() as f32 - 0.5),
+        2.0 * (depth[pos] as f32 / depth.width() as f32 - 0.5),
+    );
+
+    let lights = [
+        Vector4::new(5.0, -5.0, 10.0, 0.5),
+        Vector4::new(-5.0, 0.0, 10.0, 0.15),
+        Vector4::new(0.0, -5.0, 10.0, 0.15),
+    ];
+    let mut accum = 0.2; // ambient
+    for light in lights {
+        let light_dir = (light.xyz() - p).normalize();
+        accum += light_dir.dot(&n).max(0.0) * light.w;
+    }
+
+    // TODO SSAO dimming
+
+    accum = accum.clamp(0.0, 1.0);
+
+    let c = (accum * 255.0) as u8;
+    [c, c, c]
+}

--- a/fidget/src/render/mod.rs
+++ b/fidget/src/render/mod.rs
@@ -9,6 +9,8 @@ use crate::{
 };
 use nalgebra::Point2;
 
+pub mod effects;
+
 mod config;
 mod region;
 mod render2d;

--- a/models/colonnade.vm
+++ b/models/colonnade.vm
@@ -1,4 +1,5 @@
 # Model of a colonnade with a balcony and outside staircase
+# Recommended render settings: --scale 0.7 --pitch 60 --roll 30
 _0 var-y
 _1 const 10
 _2 mul _0 _1

--- a/models/tanglecube.vm
+++ b/models/tanglecube.vm
@@ -1,3 +1,4 @@
+# Recommended settings: --scale 0.222 --pitch -25 --yaw 30
 _x var-x
 _y var-y
 _z var-z


### PR DESCRIPTION
- Add `fidget::render::effects` to combine depth and heightmap into a shaded image
- Add `--roll` argument to `fidget-cli`
- Replace `--color` with `--mode={shaded,normals,heightmap}` in `fidget-cli`
- Include recommended render settings in example models

![out](https://github.com/user-attachments/assets/c45ae5d0-a5d7-4bf5-9ce7-9154d0eb9deb)
