### PR TITLE
CI updates

### DIFF
--- a/.github/workflows/check-aarch64.yml
+++ b/.github/workflows/check-aarch64.yml
@@ -22,10 +22,20 @@ jobs:
     runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
-    - uses: Swatinem/rust-cache@v2
+    - uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-check
     - name: Install target
       run: rustup target add ${{ matrix.target }}
     - name: Check
       run: cargo check --target=${{ matrix.target }} --all-targets --verbose
     - name: Clippy
       run: cargo clippy --target=${{ matrix.target }} --all-targets --verbose
+    - name: Check format
+      run: cargo fmt -- --check || exit 1

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -16,7 +16,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: Swatinem/rust-cache@v2
+    - uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-check
     - name: Install nightly Rust
       run: rustup default nightly
     - name: Check docs

--- a/.github/workflows/check-wasm.yml
+++ b/.github/workflows/check-wasm.yml
@@ -20,7 +20,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: Swatinem/rust-cache@v2
+    - uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-check
     - name: Install wasm target
       run: rustup target add ${{ matrix.target }}
     - name: Check

--- a/.github/workflows/check-x86_64.yml
+++ b/.github/workflows/check-x86_64.yml
@@ -21,7 +21,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: Swatinem/rust-cache@v2
+    - uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-check
     - name: Install target
       run: rustup target add ${{ matrix.target }}
     - name: Check

--- a/.github/workflows/constraints-demo.yml
+++ b/.github/workflows/constraints-demo.yml
@@ -17,7 +17,15 @@ jobs:
         working-directory: ./demos/constraints
     steps:
     - uses: actions/checkout@v4
-    - uses: Swatinem/rust-cache@v2
+    - uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Install wasm target
       run: rustup target add wasm32-unknown-unknown
     - name: Install trunk

--- a/.github/workflows/hakari.yml
+++ b/.github/workflows/hakari.yml
@@ -14,12 +14,12 @@ jobs:
     env:
       RUSTFLAGS: -D warnings
     steps:
-      - uses: actions/checkout@v4
-      - name: Install cargo-hakari
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-hakari
-      - name: Check workspace-hack Cargo.toml is up-to-date
-        run: cargo hakari generate --diff
-      - name: Check all crates depend on workspace-hack
-        run: cargo hakari manage-deps --dry-run
+    - uses: actions/checkout@v4
+    - name: Install cargo-hakari
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-hakari
+    - name: Check workspace-hack Cargo.toml is up-to-date
+      run: cargo hakari generate --diff
+    - name: Check all crates depend on workspace-hack
+      run: cargo hakari manage-deps --dry-run

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,64 +13,23 @@ jobs:
   test:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-14"]
+        os: ["ubuntu-latest", "macos-14", "windows-latest"]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@v4
-    - uses: Swatinem/rust-cache@v2
-    - name: Build tests
-      run: cargo test --verbose --no-run
-    - name: Run crate tests
-      run: cargo test --verbose --lib
-    - name: Run doc tests
-      run: cargo test --verbose --doc
-
-  test-windows:
-    runs-on: windows-latest
-    timeout-minutes: 15
-    steps:
-    - name: Create dev drive using ReFS
-      run: |
-        $Volume = New-VHD -Path C:/fidget_dev_drive.vhdx -SizeBytes 10GB |
-                  Mount-VHD -Passthru |
-                  Initialize-Disk -Passthru |
-                  New-Partition -AssignDriveLetter -UseMaximumSize |
-                  Format-Volume -FileSystem ReFS -Confirm:$false -Force
-        Write-Output $Volume
-        Write-Output "DEV_DRIVE=$($Volume.DriveLetter):" >> $env:GITHUB_ENV
-    - uses: actions/checkout@v4
-    - name: Copy repo to dev drive
-      run: |
-        Copy-Item -Path "${{ github.workspace }}" -Destination "${{ env.DEV_DRIVE }}/fidget" -Recurse
-    - name: Select Rust toolchain
-      env:
-        CARGO_HOME: ${{ env.DEV_DRIVE }}/.cargo
-        RUSTUP_HOME: ${{ env.DEV_DRIVE }}/.rustup
-      run: |
-        rustup set profile minimal
-        rustup default stable
-    - uses: Swatinem/rust-cache@v2
+    - uses: actions/cache@v4
       with:
-        workspaces: ${{ env.DEV_DRIVE }}/fidget
-      env:
-        CARGO_HOME: ${{ env.DEV_DRIVE }}/.cargo
-        RUSTUP_HOME: ${{ env.DEV_DRIVE }}/.rustup
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test
     - name: Build tests
-      working-directory: ${{ env.DEV_DRIVE }}/fidget
-      env:
-        CARGO_HOME: ${{ env.DEV_DRIVE }}/.cargo
-        RUSTUP_HOME: ${{ env.DEV_DRIVE }}/.rustup
       run: cargo test --verbose --no-run
     - name: Run crate tests
-      working-directory: ${{ env.DEV_DRIVE }}/fidget
-      env:
-        CARGO_HOME: ${{ env.DEV_DRIVE }}/.cargo
-        RUSTUP_HOME: ${{ env.DEV_DRIVE }}/.rustup
       run: cargo test --verbose --lib
     - name: Run doc tests
-      working-directory: ${{ env.DEV_DRIVE }}/fidget
-      env:
-        CARGO_HOME: ${{ env.DEV_DRIVE }}/.cargo
-        RUSTUP_HOME: ${{ env.DEV_DRIVE }}/.rustup
       run: cargo test --verbose --doc

--- a/.github/workflows/wasm-demo.yml
+++ b/.github/workflows/wasm-demo.yml
@@ -17,7 +17,15 @@ jobs:
         working-directory: ./demos/web-editor/web
     steps:
     - uses: actions/checkout@v4
-    - uses: Swatinem/rust-cache@v2
+    - uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-wasm
     - name: Install wasm target
       run: rustup target add wasm32-unknown-unknown
     - name: Install wasm-pack


### PR DESCRIPTION
The trick of using `E:/` on Windows has stopped working (??), so this PR consolidates CI back down to a normal matrix.

In addition, it switches to using the canonical `actions/cache@v4` instead of a third-party action, to minimize surface area.