### PR TITLE
Do arithmetic optimizations in `Context::import`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
   re-exporting them in `fidget::shapes`.
 - Make `fidget::shapes::types::{Value, Type}` public; these represent types
   which can be used in shapes (with ergonomic Rhai bindings).
+- Fix missing local optimizations in `Context::import` (e.g. `x * 0 => 0`)
 
 # 0.3.7
 - Small release to fix an issue with 0.3.6 being published with invalid local

--- a/fidget/src/core/context/mod.rs
+++ b/fidget/src/core/context/mod.rs
@@ -1642,4 +1642,12 @@ mod test {
             panic!("unexpected opcode {t:?}");
         }
     }
+
+    #[test]
+    fn import_optimization() {
+        let t = Tree::x() + 0;
+        let mut ctx = Context::new();
+        let root = ctx.import(&t);
+        assert_eq!(ctx.get_op(root).unwrap(), &Op::Input(Var::X));
+    }
 }

--- a/fidget/src/core/context/mod.rs
+++ b/fidget/src/core/context/mod.rs
@@ -1190,7 +1190,21 @@ impl Context {
                         TreeOp::Binary(op, ..) => {
                             let lhs = stack.pop().unwrap();
                             let rhs = stack.pop().unwrap();
-                            let out = self.op_binary(lhs, rhs, *op).unwrap();
+                            // Call individual builders to apply optimizations
+                            let out = match op {
+                                BinaryOpcode::Add => self.add(lhs, rhs),
+                                BinaryOpcode::Sub => self.sub(lhs, rhs),
+                                BinaryOpcode::Mul => self.mul(lhs, rhs),
+                                BinaryOpcode::Div => self.div(lhs, rhs),
+                                BinaryOpcode::Atan => self.atan2(lhs, rhs),
+                                BinaryOpcode::Min => self.min(lhs, rhs),
+                                BinaryOpcode::Max => self.max(lhs, rhs),
+                                BinaryOpcode::Compare => self.compare(lhs, rhs),
+                                BinaryOpcode::Mod => self.modulo(lhs, rhs),
+                                BinaryOpcode::And => self.and(lhs, rhs),
+                                BinaryOpcode::Or => self.or(lhs, rhs),
+                            }
+                            .unwrap();
                             if Arc::strong_count(t) > 1 {
                                 seen.insert(
                                     (*axes.last().unwrap(), Arc::as_ptr(t)),


### PR DESCRIPTION
This helps for non-affine transformations, which may have identity operations.