### PR TITLE
Improve `Tree` ergonomics in Rhai

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@
 - Make `fidget::shapes::types::{Value, Type}` public; these represent types
   which can be used in shapes (with ergonomic Rhai bindings).
 - Fix missing local optimizations in `Context::import` (e.g. `x * 0 => 0`)
+- Rename `remap_xyz(..)` to just `remap(..)` in Rhai bindings; add a
+  two-argument version which leaves `z` unchanged
 
 # 0.3.7
 - Small release to fix an issue with 0.3.6 being published with invalid local

--- a/models/cabin.rhai
+++ b/models/cabin.rhai
@@ -2,8 +2,8 @@
 // Perspective render: --scale 0.05 --pitch 80 --roll 130 --center=0,0,-14 --perspective=0.2 --zflatten 2
 let logs = x.abs() - 10 -  max(0.05, 1.0 - (y % 2 - 1).square()).sqrt();
 let cabin = max(
-    logs.remap_xyz(x, z, y),
-    logs.remap_xyz(y, z, x)
+    logs.remap(x, z, y),
+    logs.remap(y, z, x)
 );
 
 let roof = z/2 + y.abs()/2 - 15;
@@ -23,7 +23,7 @@ let door_width = max(10 - x, x - 11);
 let door_frame = max(max(door_frame, door_frame_inner),
     door_width);
 let doorknob = (x.square() + y.square() + z.square()).sqrt() - 0.6;
-let door = min(door_frame, doorknob.remap_xyz(x - 10.5, y - 2, z - 6));
+let door = min(door_frame, doorknob.remap(x - 10.5, y - 2, z - 6));
 let cabin = max(cabin, -max(-door_frame_inner, door_width));
 let cabin = min(cabin, door);
 

--- a/models/sponge.rhai
+++ b/models/sponge.rhai
@@ -2,18 +2,18 @@
 // Recommended render settings: --scale 0.75 --pitch -25 --yaw -30
 fn recurse(x, y, z, depth) {
     let r = ((x + 1) % 2 - 1).abs();
-    let base = intersection(r, r.remap_xyz(y, x, z)) - 1/3.;
+    let base = intersection(r, r.remap(y, x, z)) - 1/3.;
     let out = base;
     for i in 0..depth {
-        out = union(base, out.remap_xyz(x * 3, y * 3, z))
+        out = union(base, out.remap(x * 3, y * 3, z))
     }
     out
 }
 
 let square = intersection(x.abs() - 1, y.abs() - 1);
 let xy = difference(square, recurse(x, y, z, 3));
-let yz = xy.remap_xyz(y, z, x);
-let zx = xy.remap_xyz(z, x, y);
+let yz = xy.remap(y, z, x);
+let zx = xy.remap(z, x, y);
 let sponge = intersection(intersection(xy, yz), zx);
 
 let radius = (x.square() + y.square() + z.square()).sqrt();
@@ -22,4 +22,4 @@ let rescale = manhattan / radius;
 let blend = 1.0; // adjust the sphere-ness of the sponge
 let r = (rescale * blend) + (1.0 - blend);
 
-draw(sponge.remap_xyz(x / r, y / r, z / r));
+draw(sponge.remap(x / r, y / r, z / r));


### PR DESCRIPTION
- Add minimal printer, which knows about X/Y/Z, and otherwise prints `Tree(..)`
- Rename `remap_xyz` to `remap`, and add a two-argument variant (which ignores Z)