### PR TITLE
Replace `view` with `world_to_model` in render configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
     - `Tree::ptr_eq` can be used to perform shallow equality checks
 - Changed 3D image rendering to saturate when voxels are touching the camera.
   Saturated voxels snap to the image's depth and have a normal of `[0, 0, 1]`.
+- Replaced `view` in `ImageRenderConfig` and `VoxelRenderConfig` with a generic
+  `world_to_model` matrix, for more flexibility when rendering.
 
 # 0.3.8
 - Bug fix: `Image::height()` was returning width instead!

--- a/demos/viewer/src/main.rs
+++ b/demos/viewer/src/main.rs
@@ -177,7 +177,7 @@ fn render_2d<F: fidget::eval::Function + fidget::render::RenderHints>(
     let config = ImageRenderConfig {
         image_size,
         tile_sizes: F::tile_sizes_2d(),
-        view,
+        world_to_model: view.world_to_model(),
         pixel_perfect: matches!(mode, Mode2D::Sdf),
         ..Default::default()
     };
@@ -211,7 +211,7 @@ fn render_3d<F: fidget::eval::Function + fidget::render::RenderHints>(
     let config = VoxelRenderConfig {
         image_size,
         tile_sizes: F::tile_sizes_3d(),
-        view,
+        world_to_model: view.world_to_model(),
         ..Default::default()
     };
 

--- a/demos/web-editor/crate/src/lib.rs
+++ b/demos/web-editor/crate/src/lib.rs
@@ -66,7 +66,7 @@ pub fn render_2d(
             threads: Some(&ThreadPool::Global),
             tile_sizes: TileSizes::new(&[64, 16, 8]).unwrap(),
             pixel_perfect: false,
-            view,
+            world_to_model: view.world_to_model(),
             cancel,
         };
 
@@ -131,7 +131,7 @@ fn render_3d_inner(
         image_size: VoxelSize::from(image_size as u32),
         threads: Some(&ThreadPool::Global),
         tile_sizes: TileSizes::new(&[128, 64, 32, 16, 8]).unwrap(),
-        view,
+        world_to_model: view.world_to_model(),
         cancel,
     };
     cfg.run(shape.clone())

--- a/fidget/src/render/config.rs
+++ b/fidget/src/render/config.rs
@@ -93,7 +93,7 @@ pub struct ImageRenderConfig<'a> {
     pub image_size: ImageSize,
 
     /// World-to-model transform
-    pub view: View2,
+    pub world_to_model: nalgebra::Matrix3<f32>,
 
     /// Render the distance values of individual pixels
     pub pixel_perfect: bool,
@@ -120,7 +120,7 @@ impl Default for ImageRenderConfig<'_> {
         Self {
             image_size: ImageSize::from(512),
             tile_sizes: TileSizes::new(&[128, 32, 8]).unwrap(),
-            view: View2::default(),
+            world_to_model: View2::default().world_to_model(),
             pixel_perfect: false,
             threads: Some(&ThreadPool::Global),
             cancel: CancelToken::new(),
@@ -167,7 +167,7 @@ impl ImageRenderConfig<'_> {
 
     /// Returns the combined screen-to-model transform matrix
     pub fn mat(&self) -> Matrix3<f32> {
-        self.view.world_to_model() * self.image_size.screen_to_world()
+        self.world_to_model * self.image_size.screen_to_world()
     }
 }
 
@@ -181,7 +181,7 @@ pub struct VoxelRenderConfig<'a> {
     pub image_size: VoxelSize,
 
     /// World-to-model transform
-    pub view: View3,
+    pub world_to_model: nalgebra::Matrix4<f32>,
 
     /// Tile sizes to use during evaluation.
     ///
@@ -205,7 +205,7 @@ impl Default for VoxelRenderConfig<'_> {
         Self {
             image_size: VoxelSize::from(512),
             tile_sizes: TileSizes::new(&[128, 64, 32, 16, 8]).unwrap(),
-            view: View3::default(),
+            world_to_model: View3::default().world_to_model(),
 
             threads: Some(&ThreadPool::Global),
             cancel: CancelToken::new(),
@@ -256,7 +256,7 @@ impl VoxelRenderConfig<'_> {
 
     /// Returns the combined screen-to-model transform matrix
     pub fn mat(&self) -> Matrix4<f32> {
-        self.view.world_to_model() * self.image_size.screen_to_world()
+        self.world_to_model * self.image_size.screen_to_world()
     }
 }
 
@@ -341,10 +341,11 @@ mod test {
     fn test_camera_render_config() {
         let config = ImageRenderConfig {
             image_size: ImageSize::from(512),
-            view: View2::from_center_and_scale(
+            world_to_model: View2::from_center_and_scale(
                 nalgebra::Vector2::new(0.5, 0.5),
                 0.5,
-            ),
+            )
+            .world_to_model(),
             ..Default::default()
         };
         let mat = config.mat();
@@ -363,10 +364,11 @@ mod test {
 
         let config = ImageRenderConfig {
             image_size: ImageSize::from(512),
-            view: View2::from_center_and_scale(
+            world_to_model: View2::from_center_and_scale(
                 nalgebra::Vector2::new(0.5, 0.5),
                 0.25,
-            ),
+            )
+            .world_to_model(),
             ..Default::default()
         };
         let mat = config.mat();

--- a/fidget/src/render/render2d.rs
+++ b/fidget/src/render/render2d.rs
@@ -360,7 +360,7 @@ mod test {
             let width = if self.wide { 64 } else { 32 };
             let cfg = ImageRenderConfig {
                 image_size: ImageSize::new(width, 32),
-                view: self.view,
+                world_to_model: self.view.world_to_model(),
                 ..Default::default()
             };
             let out = cfg

--- a/fidget/src/render/render3d.rs
+++ b/fidget/src/render/render3d.rs
@@ -420,7 +420,11 @@ mod test {
         for scale in [1.0, 0.5] {
             let cfg = VoxelRenderConfig {
                 image_size: VoxelSize::from(size),
-                view: View3::from_center_and_scale(Vector3::zeros(), scale),
+                world_to_model: View3::from_center_and_scale(
+                    Vector3::zeros(),
+                    scale,
+                )
+                .world_to_model(),
                 ..Default::default()
             };
             let m = cfg.image_size.screen_to_world();


### PR DESCRIPTION
This provides more flexibility to adjust the transform matrix, e.g. for perspective or z-flattening.