### PR TITLE
SSAO and denoising

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,10 @@
     - Define `DepthImage`, `NormalImage`, and `ColorImage` specializations
     - Use these types in 2D and 3D rendering
 - Remove `Grad::to_rgb` in favor of handling it at the image level
-- Add `fidget::render::effects` module for post-processing rendered images
+- Add `fidget::render::effects` module for post-processing rendered images:
+    - Combining depth and normal images into a shaded image
+    - Denoising normals to fix back-facing samples
+    - Computing and applying screen-space ambient occlusion
 - Optimize implementation of interval `modulo` for cases where the right-hand
   argument is a positive constant value (which is the most common when using it
   for domain repetition)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,6 +871,7 @@ dependencies = [
  "log",
  "nalgebra",
  "rayon",
+ "strum",
  "workspace-hack",
 ]
 
@@ -2124,6 +2125,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+
+[[package]]
 name = "ryu"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2300,6 +2307,28 @@ name = "strsim"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+
+[[package]]
+name = "strum"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.48",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ rayon = "1.10"
 rhai = { version = "1.17", features = ["sync"] }
 serde = { version = "1.0", features = ["derive", "rc"] }
 static_assertions = "1"
+strum = { version = "0.27", features = ["derive"] }
 thiserror = "1"
 wasm-bindgen = "0.2.92"
 wasm-bindgen-futures = "0.4"

--- a/demos/cli/Cargo.toml
+++ b/demos/cli/Cargo.toml
@@ -12,6 +12,7 @@ image.workspace = true
 log.workspace = true
 nalgebra.workspace = true
 rayon.workspace = true
+strum.workspace = true
 
 fidget.path = "../../fidget"
 workspace-hack = { version = "0.1", path = "../../workspace-hack" }

--- a/fidget/src/render/effects.rs
+++ b/fidget/src/render/effects.rs
@@ -1,8 +1,10 @@
 //! Post-processing effects for rendered images
 
-use super::{ColorImage, DepthImage, NormalImage, ThreadPool};
-use nalgebra::{Vector3, Vector4};
-use rayon::prelude::*;
+use super::{ColorImage, DepthImage, Image, NormalImage, ThreadPool};
+use nalgebra::{
+    Const, Matrix3, MatrixXx2, MatrixXx3, OMatrix, RowVector2, RowVector3,
+    Vector3, Vector4,
+};
 
 /// Combines two images with shading
 ///
@@ -17,27 +19,65 @@ pub fn apply_shading(
     assert_eq!(depth.height(), norm.height());
 
     let mut out = ColorImage::new(depth.width(), depth.height());
-    if let Some(threads) = threads {
-        threads.run(|| {
-            out.par_rows_mut().enumerate().for_each(move |(y, row)| {
-                for (x, v) in row.iter_mut().enumerate() {
-                    let pos = (y, x);
-                    if depth[pos] > 0 {
-                        *v = shade_pixel(depth, norm, pos);
-                    }
-                }
-            })
-        });
-    } else {
-        for y in 0..depth.height() {
-            for x in 0..depth.width() {
-                let pos = (y, x);
-                if depth[pos] > 0 {
-                    out[pos] = shade_pixel(depth, norm, pos);
-                }
+    out.apply_effect(
+        |x, y| {
+            if depth[(y, x)] > 0 {
+                shade_pixel(depth, norm, x, y)
+            } else {
+                [0u8; 3]
             }
-        }
-    }
+        },
+        threads,
+    );
+    out
+}
+
+/// Computes SSAO occlusion at each pixel in an image
+///
+/// # Panics
+/// If the images have different widths or heights
+pub fn compute_ssao(
+    depth: &DepthImage,
+    norm: &NormalImage,
+    threads: Option<ThreadPool>,
+) -> Image<f32> {
+    // TODO make an object that is a bound Depth + Normal image with conditions
+    // already checked, maybe GBuffer?
+    assert_eq!(depth.width(), norm.width());
+    assert_eq!(depth.height(), norm.height());
+    let (ssao_kernel, ssao_noise) = ssao_kernel(32);
+
+    let mut out = Image::<f32>::new(depth.width(), depth.height());
+    out.apply_effect(
+        |x, y| {
+            if depth[(y, x)] > 0 {
+                compute_pixel_ssao(depth, norm, x, y, &ssao_kernel, &ssao_noise)
+            } else {
+                f32::NAN
+            }
+        },
+        threads,
+    );
+
+    out
+}
+
+/// Blurs the given image
+pub fn compute_blur(
+    ssao: &Image<f32>,
+    threads: Option<ThreadPool>,
+) -> Image<f32> {
+    let mut out = Image::<f32>::new(ssao.width(), ssao.height());
+    out.apply_effect(
+        |x, y| {
+            if ssao[(y, x)].is_nan() {
+                f32::NAN
+            } else {
+                compute_pixel_blur(ssao, x, y)
+            }
+        },
+        threads,
+    );
     out
 }
 
@@ -45,17 +85,18 @@ pub fn apply_shading(
 fn shade_pixel(
     depth: &DepthImage,
     norm: &NormalImage,
-    pos: (usize, usize),
+    x: usize,
+    y: usize,
 ) -> [u8; 3] {
-    let [nx, ny, nz] = norm[pos];
+    let [nx, ny, nz] = norm[(y, x)];
     let n = Vector3::new(nx, ny, nz).normalize();
 
     // Convert from pixel to world coordinates
     // XXX we're missing the actual depth scale
     let p = Vector3::new(
-        2.0 * (pos.1 as f32 / depth.width() as f32 - 0.5),
-        2.0 * (pos.0 as f32 / depth.height() as f32 - 0.5),
-        2.0 * (depth[pos] as f32 / depth.width() as f32 - 0.5),
+        2.0 * (x as f32 / depth.width() as f32 - 0.5),
+        2.0 * (y as f32 / depth.height() as f32 - 0.5),
+        2.0 * (depth[(y, x)] as f32 / depth.width() as f32 - 0.5),
     );
 
     let lights = [
@@ -69,10 +110,177 @@ fn shade_pixel(
         accum += light_dir.dot(&n).max(0.0) * light.w;
     }
 
-    // TODO SSAO dimming
-
     accum = accum.clamp(0.0, 1.0);
 
     let c = (accum * 255.0) as u8;
     [c, c, c]
+}
+
+/// Compute an SSAO shading factor for a single pixel
+///
+/// Returns NAN if the pixel is empty (i.e. its depth is 0)
+fn compute_pixel_ssao(
+    depth: &DepthImage,
+    norm: &NormalImage,
+    x: usize,
+    y: usize,
+    kernel: &OMatrix<f32, nalgebra::Dyn, Const<3>>,
+    noise: &OMatrix<f32, nalgebra::Dyn, Const<2>>,
+) -> f32 {
+    let pos = (y, x);
+    let [nx, ny, nz] = norm[pos];
+    let d = depth[pos];
+
+    if d == 0 {
+        return f32::NAN;
+    }
+
+    // XXX this is guessing at the depth
+    let p = Vector3::new(
+        (((x as f32) / depth.width() as f32) + 0.5) * 2.0,
+        (((y as f32) / depth.height() as f32) + 0.5) * 2.0,
+        (((d as f32) / depth.width() as f32) + 0.5) * 2.0,
+    );
+
+    // Get normal from the image
+    let n = Vector3::new(nx, ny, nz).normalize();
+
+    // Get a rotation vector based on pixel index, and add a Z coordinate
+    let idx = pos.0 + pos.1 * depth.width();
+    let rvec = noise.row(idx % noise.nrows()).transpose();
+    let rvec = Vector3::new(rvec.x, rvec.y, 0.0);
+
+    // Build our transform matrix, using the Gram-Schmidt process
+    let tangent = (rvec - n * rvec.dot(&n)).normalize();
+    let bitangent = n.cross(&tangent);
+    let tbn = Matrix3::from_columns(&[tangent, bitangent, n]);
+
+    const RADIUS: f32 = 0.1;
+    let mut occlusion = 0.0;
+    for i in 0..kernel.nrows() {
+        let sample_pos = tbn * kernel.row(i).transpose() * RADIUS + p;
+        // XXX this distorts samples for non-square images
+        let px = ((sample_pos.x / 2.0) + 0.5) * depth.width() as f32;
+        let py = ((sample_pos.y / 2.0) + 0.5) * depth.height() as f32;
+
+        // Get depth from heightmap
+        let actual_h = if px < depth.width() as f32
+            && py < depth.height() as f32
+            && px > 0.0
+            && py > 0.0
+        {
+            depth[(py as usize, px as usize)]
+        } else {
+            0
+        };
+
+        // XXX same caveat about image depth here
+        let actual_z = (((actual_h as f32) / depth.width() as f32) + 0.5) * 2.0;
+
+        let dz = sample_pos.z - actual_z;
+        if dz < RADIUS {
+            occlusion += (sample_pos.z <= actual_z) as usize as f32;
+        } else if dz < RADIUS * 2.0 && sample_pos.z <= actual_z {
+            occlusion += ((RADIUS - (dz - RADIUS)) / RADIUS).powi(2);
+        }
+    }
+    1.0 - (occlusion / kernel.nrows() as f32)
+}
+
+/// Computes a single blurred pixel
+fn compute_pixel_blur(ssao: &Image<f32>, x: usize, y: usize) -> f32 {
+    let mut best = 1000000.0;
+    let mut value = 0.0;
+    const BLUR_RADIUS: isize = 2;
+    let x = x as isize;
+    let y = y as isize;
+    let mut run = |xmin, ymin| {
+        let mut sum = 0.0;
+        let mut count = 0;
+        for i in 0..=BLUR_RADIUS {
+            for j in 0..=BLUR_RADIUS {
+                let tx = x + xmin + i;
+                let ty = y + ymin + j;
+                if tx >= 0
+                    && ty >= 0
+                    && (tx as usize) < ssao.width()
+                    && (ty as usize) < ssao.height()
+                {
+                    let s = ssao[(ty as usize, tx as usize)];
+                    if !s.is_nan() {
+                        sum += s;
+                        count += 1;
+                    }
+                }
+            }
+        }
+        let mean = sum / count as f32;
+        let mut stdev = 0.0;
+        for i in 0..=BLUR_RADIUS {
+            for j in 0..=BLUR_RADIUS {
+                let tx = x + xmin + i;
+                let ty = y + ymin + j;
+                if tx >= 0
+                    && ty >= 0
+                    && (tx as usize) < ssao.width()
+                    && (ty as usize) < ssao.height()
+                {
+                    let s = ssao[(ty as usize, tx as usize)];
+                    if !s.is_nan() {
+                        stdev += (mean - s).powi(2);
+                    }
+                }
+            }
+        }
+        let stdev = ((stdev / count as f32) - 1.0).sqrt();
+        if stdev < best {
+            best = stdev;
+            value = mean;
+        }
+    };
+    run(0, 0);
+    run(-BLUR_RADIUS, 0);
+    run(0, -BLUR_RADIUS);
+    run(-BLUR_RADIUS, -BLUR_RADIUS);
+
+    value
+}
+
+/// Returns a tuple of `(kernel, noise)` matrices for SSAO
+///
+/// - `kernel` is a set of points in a hemisphere, used for sampling the depth
+///   buffer; it should be oriented based on surface normal
+/// - `noise` is a list of random XY rotations, which can be applied to the
+///   kernel to reduce banding
+pub fn ssao_kernel(
+    n: usize,
+) -> (
+    OMatrix<f32, nalgebra::Dyn, Const<3>>,
+    OMatrix<f32, nalgebra::Dyn, Const<2>>,
+) {
+    // Based on http://john-chapman-graphics.blogspot.com/2013/01/ssao-tutorial.html
+    use rand::prelude::*;
+
+    let mut kernel = MatrixXx3::<f32>::zeros(n);
+    let mut noise = MatrixXx2::<f32>::zeros(n);
+    let mut rng = thread_rng();
+    let xy_range = rand::distributions::Uniform::new_inclusive(-1.0, 1.0);
+    let z_range = rand::distributions::Uniform::new_inclusive(0.0, 1.0);
+
+    for i in 0..64 {
+        let row = RowVector3::<f32>::new(
+            rng.sample(xy_range),
+            rng.sample(xy_range),
+            rng.sample(z_range),
+        );
+        // Scale to keep most samples near the center
+        let scale =
+            ((i as f32) / (kernel.nrows() as f32 - 1.0)).powi(2) * 0.9 + 0.1;
+        kernel.set_row(i, &(row * scale / row.norm()));
+
+        let row =
+            RowVector2::<f32>::new(rng.sample(xy_range), rng.sample(xy_range));
+        noise.set_row(i, &(row / row.norm()));
+    }
+    (kernel, noise)
 }

--- a/fidget/src/render/mod.rs
+++ b/fidget/src/render/mod.rs
@@ -414,43 +414,25 @@ impl<P: Default + Clone> Image<P> {
     }
 }
 
-impl<P> Image<P> {
-    /// Returns a mutable row in the image
-    pub fn row_mut(&mut self, row: usize) -> &mut [P] {
-        &mut self.data[row * self.height..][..self.width]
-    }
-}
-
 impl<P: Send> Image<P> {
-    /// Returns a parallel mutable iterator over rows
-    ///
-    /// This is useful for processing pixels in parallel, e.g. for shading
-    pub fn par_rows_mut(
-        &mut self,
-    ) -> impl IndexedParallelIterator<Item = &mut [P]> {
-        self.data.par_chunks_mut(self.width)
-    }
-
     /// Generates an image by computing a per-pixel function
     pub fn apply_effect<F: Fn(usize, usize) -> P + Send + Sync>(
         &mut self,
         f: F,
         threads: Option<ThreadPool>,
     ) {
+        let r = |(y, row): (usize, &mut [P])| {
+            for (x, v) in row.iter_mut().enumerate() {
+                *v = f(x, y);
+            }
+        };
+
         if let Some(threads) = threads {
             threads.run(|| {
-                self.par_rows_mut().enumerate().for_each(|(y, row)| {
-                    for (x, v) in row.iter_mut().enumerate() {
-                        *v = f(x, y);
-                    }
-                })
-            });
+                self.data.par_chunks_mut(self.width).enumerate().for_each(r)
+            })
         } else {
-            for y in 0..self.height {
-                for x in 0..self.width {
-                    self[(y, x)] = f(x, y);
-                }
-            }
+            self.data.chunks_mut(self.width).enumerate().for_each(r)
         }
     }
 }


### PR DESCRIPTION
- Denoising removes spurious back-facing pixels, replacing them with an average of a neighboring quadrant
- SSAO does screen-space ambient occlusion

![foo](https://github.com/user-attachments/assets/83261dcd-4111-4d14-963d-72ebbf603c70)
