### PR TITLE
Add pow() method on trees

### DIFF
--- a/fidget/src/core/context/tree.rs
+++ b/fidget/src/core/context/tree.rs
@@ -290,6 +290,9 @@ impl Tree {
     pub fn neg(&self) -> Self {
         Self::op_unary(self.clone(), UnaryOpcode::Neg)
     }
+    pub fn recip(&self) -> Self {
+        Self::op_unary(self.clone(), UnaryOpcode::Recip)
+    }
     pub fn sin(&self) -> Self {
         Self::op_unary(self.clone(), UnaryOpcode::Sin)
     }


### PR DESCRIPTION
... using [exponentiation by squaring](https://en.wikipedia.org/wiki/Exponentiation_by_squaring#With_constant_auxiliary_memory). 

I think this is worth including in fidget. The only tweaks from the basic non-recursive algorithm on Wikipedia are:
1. skip an unnecessary multiplication by 1
3. use `recip` instead of 1/x.

produces nice looking graphs, e.g.: x^63

![image](https://github.com/user-attachments/assets/9df96624-2d48-4dfb-ac47-1e426981d1cc)
