### PR TITLE
Add shaded mode for web demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Replaced `view` in `ImageRenderConfig` and `VoxelRenderConfig` with a generic
   `world_to_model` matrix, for more flexibility when rendering.
 - Add mathematical constants for Rhai scripts (`PI`, `E`, `TAU`...)
+- Add shaded render mode in web demo
 
 # 0.3.8
 - Bug fix: `Image::height()` was returning width instead!

--- a/demos/web-editor/web/src/index.html
+++ b/demos/web-editor/web/src/index.html
@@ -59,6 +59,7 @@
           <option value="bitmap">2D (bitmap)</option>
           <option value="normals" selected="selected">3D (normals)</option>
           <option value="heightmap">3D (heightmap)</option>
+          <option value="shaded">3D (shaded)</option>
         </select>
       </div>
     </div>

--- a/demos/web-editor/web/src/index.ts
+++ b/demos/web-editor/web/src/index.ts
@@ -504,6 +504,14 @@ class Scene {
     this.shadedProgram = new ShadedProgramInfo(this.gl);
     this.currentMode = "normals";
 
+    // Enable float texture extension (required for gl.FLOAT textures)
+    const floatExt = this.gl.getExtension("OES_texture_float");
+    if (!floatExt) {
+      throw new Error(
+        "Float textures not supported - required for shaded mode",
+      );
+    }
+
     // RGBA textures for bitmap/heightmap/normals modes
     this.rgbaTextures = [];
     // Float textures for depth+normal data (shaded mode)

--- a/demos/web-editor/web/src/index.ts
+++ b/demos/web-editor/web/src/index.ts
@@ -732,12 +732,13 @@ class Scene {
     // 0 = use type and numComponents above
     const offset = 0; // how many bytes inside the buffer to start from
     this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.buffers.pos);
-    
+
     // Use the appropriate program's vertex attribute based on current mode
-    const vertexAttrib = this.currentMode === "shaded" 
-      ? this.shadedProgram.vertexPositionAttrib 
-      : this.basicProgram.vertexPositionAttrib;
-    
+    const vertexAttrib =
+      this.currentMode === "shaded"
+        ? this.shadedProgram.vertexPositionAttrib
+        : this.basicProgram.vertexPositionAttrib;
+
     this.gl.vertexAttribPointer(
       vertexAttrib,
       numComponents,

--- a/demos/web-editor/web/src/message.ts
+++ b/demos/web-editor/web/src/message.ts
@@ -11,7 +11,7 @@ export class ScriptRequest {
   }
 }
 
-type RenderMode = "bitmap" | "heightmap" | "normals";
+type RenderMode = "bitmap" | "heightmap" | "normals" | "shaded";
 export class RenderRequest {
   kind: "shape";
   tape: Uint8Array;

--- a/demos/web-editor/web/src/worker.ts
+++ b/demos/web-editor/web/src/worker.ts
@@ -36,6 +36,11 @@ class Worker {
           out = fidget.render_normals(shape, size, camera, cancel);
           break;
         }
+        case "shaded": {
+          const camera = fidget.JsCamera3.deserialize(s.camera);
+          out = fidget.render_depth_normals(shape, size, camera, cancel);
+          break;
+        }
       }
       postMessage(new ImageResponse(out, s.depth), { transfer: [out.buffer] });
     } catch (e) {


### PR DESCRIPTION
Add shaded render mode in web demo. Browser must support floating point textures.

<img width="1045" height="557" alt="Screenshot 2025-07-22 at 1 55 59 PM" src="https://github.com/user-attachments/assets/45ee01da-e276-4174-a097-ff304c3e55ac" />
