### PR TITLE
Add affine transforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
   a point with `i32` coordinates (instead of `f32`).  This helps us distinguish
   between screen (pixel) and world (floating-point) coordinates at the type
   level.
+- Add `Tree::remap_affine` (and `TreeOp::RemapAffine`) to perform affine
+  transformations on math expressions.  These transformations are composable;
+  two affine transforms will be combined into a single transform if stacked
+  together.
 
 # 0.3.5
 - Added `#[derive(Serialize, Deserialize)]` to `View2` and `View3`

--- a/fidget/src/core/context/tree.rs
+++ b/fidget/src/core/context/tree.rs
@@ -458,8 +458,10 @@ mod test {
         let mut ctx = Context::new();
         let v_ = ctx.import(&s);
 
-        assert_eq!(ctx.eval_xyz(v_, 0.0, 1.0, 0.0).unwrap(), 1.0);
-        assert_eq!(ctx.eval_xyz(v_, 0.0, -2.0, 0.0).unwrap(), -2.0);
+        assert!((ctx.eval_xyz(v_, 0.0, 1.0, 0.0).unwrap() - 1.0).abs() < 1e-6);
+        assert!(
+            (ctx.eval_xyz(v_, 0.0, -2.0, 0.0).unwrap() - -2.0).abs() < 1e-6
+        );
     }
 
     #[test]

--- a/fidget/src/core/context/tree.rs
+++ b/fidget/src/core/context/tree.rs
@@ -194,9 +194,9 @@ impl Tree {
     pub fn remap_affine(&self, mat: nalgebra::Affine3<f64>) -> Tree {
         // Flatten affine trees
         let out = match &*self.0 {
-            TreeOp::RemapAffine { target, mat: prev } => TreeOp::RemapAffine {
+            TreeOp::RemapAffine { target, mat: next } => TreeOp::RemapAffine {
                 target: target.clone(),
-                mat: mat * prev,
+                mat: mat * next,
             },
             _ => TreeOp::RemapAffine {
                 target: self.0.clone(),


### PR DESCRIPTION
When building math trees with transforms, merging affine transforms helps to keep intervals tight.