### PR TITLE
Use default values in `FromDynamic` conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@
 - Fix issue where `Shape::eval_*` functions would return an empty slice if there
   were no active variables in the shape; it now returns a slice that's the
   correct size (i.e. matching the input slices).
+- In Rhai bindings, `FromDynamic` now takes the field's default value as a hint,
+  which may be used when promoting other types.  For example, if you pass a
+  `vec2` (instead of a `vec3`) to both `Move` and `Scale`, the `z` component
+  will be set to 0 for `Move` and 1 for `Scale`.
 
 # 0.3.7
 - Small release to fix an issue with 0.3.6 being published with invalid local

--- a/fidget/src/rhai/mod.rs
+++ b/fidget/src/rhai/mod.rs
@@ -201,7 +201,7 @@ fn draw(
     ctx: NativeCallContext,
     tree: rhai::Dynamic,
 ) -> Result<(), Box<EvalAltResult>> {
-    let tree = Tree::from_dynamic(&ctx, tree)?;
+    let tree = Tree::from_dynamic(&ctx, tree, None)?;
     let ctx = ctx.tag().unwrap().clone_cast::<Arc<Mutex<ScriptContext>>>();
     ctx.lock().unwrap().shapes.push(DrawShape {
         tree,
@@ -217,7 +217,7 @@ fn draw_rgb(
     g: f64,
     b: f64,
 ) -> Result<(), Box<EvalAltResult>> {
-    let tree = Tree::from_dynamic(&ctx, tree)?;
+    let tree = Tree::from_dynamic(&ctx, tree, None)?;
     let ctx = ctx.tag().unwrap().clone_cast::<Arc<Mutex<ScriptContext>>>();
     let f = |a| {
         if a < 0.0 {
@@ -253,6 +253,7 @@ where
     fn from_dynamic(
         ctx: &rhai::NativeCallContext,
         v: rhai::Dynamic,
+        default: Option<&Self>,
     ) -> Result<Self, Box<EvalAltResult>>;
 }
 
@@ -260,6 +261,7 @@ impl FromDynamic for f64 {
     fn from_dynamic(
         ctx: &rhai::NativeCallContext,
         d: rhai::Dynamic,
+        _default: Option<&f64>,
     ) -> Result<Self, Box<EvalAltResult>> {
         let ty = d.type_name();
         d.clone()

--- a/fidget/src/rhai/shapes.rs
+++ b/fidget/src/rhai/shapes.rs
@@ -533,6 +533,7 @@ unique!(build_unique8, a, b, c, d, e, f, g, h);
 mod test {
     use super::*;
     use crate::shapes::*;
+    use crate::{Context, context::Op, var::Var};
 
     #[test]
     fn circle_builder() {
@@ -574,5 +575,20 @@ mod test {
         assert!(e.eval::<Tree>("circle([1, 2])").is_ok());
 
         assert!(e.eval::<Tree>("circle()").is_ok());
+    }
+
+    #[test]
+    fn scale_and_move_defaults() {
+        let mut e = crate::rhai::Engine::new();
+        let v = e.eval("z.move([1, 1])").unwrap();
+        let mut ctx = Context::new();
+        let root = ctx.import(&v);
+        assert_eq!(ctx.get_op(root).unwrap(), &Op::Input(Var::Z));
+
+        let mut e = crate::rhai::Engine::new();
+        let v = e.eval("z.scale([1, 1])").unwrap();
+        let mut ctx = Context::new();
+        let root = ctx.import(&v);
+        assert_eq!(ctx.get_op(root).unwrap(), &Op::Input(Var::Z));
     }
 }

--- a/fidget/src/rhai/shapes.rs
+++ b/fidget/src/rhai/shapes.rs
@@ -101,34 +101,100 @@ impl TypeTag {
         self,
         ctx: &NativeCallContext,
         v: rhai::Dynamic,
+        default: Option<Type>,
     ) -> Result<Type, Box<EvalAltResult>> {
+        let default = default.as_ref();
         let out = match self {
-            TypeTag::Float => Type::Float(<_>::from_dynamic(ctx, v)?),
-            TypeTag::Vec2 => Type::Vec2(<_>::from_dynamic(ctx, v)?),
-            TypeTag::Vec3 => Type::Vec3(<_>::from_dynamic(ctx, v)?),
-            TypeTag::Vec4 => Type::Vec4(<_>::from_dynamic(ctx, v)?),
-            TypeTag::Tree => Type::Tree(<_>::from_dynamic(ctx, v)?),
-            TypeTag::VecTree => Type::VecTree(<_>::from_dynamic(ctx, v)?),
+            TypeTag::Float => {
+                Type::Float(from_dynamic_with_hint(ctx, v, default)?)
+            }
+            TypeTag::Vec2 => {
+                Type::Vec2(from_dynamic_with_hint(ctx, v, default)?)
+            }
+            TypeTag::Vec3 => {
+                Type::Vec3(from_dynamic_with_hint(ctx, v, default)?)
+            }
+            TypeTag::Vec4 => {
+                Type::Vec4(from_dynamic_with_hint(ctx, v, default)?)
+            }
+            TypeTag::Tree => {
+                Type::Tree(from_dynamic_with_hint(ctx, v, default)?)
+            }
+            TypeTag::VecTree => {
+                Type::VecTree(from_dynamic_with_hint(ctx, v, default)?)
+            }
         };
         Ok(out)
     }
 }
 
+fn from_dynamic_with_hint<T: FromDynamic>(
+    ctx: &NativeCallContext,
+    v: rhai::Dynamic,
+    default: Option<&Type>,
+) -> Result<T, Box<EvalAltResult>>
+where
+    Type: TypeGet<T>,
+{
+    <_>::from_dynamic(ctx, v, default.as_ref().and_then(|d| d.get()))
+}
+
+trait TypeGet<T> {
+    fn get(&self) -> Option<&T>;
+}
+
+macro_rules! type_get {
+    ($ty:ty, $name:ident) => {
+        impl TypeGet<$ty> for Type {
+            fn get(&self) -> Option<&$ty> {
+                if let Type::$name(f) = self {
+                    Some(f)
+                } else {
+                    None
+                }
+            }
+        }
+    };
+    ($ty:ident) => {
+        type_get!($ty, $ty);
+    };
+}
+
+type_get!(f64, Float);
+type_get!(Vec2);
+type_get!(Vec3);
+type_get!(Vec4);
+type_get!(Tree);
+type_get!(Vec<Tree>, VecTree);
+
 impl Type {
     fn from_dynamic(
         ctx: &NativeCallContext,
         v: rhai::Dynamic,
+        default: Option<Type>,
     ) -> Result<Type, Box<EvalAltResult>> {
         // This chain is ordered to prevent implicit conversions, e.g. we check
         // `Vec<Tree>` before `Tree` becaues Tree::from_dynamic` will
-        // automaticalyl collapse a `[Tree]` list.
-        <_>::from_dynamic(ctx, v.clone())
+        // automatically collapse a `[Tree]` list.
+        let default = default.as_ref();
+        from_dynamic_with_hint(ctx, v.clone(), default)
             .map(Type::Float)
-            .or_else(|_| <_>::from_dynamic(ctx, v.clone()).map(Type::Vec2))
-            .or_else(|_| <_>::from_dynamic(ctx, v.clone()).map(Type::Vec3))
-            .or_else(|_| <_>::from_dynamic(ctx, v.clone()).map(Type::Vec4))
-            .or_else(|_| <_>::from_dynamic(ctx, v.clone()).map(Type::VecTree))
-            .or_else(|_| <_>::from_dynamic(ctx, v.clone()).map(Type::Tree))
+            .or_else(|_| {
+                from_dynamic_with_hint(ctx, v.clone(), default).map(Type::Vec2)
+            })
+            .or_else(|_| {
+                from_dynamic_with_hint(ctx, v.clone(), default).map(Type::Vec3)
+            })
+            .or_else(|_| {
+                from_dynamic_with_hint(ctx, v.clone(), default).map(Type::Vec4)
+            })
+            .or_else(|_| {
+                from_dynamic_with_hint(ctx, v.clone(), default)
+                    .map(Type::VecTree)
+            })
+            .or_else(|_| {
+                from_dynamic_with_hint(ctx, v.clone(), default).map(Type::Tree)
+            })
             .map_err(|_| {
                 Box::new(rhai::EvalAltResult::ErrorMismatchDataType(
                     "any Rust-compatible Type".to_string(),
@@ -268,7 +334,7 @@ fn build_transform<T: Facet<'static> + Into<Tree>>(
     t: rhai::Dynamic,
     m: rhai::Map,
 ) -> Result<Tree, Box<EvalAltResult>> {
-    let mut t = Some(Tree::from_dynamic(&ctx, t)?);
+    let mut t = Some(Tree::from_dynamic(&ctx, t, None)?);
 
     let mut builder = facet::Partial::alloc_shape(T::SHAPE).unwrap();
     let facet::Type::User(facet::UserType::Struct(shape)) = T::SHAPE.ty else {
@@ -291,7 +357,11 @@ fn build_transform<T: Facet<'static> + Into<Tree>>(
             )
             .into());
         };
-        let v = tag.into_type(&ctx, v)?;
+        let d = f
+            .vtable
+            .default_fn
+            .map(|df| unsafe { tag.build_from_default_fn(df) });
+        let v = tag.into_type(&ctx, v, d)?;
         v.put(&mut builder, i);
     }
 
@@ -324,7 +394,7 @@ fn build_transform_one<T: Facet<'static> + Into<Tree>>(
     };
     assert_eq!(shape.fields.len(), 2);
 
-    let mut t = Some(Tree::from_dynamic(&ctx, t)?);
+    let mut t = Some(Tree::from_dynamic(&ctx, t, None)?);
     let mut arg = Some(arg);
 
     let mut builder = facet::Partial::alloc_shape(T::SHAPE).unwrap();
@@ -335,7 +405,11 @@ fn build_transform_one<T: Facet<'static> + Into<Tree>>(
             let t = t.take().unwrap();
             builder.set_nth_field(i, t).unwrap();
         } else {
-            let v = tag.into_type(&ctx, arg.take().unwrap())?;
+            let d = f
+                .vtable
+                .default_fn
+                .map(|df| unsafe { tag.build_from_default_fn(df) });
+            let v = tag.into_type(&ctx, arg.take().unwrap(), d)?;
             v.put(&mut builder, i);
         }
     }
@@ -364,8 +438,8 @@ fn build_binary<T: Facet<'static> + Into<Tree>>(
             .all(|f| f.shape().id == ConstTypeId::of::<Tree>())
     );
 
-    let a = Tree::from_dynamic(&ctx, a)?;
-    let b = Tree::from_dynamic(&ctx, b)?;
+    let a = Tree::from_dynamic(&ctx, a, None)?;
+    let b = Tree::from_dynamic(&ctx, b, None)?;
 
     let mut builder = facet::Partial::alloc_shape(T::SHAPE).unwrap();
 
@@ -391,10 +465,14 @@ fn build_from_map<T: Facet<'static> + Into<Tree>>(
     for (i, f) in shape.fields.iter().enumerate() {
         let tag = TypeTag::try_from(f.shape().id).unwrap();
 
+        let d = f
+            .vtable
+            .default_fn
+            .map(|df| unsafe { tag.build_from_default_fn(df) });
         let v = if let Some(v) = m.get(f.name).cloned() {
-            tag.into_type(&ctx, v)?
-        } else if let Some(df) = f.vtable.default_fn {
-            unsafe { tag.build_from_default_fn(df) }
+            tag.into_type(&ctx, v, d)?
+        } else if let Some(v) = d {
+            v
         } else {
             return Err(EvalAltResult::ErrorRuntime(
                 format!("field {} must be provided for {}", f.name, T::SHAPE)
@@ -441,7 +519,7 @@ macro_rules! reducer {
 
             let mut builder = facet::Partial::alloc_shape(&T::SHAPE).unwrap();
             let v = vec![$(
-                Tree::from_dynamic(&ctx, $v)?
+                Tree::from_dynamic(&ctx, $v, None)?
             ),*];
             builder.set_nth_field(0, v).unwrap();
 
@@ -476,20 +554,24 @@ macro_rules! unique {
             };
 
             // Build a map of our known values
-            let mut vs = enum_map::EnumMap::<TypeTag, Option<Type>>::default();
+            let mut vs = enum_map::EnumMap::<TypeTag, Option<rhai::Dynamic>>::default();
             $(
-                let $v = Type::from_dynamic(&ctx, $v)?;
-                let tag = $v.discriminant();
+                let tag = Type::from_dynamic(&ctx, $v.clone(), None)?.discriminant();
                 vs[tag] = Some($v);
             )*
 
             let mut builder = facet::Partial::alloc_shape(&T::SHAPE).unwrap();
             for (i, f) in shape.fields.iter().enumerate() {
                 let tag = TypeTag::try_from(f.shape().id).unwrap();
+
+                let d = f
+                    .vtable
+                    .default_fn
+                    .map(|df| unsafe { tag.build_from_default_fn(df) });
                 let v = if let Some(v) = vs[tag].take() {
+                    tag.into_type(&ctx, v, d).unwrap()
+                } else if let Some(v) = d {
                     v
-                } else if let Some(df) = f.vtable.default_fn {
-                    unsafe { tag.build_from_default_fn(df) }
                 } else {
                     return Err(EvalAltResult::ErrorRuntime(
                         format!("missing argument of type {}", f.shape())
@@ -579,12 +661,14 @@ mod test {
 
     #[test]
     fn scale_and_move_defaults() {
+        // Move should default to 0 on the Z axis
         let mut e = crate::rhai::Engine::new();
         let v = e.eval("z.move([1, 1])").unwrap();
         let mut ctx = Context::new();
         let root = ctx.import(&v);
         assert_eq!(ctx.get_op(root).unwrap(), &Op::Input(Var::Z));
 
+        // Scale should default to 1 on the Z axis
         let mut e = crate::rhai::Engine::new();
         let v = e.eval("z.scale([1, 1])").unwrap();
         let mut ctx = Context::new();

--- a/fidget/src/rhai/tree.rs
+++ b/fidget/src/rhai/tree.rs
@@ -6,12 +6,13 @@ impl FromDynamic for Tree {
     fn from_dynamic(
         ctx: &rhai::NativeCallContext,
         d: rhai::Dynamic,
+        _default: Option<&Tree>,
     ) -> Result<Self, Box<EvalAltResult>> {
         if let Some(t) = d.clone().try_cast::<Tree>() {
             Ok(t)
-        } else if let Ok(v) = f64::from_dynamic(ctx, d.clone()) {
+        } else if let Ok(v) = f64::from_dynamic(ctx, d.clone(), None) {
             Ok(Tree::constant(v))
-        } else if let Ok(v) = <Vec<Tree>>::from_dynamic(ctx, d.clone()) {
+        } else if let Ok(v) = <Vec<Tree>>::from_dynamic(ctx, d.clone(), None) {
             Ok(crate::shapes::Union { input: v }.into())
         } else {
             Err(Box::new(rhai::EvalAltResult::ErrorMismatchDataType(
@@ -27,10 +28,11 @@ impl FromDynamic for Vec<Tree> {
     fn from_dynamic(
         ctx: &rhai::NativeCallContext,
         d: rhai::Dynamic,
+        _default: Option<&Vec<Tree>>,
     ) -> Result<Self, Box<EvalAltResult>> {
         if let Ok(d) = d.clone().into_array() {
             d.into_iter()
-                .map(|v| Tree::from_dynamic(ctx, v))
+                .map(|v| Tree::from_dynamic(ctx, v, None))
                 .collect::<Result<Vec<_>, _>>()
         } else {
             Err(Box::new(rhai::EvalAltResult::ErrorMismatchDataType(
@@ -102,7 +104,7 @@ fn remap_xyz(
     y: Tree,
     z: Tree,
 ) -> Result<Tree, Box<EvalAltResult>> {
-    let shape = Tree::from_dynamic(&ctx, shape)?;
+    let shape = Tree::from_dynamic(&ctx, shape, None)?;
     Ok(shape.remap_xyz(x, y, z))
 }
 
@@ -119,7 +121,7 @@ macro_rules! define_binary_fns {
                 a: Tree,
                 b: rhai::Dynamic,
             ) -> Result<Tree, Box<rhai::EvalAltResult>> {
-                let b = Tree::from_dynamic(&ctx, b)?;
+                let b = Tree::from_dynamic(&ctx, b, None)?;
                 Ok(a.$name(b))
             }
             pub fn dyn_tree(
@@ -127,7 +129,7 @@ macro_rules! define_binary_fns {
                 a: rhai::Dynamic,
                 b: Tree,
             ) -> Result<Tree, Box<rhai::EvalAltResult>> {
-                let a = Tree::from_dynamic(&ctx, a)?;
+                let a = Tree::from_dynamic(&ctx, a, None)?;
                 Ok(a.$name(b))
             }
         }
@@ -142,7 +144,7 @@ macro_rules! define_unary_fns {
                 ctx: NativeCallContext,
                 a: rhai::Dynamic,
             ) -> Result<Tree, Box<EvalAltResult>> {
-                let a = Tree::from_dynamic(&ctx, a)?;
+                let a = Tree::from_dynamic(&ctx, a, None)?;
                 Ok(a.$name())
             }
         }

--- a/fidget/src/rhai/vec.rs
+++ b/fidget/src/rhai/vec.rs
@@ -74,8 +74,8 @@ impl CustomType for Vec2 {
                  x: rhai::Dynamic,
                  y: rhai::Dynamic|
                  -> Result<Self, Box<EvalAltResult>> {
-                    let x = f64::from_dynamic(&ctx, x)?;
-                    let y = f64::from_dynamic(&ctx, y)?;
+                    let x = f64::from_dynamic(&ctx, x, None)?;
+                    let y = f64::from_dynamic(&ctx, y, None)?;
                     Ok(Self { x, y })
                 },
             )
@@ -95,9 +95,9 @@ impl CustomType for Vec3 {
                  y: rhai::Dynamic,
                  z: rhai::Dynamic|
                  -> Result<Self, Box<EvalAltResult>> {
-                    let x = f64::from_dynamic(&ctx, x)?;
-                    let y = f64::from_dynamic(&ctx, y)?;
-                    let z = f64::from_dynamic(&ctx, z)?;
+                    let x = f64::from_dynamic(&ctx, x, None)?;
+                    let y = f64::from_dynamic(&ctx, y, None)?;
+                    let z = f64::from_dynamic(&ctx, z, None)?;
                     Ok(Self { x, y, z })
                 },
             )
@@ -111,6 +111,7 @@ impl FromDynamic for Vec2 {
     fn from_dynamic(
         ctx: &rhai::NativeCallContext,
         d: rhai::Dynamic,
+        _default: Option<&Vec2>,
     ) -> Result<Self, Box<EvalAltResult>> {
         if let Some(v) = d.clone().try_cast() {
             Ok(v)
@@ -124,8 +125,8 @@ impl FromDynamic for Vec2 {
             })?;
             match array.len() {
                 2 => {
-                    let x = f64::from_dynamic(ctx, array[0].clone())?;
-                    let y = f64::from_dynamic(ctx, array[1].clone())?;
+                    let x = f64::from_dynamic(ctx, array[0].clone(), None)?;
+                    let y = f64::from_dynamic(ctx, array[1].clone(), None)?;
                     Ok(Vec2 { x, y })
                 }
                 n => Err(EvalAltResult::ErrorMismatchDataType(
@@ -143,12 +144,13 @@ impl FromDynamic for Vec3 {
     fn from_dynamic(
         ctx: &rhai::NativeCallContext,
         d: rhai::Dynamic,
+        default: Option<&Vec3>,
     ) -> Result<Self, Box<EvalAltResult>> {
-        if let Ok(v) = Vec2::from_dynamic(ctx, d.clone()) {
+        if let Ok(v) = Vec2::from_dynamic(ctx, d.clone(), None) {
             Ok(Vec3 {
                 x: v.x,
                 y: v.y,
-                z: 0.0,
+                z: default.map(|d| d.z).unwrap_or(0.0),
             })
         } else if let Some(v) = d.clone().try_cast() {
             Ok(v)
@@ -162,9 +164,9 @@ impl FromDynamic for Vec3 {
             })?;
             match array.len() {
                 3 => {
-                    let x = f64::from_dynamic(ctx, array[0].clone())?;
-                    let y = f64::from_dynamic(ctx, array[1].clone())?;
-                    let z = f64::from_dynamic(ctx, array[2].clone())?;
+                    let x = f64::from_dynamic(ctx, array[0].clone(), None)?;
+                    let y = f64::from_dynamic(ctx, array[1].clone(), None)?;
+                    let z = f64::from_dynamic(ctx, array[2].clone(), None)?;
                     Ok(Vec3 { x, y, z })
                 }
                 n => Err(EvalAltResult::ErrorMismatchDataType(
@@ -182,6 +184,7 @@ impl FromDynamic for Vec4 {
     fn from_dynamic(
         ctx: &rhai::NativeCallContext,
         d: rhai::Dynamic,
+        _default: Option<&Vec4>,
     ) -> Result<Self, Box<EvalAltResult>> {
         if let Some(v) = d.clone().try_cast() {
             Ok(v)
@@ -195,10 +198,10 @@ impl FromDynamic for Vec4 {
             })?;
             match array.len() {
                 4 => {
-                    let x = f64::from_dynamic(ctx, array[0].clone())?;
-                    let y = f64::from_dynamic(ctx, array[1].clone())?;
-                    let z = f64::from_dynamic(ctx, array[2].clone())?;
-                    let w = f64::from_dynamic(ctx, array[3].clone())?;
+                    let x = f64::from_dynamic(ctx, array[0].clone(), None)?;
+                    let y = f64::from_dynamic(ctx, array[1].clone(), None)?;
+                    let z = f64::from_dynamic(ctx, array[2].clone(), None)?;
+                    let w = f64::from_dynamic(ctx, array[3].clone(), None)?;
                     Ok(Vec4 { x, y, z, w })
                 }
                 n => Err(EvalAltResult::ErrorMismatchDataType(


### PR DESCRIPTION
This improves the `vec2` → `vec3` implicit conversions, e.g. `shape.move([1, 1])` should use Z = 0, while `shape.scale([1, 1])` should use Z = 1.