### PR TITLE
Fix shape evaluation of constant functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@
     - These annotations are used in the Rhai bindings to build shapes without
       specifying every field, e.g. `circle(1)` leaves the center as a default
       value.
+- Fix issue where `Shape::eval_*` functions would return an empty slice if there
+  were no active variables in the shape; it now returns a slice that's the
+  correct size (i.e. matching the input slices).
 
 # 0.3.7
 - Small release to fix an issue with 0.3.6 being published with invalid local

--- a/fidget/src/render/render2d.rs
+++ b/fidget/src/render/render2d.rs
@@ -689,6 +689,21 @@ mod test {
         .test(shape, EXPECTED_05);
     }
 
+    fn check_neg_infinity<F: Function + MathFunction>() {
+        let mut ctx = Context::new();
+        let root = ctx.constant(-f64::INFINITY);
+        let shape = Shape::<F>::new(&ctx, root).unwrap();
+
+        let cfg = ImageRenderConfig {
+            image_size: ImageSize::new(256, 256),
+            pixel_perfect: true,
+            threads: None,
+            ..Default::default()
+        };
+        let out = cfg.run(shape).unwrap();
+        assert!(out.into_iter().all(|i| i.inside()));
+    }
+
     macro_rules! render_tests {
         ($i:ident) => {
             mod $i {
@@ -716,6 +731,7 @@ mod test {
     render_tests!(check_hi_bounded);
     render_tests!(check_quarter);
     render_tests!(check_circle_var);
+    render_tests!(check_neg_infinity);
 
     #[test]
     fn render2d_cancel() {


### PR DESCRIPTION
Previously, this would return an empty slice `[]` regardless of input length, which caused panics in image rendering.