### PR TITLE
Optimize interval modulo

### DIFF
--- a/fidget/src/core/eval/test/interval.rs
+++ b/fidget/src/core/eval/test/interval.rs
@@ -702,6 +702,30 @@ where
         assert!(trace.is_none());
     }
 
+    pub fn test_i_modulo() {
+        let mut ctx = Context::new();
+        let x = ctx.x();
+        let y = ctx.y();
+        let out = ctx.modulo(x, y).unwrap();
+
+        let shape = F::new(&ctx, &[out]).unwrap();
+        let tape = shape.interval_tape(Default::default());
+        let vs = bind_xy(&tape);
+        let mut eval = F::new_interval_eval();
+
+        let (out, _trace) =
+            eval.eval(&tape, &vs([-5.0, 0.0], [1.0, 1.0])).unwrap();
+        assert_eq!(out[0], Interval::new(0.0, 1.0));
+
+        let (out, _trace) =
+            eval.eval(&tape, &vs([4.5, 4.75], [1.0, 1.0])).unwrap();
+        assert_eq!(out[0], Interval::new(0.5, 0.75));
+
+        let (out, _trace) =
+            eval.eval(&tape, &vs([-4.75, -4.5], [1.0, 1.0])).unwrap();
+        assert_eq!(out[0], Interval::new(0.25, 0.5));
+    }
+
     pub fn test_i_simplify() {
         let mut ctx = Context::new();
         let x = ctx.x();
@@ -1168,6 +1192,7 @@ macro_rules! interval_tests {
         $crate::interval_test!(test_i_and, $t);
         $crate::interval_test!(test_i_or, $t);
         $crate::interval_test!(test_i_compare, $t);
+        $crate::interval_test!(test_i_modulo, $t);
         $crate::interval_test!(test_i_simplify, $t);
         $crate::interval_test!(test_i_simplify_conditional, $t);
         $crate::interval_test!(test_i_stress, $t);

--- a/fidget/src/core/types/interval.rs
+++ b/fidget/src/core/types/interval.rs
@@ -336,10 +336,21 @@ impl Interval {
 
     /// Least non-negative remainder
     pub fn rem_euclid(&self, other: Interval) -> Self {
+        // TODO optimize this more?
         if self.has_nan() || other.has_nan() || other.contains(0.0) {
             f32::NAN.into()
+        } else if other.lower == other.upper && other.lower > 0.0 {
+            let a = self.lower / other.lower;
+            let b = self.upper / other.lower;
+            if a != a.floor() && a.floor() == b.floor() {
+                Interval::new(
+                    self.lower.rem_euclid(other.lower),
+                    self.upper.rem_euclid(other.lower),
+                )
+            } else {
+                Interval::new(0.0, other.abs().upper())
+            }
         } else {
-            // TODO optimize this
             Interval::new(0.0, other.abs().upper())
         }
     }

--- a/models/sponge.rhai
+++ b/models/sponge.rhai
@@ -1,4 +1,5 @@
 // Menger sponge, with optional sphere-ification
+// Recommended render settings: --scale 0.75 --pitch -25 --yaw -30
 fn recurse(x, y, z, depth) {
     let r = ((x + 1) % 2 - 1).abs();
     let base = intersection(r, r.remap_xyz(y, x, z)) - 1/3.;


### PR DESCRIPTION
Doing actual interval arithmetic for certain cases of `modulo`, we can be faster than just returning the entire range.

```
cargo run --release -pfidget-cli -- render3d -i models/sponge.rhai  -s1024 -olocal/out.png --eval=vm --scale 0.75 --mode=shaded --pitch -25 --yaw -30 -N10
```

`main`: 1483 ms
This branch: 791 ms