### PR TITLE
Add constants for Rhai scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   Saturated voxels snap to the image's depth and have a normal of `[0, 0, 1]`.
 - Replaced `view` in `ImageRenderConfig` and `VoxelRenderConfig` with a generic
   `world_to_model` matrix, for more flexibility when rendering.
+- Add mathematical constants for Rhai scripts (`PI`, `E`, `TAU`...)
 
 # 0.3.8
 - Bug fix: `Image::height()` was returning width instead!

--- a/fidget/src/rhai/constants.rs
+++ b/fidget/src/rhai/constants.rs
@@ -8,34 +8,34 @@ pub fn get_constant(name: &str) -> Option<f64> {
         "PI" => Some(consts::PI),
         "E" => Some(consts::E),
         "TAU" => Some(consts::TAU),
-        
+
         // Square roots
         "SQRT_2" => Some(consts::SQRT_2),
-        
+
         // Logarithms
         "LN_2" => Some(consts::LN_2),
         "LN_10" => Some(consts::LN_10),
         "LOG2_E" => Some(consts::LOG2_E),
         "LOG10_E" => Some(consts::LOG10_E),
-        
+
         // Fractions of PI
         "FRAC_PI_2" => Some(consts::FRAC_PI_2),
         "FRAC_PI_3" => Some(consts::FRAC_PI_3),
         "FRAC_PI_4" => Some(consts::FRAC_PI_4),
         "FRAC_PI_6" => Some(consts::FRAC_PI_6),
         "FRAC_PI_8" => Some(consts::FRAC_PI_8),
-        
+
         // Reciprocals of PI
         "FRAC_1_PI" => Some(consts::FRAC_1_PI),
         "FRAC_2_PI" => Some(consts::FRAC_2_PI),
         "FRAC_2_SQRT_PI" => Some(consts::FRAC_2_SQRT_PI),
-        
+
         // Golden ratio and related constants
         "PHI" | "GOLDEN_RATIO" => Some(1.618033988749895_f64), // Golden ratio (1 + sqrt(5)) / 2
-        
+
         // Common fractions
         "FRAC_1_SQRT_2" => Some(consts::FRAC_1_SQRT_2),
-        
+
         _ => None,
     }
 }
@@ -43,21 +43,41 @@ pub fn get_constant(name: &str) -> Option<f64> {
 #[cfg(test)]
 mod test {
     use super::*;
-    
+
     #[test]
     fn test_get_constant() {
         // Test basic constants
-        assert!((get_constant("PI").unwrap() - std::f64::consts::PI).abs() < f64::EPSILON);
-        assert!((get_constant("E").unwrap() - std::f64::consts::E).abs() < f64::EPSILON);
-        assert!((get_constant("TAU").unwrap() - std::f64::consts::TAU).abs() < f64::EPSILON);
-        
+        assert!(
+            (get_constant("PI").unwrap() - std::f64::consts::PI).abs()
+                < f64::EPSILON
+        );
+        assert!(
+            (get_constant("E").unwrap() - std::f64::consts::E).abs()
+                < f64::EPSILON
+        );
+        assert!(
+            (get_constant("TAU").unwrap() - std::f64::consts::TAU).abs()
+                < f64::EPSILON
+        );
+
         // Test golden ratio
-        assert!((get_constant("PHI").unwrap() - 1.618033988749895_f64).abs() < f64::EPSILON);
-        assert!((get_constant("GOLDEN_RATIO").unwrap() - 1.618033988749895_f64).abs() < f64::EPSILON);
-        
+        assert!(
+            (get_constant("PHI").unwrap() - 1.618033988749895_f64).abs()
+                < f64::EPSILON
+        );
+        assert!(
+            (get_constant("GOLDEN_RATIO").unwrap() - 1.618033988749895_f64)
+                .abs()
+                < f64::EPSILON
+        );
+
         // Test fractions of PI
-        assert!((get_constant("FRAC_PI_2").unwrap() - std::f64::consts::FRAC_PI_2).abs() < f64::EPSILON);
-        
+        assert!(
+            (get_constant("FRAC_PI_2").unwrap() - std::f64::consts::FRAC_PI_2)
+                .abs()
+                < f64::EPSILON
+        );
+
         // Test unknown constant
         assert!(get_constant("UNKNOWN").is_none());
     }

--- a/fidget/src/rhai/constants.rs
+++ b/fidget/src/rhai/constants.rs
@@ -1,0 +1,64 @@
+//! Mathematical constants for Rhai scripts
+use std::f64::consts;
+
+/// Get a mathematical constant by name
+pub fn get_constant(name: &str) -> Option<f64> {
+    match name {
+        // Basic mathematical constants
+        "PI" => Some(consts::PI),
+        "E" => Some(consts::E),
+        "TAU" => Some(consts::TAU),
+        
+        // Square roots
+        "SQRT_2" => Some(consts::SQRT_2),
+        
+        // Logarithms
+        "LN_2" => Some(consts::LN_2),
+        "LN_10" => Some(consts::LN_10),
+        "LOG2_E" => Some(consts::LOG2_E),
+        "LOG10_E" => Some(consts::LOG10_E),
+        
+        // Fractions of PI
+        "FRAC_PI_2" => Some(consts::FRAC_PI_2),
+        "FRAC_PI_3" => Some(consts::FRAC_PI_3),
+        "FRAC_PI_4" => Some(consts::FRAC_PI_4),
+        "FRAC_PI_6" => Some(consts::FRAC_PI_6),
+        "FRAC_PI_8" => Some(consts::FRAC_PI_8),
+        
+        // Reciprocals of PI
+        "FRAC_1_PI" => Some(consts::FRAC_1_PI),
+        "FRAC_2_PI" => Some(consts::FRAC_2_PI),
+        "FRAC_2_SQRT_PI" => Some(consts::FRAC_2_SQRT_PI),
+        
+        // Golden ratio and related constants
+        "PHI" | "GOLDEN_RATIO" => Some(1.618033988749895_f64), // Golden ratio (1 + sqrt(5)) / 2
+        
+        // Common fractions
+        "FRAC_1_SQRT_2" => Some(consts::FRAC_1_SQRT_2),
+        
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    
+    #[test]
+    fn test_get_constant() {
+        // Test basic constants
+        assert!((get_constant("PI").unwrap() - std::f64::consts::PI).abs() < f64::EPSILON);
+        assert!((get_constant("E").unwrap() - std::f64::consts::E).abs() < f64::EPSILON);
+        assert!((get_constant("TAU").unwrap() - std::f64::consts::TAU).abs() < f64::EPSILON);
+        
+        // Test golden ratio
+        assert!((get_constant("PHI").unwrap() - 1.618033988749895_f64).abs() < f64::EPSILON);
+        assert!((get_constant("GOLDEN_RATIO").unwrap() - 1.618033988749895_f64).abs() < f64::EPSILON);
+        
+        // Test fractions of PI
+        assert!((get_constant("FRAC_PI_2").unwrap() - std::f64::consts::FRAC_PI_2).abs() < f64::EPSILON);
+        
+        // Test unknown constant
+        assert!(get_constant("UNKNOWN").is_none());
+    }
+}

--- a/fidget/src/rhai/mod.rs
+++ b/fidget/src/rhai/mod.rs
@@ -377,16 +377,18 @@ mod test {
     #[test]
     fn test_constants() {
         let engine = engine();
-        
+
         // Test that PI constant is available
         let pi: f64 = engine.eval("PI").unwrap();
         assert!((pi - std::f64::consts::PI).abs() < f64::EPSILON);
-        
+
         // Test using constants in angular calculations
-        let t = engine.eval("let angle = PI / 4.0; x * cos(angle) + y * sin(angle)").unwrap();
+        let t = engine
+            .eval("let angle = PI / 4.0; x * cos(angle) + y * sin(angle)")
+            .unwrap();
         let mut ctx = Context::new();
         let expr = ctx.import(&t);
-        
+
         // Evaluate at (1, 1) - should be sqrt(2) since cos(π/4) = sin(π/4) = 1/√2
         let result = ctx.eval_xyz(expr, 1.0, 1.0, 0.0).unwrap();
         let expected = std::f64::consts::SQRT_2;

--- a/fidget/src/rhai/mod.rs
+++ b/fidget/src/rhai/mod.rs
@@ -43,6 +43,29 @@
 //! `x, y, z` variables are also automatically injected into the `Engine`'s
 //! context before evaluation.
 //!
+//! # Mathematical constants
+//! The Rhai context includes common mathematical constants that can be used
+//! in expressions:
+//!
+//! ```
+//! # fidget::rhai::engine().run("
+//! // Use PI for angular calculations
+//! let angle = PI / 4.0;
+//! let radius = 2.0;
+//! circle(#{ center: [radius * cos(angle), radius * sin(angle)], radius: 1.0 })
+//! # ").unwrap();
+//! ```
+//!
+//! Available constants include:
+//! - `PI` - π (3.14159...)
+//! - `E` - Euler's number (2.71828...)
+//! - `TAU` - 2π (6.28318...)
+//! - `PHI` / `GOLDEN_RATIO` - Golden ratio (1.61803...)
+//! - `SQRT_2`, `SQRT_3` - Square roots
+//! - `FRAC_PI_2`, `FRAC_PI_4`, etc. - Fractions of π
+//! - `LN_2`, `LN_10` - Natural logarithms
+//! - And many more mathematical constants
+//!
 //! # Vector types
 //! The Rhai context includes `vec2`, `vec3`, and `vec4` types, which are
 //! roughly analogous to their GLSL equivalents (for floating-point only).
@@ -200,6 +223,7 @@
 //! .move(#{ offset: [1, 1] });
 //! # ").unwrap();
 //! ```
+pub mod constants;
 pub mod shapes;
 pub mod tree;
 pub mod types;
@@ -208,6 +232,7 @@ use crate::context::Tree;
 
 /// Build a new engine with Fidget-specific bindings and settings
 ///
+/// - Mathematical constants (PI, E, TAU, etc.), provided by the [`resolver`] function
 /// - `Tree`-specific type, overloads, and `axes()` ([`tree::register`])
 /// - Custom types (e.g. GLSL-style vectors), provided by [`types::register`]
 /// - Shapes and transforms ([`shapes::register`])
@@ -217,7 +242,7 @@ use crate::context::Tree;
 /// - [`set_fail_on_invalid_map_property`](rhai::Engine::set_fail_on_invalid_map_property)
 ///   set to `true`, so that missing map items raise an error
 /// - A custom resolver ([`resolver`]) which provides fallbacks for `x`, `y`,
-///   and `z` (if not defined)
+///   `z`, and mathematical constants (if not defined)
 pub fn engine() -> rhai::Engine {
     let mut engine = rhai::Engine::new();
 
@@ -241,7 +266,7 @@ pub fn engine() -> rhai::Engine {
     engine
 }
 
-/// Variable resolver which provides `x`, `y`, `z` if not found
+/// Variable resolver which provides `x`, `y`, `z` and mathematical constants if not found
 pub fn resolver(
     name: &str,
     _index: usize,
@@ -254,7 +279,14 @@ pub fn resolver(
             "x" => Ok(Some(rhai::Dynamic::from(Tree::x()))),
             "y" => Ok(Some(rhai::Dynamic::from(Tree::y()))),
             "z" => Ok(Some(rhai::Dynamic::from(Tree::z()))),
-            _ => Ok(None),
+            _ => {
+                // Try to resolve as a mathematical constant
+                if let Some(constant) = constants::get_constant(name) {
+                    Ok(Some(rhai::Dynamic::from(constant)))
+                } else {
+                    Ok(None)
+                }
+            }
         }
     }
 }
@@ -340,5 +372,24 @@ mod test {
         let out: i64 =
             engine.eval("let foo = []; foo.push(1); foo.len()").unwrap();
         assert_eq!(out, 1);
+    }
+
+    #[test]
+    fn test_constants() {
+        let engine = engine();
+        
+        // Test that PI constant is available
+        let pi: f64 = engine.eval("PI").unwrap();
+        assert!((pi - std::f64::consts::PI).abs() < f64::EPSILON);
+        
+        // Test using constants in angular calculations
+        let t = engine.eval("let angle = PI / 4.0; x * cos(angle) + y * sin(angle)").unwrap();
+        let mut ctx = Context::new();
+        let expr = ctx.import(&t);
+        
+        // Evaluate at (1, 1) - should be sqrt(2) since cos(π/4) = sin(π/4) = 1/√2
+        let result = ctx.eval_xyz(expr, 1.0, 1.0, 0.0).unwrap();
+        let expected = std::f64::consts::SQRT_2;
+        assert!((result - expected).abs() < 1e-10);
     }
 }


### PR DESCRIPTION
Use resolver to add few handy constants (similar to x, y, z).