### PR TITLE
Add `center` argument for 2d rendering in `fidget-cli`

### DIFF
--- a/demos/viewer/src/main.rs
+++ b/demos/viewer/src/main.rs
@@ -281,7 +281,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     file_watcher_tx.send(()).unwrap()
                 }
             }
-            Err(e) => panic!("watch error: {:?}", e),
+            Err(e) => panic!("watch error: {e:?}"),
         },
     )
     .unwrap();

--- a/fidget/src/core/context/mod.rs
+++ b/fidget/src/core/context/mod.rs
@@ -1019,7 +1019,7 @@ impl Context {
         let mut out = format!(r#"n{} [label = ""#, i.get());
         let op = self.get_op(i).unwrap();
         match op {
-            Op::Const(c) => write!(out, "{}", c).unwrap(),
+            Op::Const(c) => write!(out, "{c}").unwrap(),
             Op::Input(v) => {
                 out += &v.to_string();
             }

--- a/fidget/src/rhai/shapes.rs
+++ b/fidget/src/rhai/shapes.rs
@@ -454,7 +454,7 @@ fn from_enum_map<T: Facet<'static> + Into<Tree>>(
 
     if let Some((k, _v)) = vs.iter().find(|(_k, v)| v.is_some()) {
         return Err(EvalAltResult::ErrorRuntime(
-            format!("shape does not have an argument of type {:?}", k).into(),
+            format!("shape does not have an argument of type {k:?}").into(),
             ctx.position(),
         )
         .into());

--- a/fidget/src/shapes/types.rs
+++ b/fidget/src/shapes/types.rs
@@ -434,7 +434,7 @@ impl std::fmt::Display for Type {
             Type::Tree => "Tree",
             Type::VecTree => "Vec<Tree>",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 


### PR DESCRIPTION
(also fixes new clippy lints, presumably in Rust 1.88)