### PR TITLE
Fix bulk evaluation with > 1 output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # 0.3.9 (unreleased)
+- Fix invalid access when doing bulk evaluation on a `Function` with more than
+  one output.  This caused a panic using the VM evaluator, and a segfault
+  (typically) using the JIT evaluator.
 - Make `PartialEq` for `Tree` objects do deep comparisons, instead of shallow
   (pointer) equality
     - This is more expensive, but matches typical data structures in Rust

--- a/fidget/src/core/eval/test/float_slice.rs
+++ b/fidget/src/core/eval/test/float_slice.rs
@@ -210,6 +210,39 @@ impl<F: Function + MathFunction> TestFloatSlice<F> {
         }
     }
 
+    pub fn test_f_multiple_outputs() {
+        let mut ctx = Context::new();
+        let rgb = [ctx.x(), ctx.y(), ctx.z()];
+
+        let f = F::new(&ctx, &rgb).unwrap();
+        let vars = f.vars();
+        let tape = f.float_slice_tape(Default::default());
+
+        let mut eval = F::new_float_slice_eval();
+        let xs = vec![0f32; 8];
+        let ys = vec![1f32; 8];
+        let zs = vec![2f32; 8];
+
+        // Dummy values, which we have to shuffle around
+        let mut vs = [xs.as_slice(), ys.as_slice(), zs.as_slice()];
+        if let Some(ix) = vars.get(&Var::X) {
+            vs[ix] = &xs;
+        }
+        if let Some(iy) = vars.get(&Var::Y) {
+            vs[iy] = &ys;
+        }
+        if let Some(iz) = vars.get(&Var::Z) {
+            vs[iz] = &zs;
+        }
+        let out = eval.eval(&tape, &vs).unwrap();
+        let r = &out[0];
+        let g = &out[1];
+        let b = &out[2];
+        assert!(r.iter().all(|r| *r == 0.0));
+        assert!(g.iter().all(|g| *g == 1.0));
+        assert!(b.iter().all(|b| *b == 2.0));
+    }
+
     pub fn test_f_stress() {
         for n in [4, 8, 12, 16, 32, 256, 512] {
             Self::test_f_stress_n(n);
@@ -385,6 +418,7 @@ macro_rules! float_slice_tests {
         $crate::float_slice_test!(test_f_sin, $t);
         $crate::float_slice_test!(test_f_shape_var, $t);
         $crate::float_slice_test!(test_f_stress, $t);
+        $crate::float_slice_test!(test_f_multiple_outputs, $t);
 
         mod f_unary {
             use super::*;

--- a/fidget/src/core/eval/test/interval.rs
+++ b/fidget/src/core/eval/test/interval.rs
@@ -922,6 +922,39 @@ where
         out
     }
 
+    pub fn test_i_multiple_outputs() {
+        let mut ctx = Context::new();
+        let rgb = [ctx.x(), ctx.y(), ctx.z()];
+
+        let f = F::new(&ctx, &rgb).unwrap();
+        let vars = f.vars();
+        let tape = f.interval_tape(Default::default());
+
+        let mut eval = F::new_interval_eval();
+        let xs = [0f32, 1f32].into();
+        let ys = [2f32, 3f32].into();
+        let zs = [4f32, 5f32].into();
+
+        // Dummy values, which we have to shuffle around
+        let mut vs = [xs, ys, zs];
+        if let Some(ix) = vars.get(&Var::X) {
+            vs[ix] = xs;
+        }
+        if let Some(iy) = vars.get(&Var::Y) {
+            vs[iy] = ys;
+        }
+        if let Some(iz) = vars.get(&Var::Z) {
+            vs[iz] = zs;
+        }
+        let (out, _trace) = eval.eval(&tape, &vs).unwrap();
+        let r = out[0];
+        let g = out[1];
+        let b = out[2];
+        assert_eq!(r, Interval::new(0.0, 1.0));
+        assert_eq!(g, Interval::new(2.0, 3.0));
+        assert_eq!(b, Interval::new(4.0, 5.0));
+    }
+
     pub fn test_unary<C: CanonicalUnaryOp>() {
         let args = Self::interval_test_args();
 
@@ -1196,6 +1229,7 @@ macro_rules! interval_tests {
         $crate::interval_test!(test_i_simplify, $t);
         $crate::interval_test!(test_i_simplify_conditional, $t);
         $crate::interval_test!(test_i_stress, $t);
+        $crate::interval_test!(test_i_multiple_outputs, $t);
 
         mod i_unary {
             use super::*;

--- a/fidget/src/core/vm/mod.rs
+++ b/fidget/src/core/vm/mod.rs
@@ -841,9 +841,8 @@ impl<T: From<f32> + Clone> BulkVmEval<T> {
             s.resize(size, f32::NAN.into());
         }
 
-        const OUTPUT_COUNT: usize = 1;
         self.out
-            .resize_with(OUTPUT_COUNT, || vec![f32::NAN.into(); size]);
+            .resize_with(tape.output_count(), || vec![f32::NAN.into(); size]);
         for o in self.out.iter_mut() {
             o.resize(size, f32::NAN.into());
         }

--- a/fidget/src/jit/mod.rs
+++ b/fidget/src/jit/mod.rs
@@ -1226,8 +1226,7 @@ impl<T: From<f32> + Copy + SimdSize> JitBulkEval<T> {
     ) -> BulkOutput<T> {
         let n = vars.first().map(|v| v.deref().len()).unwrap_or(0);
 
-        const OUTPUT_COUNT: usize = 1;
-        self.out.resize_with(OUTPUT_COUNT, Vec::new);
+        self.out.resize_with(tape.output_count(), Vec::new);
         for o in &mut self.out {
             o.resize(n.max(T::SIMD_SIZE), f32::NAN.into());
             o.fill(f32::NAN.into());


### PR DESCRIPTION
No idea why this was still hard-coded, but it's an easy fix!