### PR TITLE
Render using smaller tiles when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # 0.3.8 (unreleased)
 - Bug fix: `Image::height()` was returning width instead!
 - Add `#[derive(PartialEq)]` to `View2` and `View3`
+- Improve rendering at small images sizes
+    - Previously, we rendered at least one tile of size `cfg.tile_sizes[0]`
+    - Now, we pick the smallest possible tile size for the root tiles; if we're
+      rendering a 32×32 image with tile sizes of `[128, 32, 8]`, then we'll
+      render a single 32×32 tile (instead of 128×128)
+    - As part of this change, a few functions were removed from the `TileSizes`
+      public API; they're now attached to an internal `struct TileSizesRef`.
 
 # 0.3.7
 - Small release to fix an issue with 0.3.6 being published with invalid local

--- a/fidget/src/render/config.rs
+++ b/fidget/src/render/config.rs
@@ -2,7 +2,7 @@ use crate::{
     eval::Function,
     render::{
         GeometryBuffer, Image, ImageSize, RenderConfig, RenderMode, TileSizes,
-        View2, View3, VoxelSize,
+        TileSizesRef, View2, View3, VoxelSize,
     },
     shape::{Shape, ShapeVars},
 };
@@ -134,8 +134,9 @@ impl RenderConfig for ImageRenderConfig<'_> {
     fn threads(&self) -> Option<&ThreadPool> {
         self.threads
     }
-    fn tile_sizes(&self) -> &TileSizes {
-        &self.tile_sizes
+    fn tile_sizes(&self) -> TileSizesRef {
+        let max_size = self.width().max(self.height()) as usize;
+        TileSizesRef::new(&self.tile_sizes, max_size)
     }
     fn is_cancelled(&self) -> bool {
         self.cancel.is_cancelled()
@@ -218,8 +219,9 @@ impl RenderConfig for VoxelRenderConfig<'_> {
     fn threads(&self) -> Option<&ThreadPool> {
         self.threads
     }
-    fn tile_sizes(&self) -> &TileSizes {
-        &self.tile_sizes
+    fn tile_sizes(&self) -> TileSizesRef {
+        let max_size = self.width().max(self.height()) as usize;
+        TileSizesRef::new(&self.tile_sizes, max_size)
     }
     fn is_cancelled(&self) -> bool {
         self.cancel.is_cancelled()


### PR DESCRIPTION
- Previously, we rendered at least one tile of size `cfg.tile_sizes[0]`
- Now, we pick the smallest possible tile size for the root tiles; if we're rendering a 32×32 image with tile sizes of `[128, 32, 8]`, then we'll render a single 32×32 tile (instead of 128×128)
- As part of this change, a few functions were removed from the `TileSizes` public API; they're now attached to an internal `struct TileSizesRef`.