### PR TITLE
New APIs for shape transforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,20 @@
 - Add mathematical constants for Rhai scripts (`PI`, `E`, `TAU`...)
 - Add `std::ops::Neg` implementation for `Vec2,3,4` types, in both Rust and
   Rhai.
+- Remove `Shape::apply_transform`; there were too many ways to apply transforms
+  to shapes, and having mutable operations on a handle passed by `Clone` opens
+  up possibilities for confusion.  Here's the new plan:
+    - When using high-level algorithms (e.g. meshing and rendering), the
+      world-to-model transform is now *only* set by the `world_to_model` matrix
+      in the config or settings object (`ImageRenderConfig`,
+      `VoxelRenderConfig`, `mesh::Settings`)
+    - When using a `Shape` directly, a transform can be set with
+      `Shape::with_transform`.  This returns a new `Shape<F, Transformed>`,
+      where `Transformed` is a marker type indicating that the transform field
+      is `Some(..)`.  `Shape::with_transform` is a one-way operation: it's only
+      available on `Shape<F>` (which is actually now `Shape<F, ()>`).  Note that
+      high-level operations require a `Shape<F, ()>`, because they set the
+      transform themselves!
 
 # 0.3.8
 - Bug fix: `Image::height()` was returning width instead!

--- a/fidget/src/mesh/octree.rs
+++ b/fidget/src/mesh/octree.rs
@@ -53,7 +53,7 @@ impl Octree {
         if t == nalgebra::Matrix4::identity() {
             Self::build_inner(shape, vars, settings)
         } else {
-            let shape = shape.clone().apply_transform(t);
+            let shape = shape.with_transform(t);
             let mut out = Self::build_inner(&shape, vars, settings);
 
             // Apply the transform from [-1, +1] back to model space
@@ -80,8 +80,8 @@ impl Octree {
         Self::build_with_vars(shape, &ShapeVars::new(), settings)
     }
 
-    fn build_inner<F: Function + RenderHints + Clone>(
-        shape: &Shape<F>,
+    fn build_inner<F: Function + RenderHints + Clone, T: Sync>(
+        shape: &Shape<F, T>,
         vars: &ShapeVars<f32>,
         settings: Settings,
     ) -> Self {
@@ -103,8 +103,8 @@ impl Octree {
     }
 
     /// Multithreaded constructor
-    fn build_inner_mt<F: Function + RenderHints + Clone>(
-        shape: &Shape<F>,
+    fn build_inner_mt<F: Function + RenderHints + Clone, T: Sync>(
+        shape: &Shape<F, T>,
         vars: &ShapeVars<f32>,
         max_depth: u8,
         threads: &ThreadPool,
@@ -516,9 +516,9 @@ impl<F: Function + RenderHints> OctreeBuilder<F> {
     /// Writes to `self.o.cells[cell]`, which must be reserved
     ///
     /// If a leaf is written, then `hermite` is populated
-    fn recurse(
+    fn recurse<T>(
         &mut self,
-        eval: &mut RenderHandle<F>,
+        eval: &mut RenderHandle<F, T>,
         vars: &ShapeVars<f32>,
         cell: CellIndex<3>,
         max_depth: u8,
@@ -582,9 +582,9 @@ impl<F: Function + RenderHints> OctreeBuilder<F> {
     /// Writes the leaf vertex to `self.o.verts`, hermite data to
     /// `self.hermite`, and the leaf data to `self.leafs`.  Does **not** write
     /// anything to `self.o.cells`; the cell is returned instead.
-    fn leaf(
+    fn leaf<T>(
         &mut self,
-        eval: &mut RenderHandle<F>,
+        eval: &mut RenderHandle<F, T>,
         vars: &ShapeVars<f32>,
         cell: CellIndex<3>,
         hermite_cell: &mut LeafHermiteData,

--- a/fidget/src/render/render3d.rs
+++ b/fidget/src/render/render3d.rs
@@ -68,7 +68,7 @@ struct Worker<'a, F: Function> {
     out: GeometryBuffer,
 }
 
-impl<'a, F: Function> RenderWorker<'a, F> for Worker<'a, F> {
+impl<'a, F: Function, T> RenderWorker<'a, F, T> for Worker<'a, F> {
     type Config = VoxelRenderConfig<'a>;
     type Output = GeometryBuffer;
 
@@ -94,7 +94,7 @@ impl<'a, F: Function> RenderWorker<'a, F> for Worker<'a, F> {
 
     fn render_tile(
         &mut self,
-        shape: &mut RenderHandle<F>,
+        shape: &mut RenderHandle<F, T>,
         vars: &ShapeVars<f32>,
         tile: super::config::Tile<2>,
     ) -> Self::Output {
@@ -124,9 +124,9 @@ impl<F: Function> Worker<'_, F> {
     /// Render a single tile
     ///
     /// Returns `true` if we should keep rendering, `false` otherwise
-    fn render_tile_recurse(
+    fn render_tile_recurse<T>(
         &mut self,
-        shape: &mut RenderHandle<F>,
+        shape: &mut RenderHandle<F, T>,
         vars: &ShapeVars<f32>,
         depth: usize,
         tile: Tile<3>,
@@ -203,9 +203,9 @@ impl<F: Function> Worker<'_, F> {
         true // keep going
     }
 
-    fn render_tile_pixels(
+    fn render_tile_pixels<T>(
         &mut self,
-        shape: &mut RenderHandle<F>,
+        shape: &mut RenderHandle<F, T>,
         vars: &ShapeVars<f32>,
         tile_size: usize,
         tile: Tile<3>,
@@ -347,9 +347,9 @@ pub fn render<F: Function>(
     vars: &ShapeVars<f32>,
     config: &VoxelRenderConfig,
 ) -> Option<GeometryBuffer> {
-    let shape = shape.apply_transform(config.mat());
+    let shape = shape.with_transform(config.mat());
 
-    let tiles = super::render_tiles::<F, Worker<F>>(shape, vars, config)?;
+    let tiles = super::render_tiles::<F, Worker<F>, _>(shape, vars, config)?;
     let tile_sizes = config.tile_sizes();
 
     let width = config.image_size.width() as usize;


### PR DESCRIPTION
Removes `Shape::apply_transform`; there were too many ways to apply transforms to shapes, and having mutable operations on a handle passed by `Clone` opens up possibilities for confusion.

Here's the new plan:

- When using high-level algorithms (e.g. meshing and rendering), the world-to-model transform is now *only* set by the `world_to_model` matrix in the config or settings object (`ImageRenderConfig`, `VoxelRenderConfig`, `mesh::Settings`)
- When using a `Shape` directly, a transform can be set with `Shape::with_transform`.  This returns a new `Shape<F, Transformed>`, where `Transformed` is a marker type indicating that the transform field is `Some(..)`.  `Shape::with_transform` is a one-way operation: it's only available on `Shape<F>` (which is actually now `Shape<F, ()>`).  Note that high-level operations require a `Shape<F, ()>`, because they set the transform themselves!