### PR TITLE
Add `vec2([..])` and `vec3([..])` to Rhai env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
       available on `Shape<F>` (which is actually now `Shape<F, ()>`).  Note that
       high-level operations require a `Shape<F, ()>`, because they set the
       transform themselves!
+- Add `vec2([..])` and `vec3([..])` functions to Rhai environment
 
 # 0.3.8
 - Bug fix: `Image::height()` was returning width instead!


### PR DESCRIPTION
Shape functions are flexible, but other functions may want a specific vector type