### PR TITLE
Simplify `ThreadPool` handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 0.3.6 (unreleased)
-(nothing yet)
+- Change `Option<ThreadPool<'a>>` to `Option<&'a ThreadPool>` throughout the
+  codebase; moving the reference out of the `ThreadPool` eliminates the need for
+  a separate `rayon::ThreadPool` object on the stack.
 
 # 0.3.5
 - Added `#[derive(Serialize, Deserialize)]` to `View2` and `View3`

--- a/demos/web-editor/crate/src/lib.rs
+++ b/demos/web-editor/crate/src/lib.rs
@@ -64,7 +64,7 @@ pub fn render_2d(
     ) -> Option<Vec<u8>> {
         let cfg = ImageRenderConfig {
             image_size: ImageSize::from(image_size as u32),
-            threads: Some(ThreadPool::Global),
+            threads: Some(&ThreadPool::Global),
             tile_sizes: TileSizes::new(&[64, 16, 8]).unwrap(),
             view,
             cancel,
@@ -134,7 +134,7 @@ fn render_3d_inner(
 ) -> Option<(DepthImage, NormalImage)> {
     let cfg = VoxelRenderConfig {
         image_size: VoxelSize::from(image_size as u32),
-        threads: Some(ThreadPool::Global),
+        threads: Some(&ThreadPool::Global),
         tile_sizes: TileSizes::new(&[128, 64, 32, 16, 8]).unwrap(),
         view,
         cancel,

--- a/fidget/src/render/config.rs
+++ b/fidget/src/render/config.rs
@@ -16,15 +16,14 @@ use std::sync::{
 ///
 /// Most users will use the global Rayon pool, but it's possible to provide your
 /// own as well.
-#[derive(Clone)]
-pub enum ThreadPool<'a> {
+pub enum ThreadPool {
     /// User-provided pool
-    Custom(&'a rayon::ThreadPool),
+    Custom(rayon::ThreadPool),
     /// Global Rayon pool
     Global,
 }
 
-impl ThreadPool<'_> {
+impl ThreadPool {
     /// Runs a function across the thread pool
     pub fn run<F: FnOnce() -> V + Send, V: Send>(&self, f: F) -> V {
         match self {
@@ -98,7 +97,7 @@ pub struct ImageRenderConfig<'a> {
     ///
     /// If this is `None`, then rendering is done in a single thread; otherwise,
     /// the provided pool is used.
-    pub threads: Option<ThreadPool<'a>>,
+    pub threads: Option<&'a ThreadPool>,
 
     /// Token to cancel rendering
     pub cancel: CancelToken,
@@ -110,7 +109,7 @@ impl Default for ImageRenderConfig<'_> {
             image_size: ImageSize::from(512),
             tile_sizes: TileSizes::new(&[128, 32, 8]).unwrap(),
             view: View2::default(),
-            threads: Some(ThreadPool::Global),
+            threads: Some(&ThreadPool::Global),
             cancel: CancelToken::new(),
         }
     }
@@ -124,7 +123,7 @@ impl RenderConfig for ImageRenderConfig<'_> {
         self.image_size.height()
     }
     fn threads(&self) -> Option<&ThreadPool> {
-        self.threads.as_ref()
+        self.threads
     }
     fn tile_sizes(&self) -> &TileSizes {
         &self.tile_sizes
@@ -181,7 +180,7 @@ pub struct VoxelRenderConfig<'a> {
     ///
     /// If this is `None`, then rendering is done in a single thread; otherwise,
     /// the provided pool is used.
-    pub threads: Option<ThreadPool<'a>>,
+    pub threads: Option<&'a ThreadPool>,
 
     /// Token to cancel rendering
     pub cancel: CancelToken,
@@ -194,7 +193,7 @@ impl Default for VoxelRenderConfig<'_> {
             tile_sizes: TileSizes::new(&[128, 64, 32, 16, 8]).unwrap(),
             view: View3::default(),
 
-            threads: Some(ThreadPool::Global),
+            threads: Some(&ThreadPool::Global),
             cancel: CancelToken::new(),
         }
     }
@@ -208,7 +207,7 @@ impl RenderConfig for VoxelRenderConfig<'_> {
         self.image_size.height()
     }
     fn threads(&self) -> Option<&ThreadPool> {
-        self.threads.as_ref()
+        self.threads
     }
     fn tile_sizes(&self) -> &TileSizes {
         &self.tile_sizes

--- a/fidget/src/render/effects.rs
+++ b/fidget/src/render/effects.rs
@@ -14,7 +14,7 @@ use rand::prelude::*;
 pub fn denoise_normals(
     depth: &DepthImage,
     norm: &NormalImage,
-    threads: Option<ThreadPool>,
+    threads: Option<&ThreadPool>,
 ) -> NormalImage {
     assert_eq!(depth.width(), norm.width());
     assert_eq!(depth.height(), norm.height());
@@ -42,14 +42,14 @@ pub fn apply_shading(
     depth: &DepthImage,
     norm: &NormalImage,
     ssao: bool,
-    threads: Option<ThreadPool>,
+    threads: Option<&ThreadPool>,
 ) -> ColorImage {
     assert_eq!(depth.width(), norm.width());
     assert_eq!(depth.height(), norm.height());
 
     let ssao = if ssao {
-        let ssao = compute_ssao(depth, norm, threads.clone());
-        Some(blur_ssao(&ssao, threads.clone()))
+        let ssao = compute_ssao(depth, norm, threads);
+        Some(blur_ssao(&ssao, threads))
     } else {
         None
     };
@@ -75,7 +75,7 @@ pub fn apply_shading(
 pub fn compute_ssao(
     depth: &DepthImage,
     norm: &NormalImage,
-    threads: Option<ThreadPool>,
+    threads: Option<&ThreadPool>,
 ) -> Image<f32> {
     // TODO make an object that is a bound Depth + Normal image with conditions
     // already checked, maybe GBuffer?
@@ -100,7 +100,10 @@ pub fn compute_ssao(
 }
 
 /// Blurs the given image, which is expected to be an SSAO occlusion map
-pub fn blur_ssao(ssao: &Image<f32>, threads: Option<ThreadPool>) -> Image<f32> {
+pub fn blur_ssao(
+    ssao: &Image<f32>,
+    threads: Option<&ThreadPool>,
+) -> Image<f32> {
     let mut out = Image::<f32>::new(ssao.width(), ssao.height());
     let blur_radius = 2;
     out.apply_effect(

--- a/fidget/src/render/mod.rs
+++ b/fidget/src/render/mod.rs
@@ -419,7 +419,7 @@ impl<P: Send> Image<P> {
     pub fn apply_effect<F: Fn(usize, usize) -> P + Send + Sync>(
         &mut self,
         f: F,
-        threads: Option<ThreadPool>,
+        threads: Option<&ThreadPool>,
     ) {
         let r = |(y, row): (usize, &mut [P])| {
             for (x, v) in row.iter_mut().enumerate() {


### PR DESCRIPTION
`Option<&'a ThreadPool>` is cleaner than `Option<ThreadPool<'a>`, because it is more easily constructed.

- The latter requires a separate `rayon::ThreadPool` which must remain alive, because it's captured as a reference in the `ThreadPool<'a>`.
- The former is easily built from an `Option<ThreadPool>`, which is a normal object to own on the stack, using `as_ref()`