### PR TITLE
Improve wasm compatiblity of cli demo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3032,13 +3032,14 @@ name = "workspace-hack"
 version = "0.1.0"
 dependencies = [
  "ahash",
- "anstream",
  "approx",
  "bitflags 2.6.0",
  "bytemuck",
  "clap",
  "clap_builder",
  "either",
+ "env_filter",
+ "env_logger",
  "getrandom",
  "libc",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ crossbeam-deque = "0.8"
 document-features = "0.2"
 dynasmrt = { version = "2.0" }
 eframe = { version = "0.29", default-features = false, features = [ "default_fonts", "glow"] }
-env_logger = "0.11.2"
+env_logger = { version = "0.11.2", default-features = false }
 getrandom = { version = "0.2", features = ["js"] }
 image = { version = "0.25", default-features = false, features = ["png"] }
 libc = "0.2"

--- a/demos/cli/Cargo.toml
+++ b/demos/cli/Cargo.toml
@@ -18,7 +18,8 @@ workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 
 [features]
 jit = ["fidget/jit"]
-default = ["jit"]
+logger-full = ["env_logger/auto-color", "env_logger/humantime", "env_logger/regex"]
+default = ["jit", "logger-full"]
 
 [[bin]]
 name = "fidget-cli"

--- a/demos/cli/src/main.rs
+++ b/demos/cli/src/main.rs
@@ -347,7 +347,10 @@ fn run_mesh<F: fidget::eval::Function + fidget::render::RenderHints>(
 
     for _ in 0..settings.n {
         let settings = fidget::mesh::Settings {
+            #[cfg(not(target_arch = "wasm32"))]
             threads: settings.threads.into(),
+            #[cfg(target_arch = "wasm32")]
+            threads: Default::default(),
             depth: settings.depth,
             ..Default::default()
         };

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -21,6 +21,8 @@ bytemuck = { version = "1", default-features = false, features = ["derive", "ext
 clap = { version = "4", features = ["derive"] }
 clap_builder = { version = "4", default-features = false, features = ["color", "help", "std", "suggestions", "usage"] }
 either = { version = "1", default-features = false, features = ["use_std"] }
+env_filter = { version = "0.1", default-features = false, features = ["regex"] }
+env_logger = { version = "0.11", default-features = false, features = ["auto-color", "humantime", "regex"] }
 getrandom = { version = "0.2", default-features = false, features = ["std"] }
 num-traits = { version = "0.2", features = ["i128"] }
 once_cell = { version = "1" }
@@ -37,7 +39,6 @@ syn = { version = "2", features = ["extra-traits", "full"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 ahash = { version = "0.8" }
-anstream = { version = "0.6" }
 bitflags = { version = "2", default-features = false, features = ["std"] }
 libc = { version = "0.2" }
 log = { version = "0.4", default-features = false, features = ["std"] }
@@ -49,7 +50,6 @@ log = { version = "0.4", default-features = false, features = ["std"] }
 memchr = { version = "2" }
 
 [target.aarch64-apple-darwin.dependencies]
-anstream = { version = "0.6" }
 bitflags = { version = "2", default-features = false, features = ["std"] }
 libc = { version = "0.2" }
 
@@ -58,7 +58,6 @@ libc = { version = "0.2" }
 
 [target.aarch64-unknown-linux-gnu.dependencies]
 ahash = { version = "0.8" }
-anstream = { version = "0.6" }
 bitflags = { version = "2", default-features = false, features = ["std"] }
 libc = { version = "0.2" }
 log = { version = "0.4", default-features = false, features = ["std"] }


### PR DESCRIPTION
While the wasm32-unknown-unknown environment makes little sense for the cli due to
the absence of any file handling, there is a case for supporting wasm32
anyways. With the wasi system interface the underlying platform provides
all the IO required, making this a viable `std` target. In particular,
WebAssembly ensures a high degree of reproducibility (especially under
implementations that ensure canonical NaN handling).

As a demo, we can pack the compiled module into an HTML page and
polyfill the file data in Javascript such as bjorn3's wasi shim.

I've only locally verified against Rust's `wasm32-wasip1` target but
forsee no reason for newer wasi preview versions to work any worse when
they are stabilized. To indicate compatibility with future versions it
would be helpful to ensure CI coverage for this target, if maintenance
effort allows it.

The main overheads of such compatibility in the core of `fidget` and its
rhai embedding appear with the `wasm32` target architecture itself, not
the `-wasi` platform. This is already covered as a Tier 1 target. There
are some subtleties with libraries that the CLI may depend on in the
future. The common terminal API libraries that would be used for
interactive modes generally do not work with `wasm` targets, many depend
on UNIX-ly libc functionality etc. Again though, this would hold even
less true for `wasm32-unknown-unknown` where definitionally no system
interface can be defined at all.

----

As an example, consider the following HTML file (packed in a zip for Github compatibility). Opening it in the browser runs a WebAssembly instance of `fidget` on the gyroid sphere example to generate a render on your machine instead of packing that image file itself. Seems pretty neat to me :slightly_smiling_face:. (On a web deployment you might of course fetch the binary dynamically but packing it for a self-contained file is also neat. 

[fidget-html.zip](https://github.com/user-attachments/files/18876132/fidget-html.zip)

Chrome/Chromium and Firefox should work effortlessly for viewing the render through the HTML file.
----

Note: the HTML file is actually a polyglot, it's also a tar archive. This archive is the root file system which WASI shim then emulates—each file data encoded base64—so you can inspect the rhai source code that was used by extracting the archive. Admittedly, part of the reason for  creating this PR was to show that trick off :grin: 