### PR TITLE
Add `fidget-bytecode`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.1
+- Add `fidget-bytecode` crate (exported as `fidget::bytecode`), which is a
+  binary representation of register instruction tapes.
+
 # 0.4.0
 ## Splitting into multiple crates
 The focus of this release is splitting `fidget` into a set of smaller crates,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1433,10 +1433,11 @@ dependencies = [
 
 [[package]]
 name = "fidget"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "criterion",
  "document-features",
+ "fidget-bytecode",
  "fidget-core",
  "fidget-gui",
  "fidget-jit",
@@ -1447,6 +1448,16 @@ dependencies = [
  "nalgebra",
  "rayon",
  "workspace-hack",
+]
+
+[[package]]
+name = "fidget-bytecode"
+version = "0.4.1"
+dependencies = [
+ "fidget-core",
+ "strum 0.27.2",
+ "workspace-hack",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1478,6 +1489,7 @@ dependencies = [
  "rand 0.9.2",
  "rayon",
  "serde",
+ "strum 0.27.2",
  "thiserror 2.0.12",
  "workspace-hack",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     # Fidget crates
     "fidget",
     "fidget-core",
+    "fidget-bytecode",
     "fidget-gui",
     "fidget-jit",
     "fidget-mesh",
@@ -24,7 +25,6 @@ exclude = ["demos/web-editor/crate"]
 
 [workspace.package]
 rust-version = "1.87"
-version = "0.4.0"
 edition = "2024"
 license = "MPL-2.0"
 repository = "https://github.com/mkeeter/fidget"
@@ -72,7 +72,7 @@ rayon = "1.10"
 rhai = { version = "=1.21.0", features = ["sync"] } # pinned due to rhai#1001
 serde = { version = "1.0", features = ["derive", "rc"] }
 static_assertions = "1"
-strum = { version = "0.27", features = ["derive"] }
+strum = { version = "0.27.2", features = ["derive"] }
 thiserror = "2"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
@@ -80,13 +80,14 @@ windows = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Memo
 zerocopy = { version = "0.8", features = ["derive"] }
 
 # Local crates
-fidget.path = "fidget"
-fidget-core    = { path = "fidget-core",    version = "=0.4.0" }
-fidget-gui     = { path = "fidget-gui",     version = "=0.4.0" }
-fidget-jit     = { path = "fidget-jit",     version = "=0.4.0" }
-fidget-mesh    = { path = "fidget-mesh",    version = "=0.4.0" }
-fidget-raster  = { path = "fidget-raster",  version = "=0.4.0" }
-fidget-rhai    = { path = "fidget-rhai",    version = "=0.4.0" }
-fidget-shapes  = { path = "fidget-shapes",  version = "=0.4.0" }
-fidget-solver  = { path = "fidget-solver",  version = "=0.4.0" }
-workspace-hack = { path = "workspace-hack", version = "0.1" }
+fidget.path     = "fidget"
+fidget-core     = { path = "fidget-core",     version = "=0.4.0" }
+fidget-bytecode = { path = "fidget-bytecode", version = "=0.4.1" }
+fidget-gui      = { path = "fidget-gui",      version = "=0.4.0" }
+fidget-jit      = { path = "fidget-jit",      version = "=0.4.0" }
+fidget-mesh     = { path = "fidget-mesh",     version = "=0.4.0" }
+fidget-raster   = { path = "fidget-raster",   version = "=0.4.0" }
+fidget-rhai     = { path = "fidget-rhai",     version = "=0.4.0" }
+fidget-shapes   = { path = "fidget-shapes",   version = "=0.4.0" }
+fidget-solver   = { path = "fidget-solver",   version = "=0.4.0" }
+workspace-hack  = { path = "workspace-hack",  version = "0.1" }

--- a/demos/web-editor/crate/Cargo.lock
+++ b/demos/web-editor/crate/Cargo.lock
@@ -420,9 +420,10 @@ dependencies = [
 
 [[package]]
 name = "fidget"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "document-features",
+ "fidget-bytecode",
  "fidget-core",
  "fidget-gui",
  "fidget-jit",
@@ -431,6 +432,16 @@ dependencies = [
  "fidget-rhai",
  "fidget-solver",
  "workspace-hack",
+]
+
+[[package]]
+name = "fidget-bytecode"
+version = "0.4.1"
+dependencies = [
+ "fidget-core",
+ "strum",
+ "workspace-hack",
+ "zerocopy 0.8.21",
 ]
 
 [[package]]
@@ -445,6 +456,7 @@ dependencies = [
  "rand",
  "rayon",
  "serde",
+ "strum",
  "thiserror",
  "workspace-hack",
 ]
@@ -1228,23 +1240,22 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "rustversion",
  "syn",
 ]
 

--- a/fidget-bytecode/Cargo.toml
+++ b/fidget-bytecode/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "fidget-shapes"
-description = "Shapes and transforms for use with Fidget"
+name = "fidget-bytecode"
+description = "Bytecode representation for Fidget expression tapes"
 readme = "README.md"
-version = "0.4.0"
+version = "0.4.1"
 
 edition.workspace = true
 license.workspace = true
@@ -14,8 +14,5 @@ rust-version.workspace = true
 fidget-core.workspace = true
 workspace-hack.workspace = true
 
-enum-map.workspace = true
-facet.workspace = true
-nalgebra.workspace = true
 strum.workspace = true
-thiserror.workspace = true
+zerocopy.workspace = true

--- a/fidget-bytecode/src/lib.rs
+++ b/fidget-bytecode/src/lib.rs
@@ -1,0 +1,263 @@
+//! Tape bytecode format
+//!
+//! Fidget's bytecode is a packed representation of a
+//! [`RegTape`](fidget_core::compiler::RegTape).  It may be used as the
+//! evaluation tape for non-Rust VMs, e.g. an interpreter running on a GPU.
+//!
+//! The format is **not stable**; it may change without notice.  It would be
+//! wise to dynamically check any interpreter against [`iter_ops`], which
+//! associates opcode integers with their names.
+//!
+//! The bytecode format is a list of little-endian `u32` words, representing
+//! tape operations in forward-evaluation order. Each operation in the tape maps
+//! to two words, though the second word is not always used.  Having a
+//! fixed-length representation makes it easier to iterate both forwards (for
+//! evaluation) and backwards (for simplification).
+//!
+//! The first two words are always `0xFFFF_FFFF 0x0000_0000`, and the last two
+//! words are always `0xFFFF_FFFF 0xFFFF_FFFF`.  Note that this is equivalent to
+//! an operation with opcode `0xFF`; this special opcode may also be used with
+//! user-defined semantics, as long as the immediate is not either reserved
+//! value.
+//!
+//! ## Register-only operations
+//!
+//! Register-only operations (i.e. opcodes without an immediate `f32` or `u32`)
+//! are packed into a single `u32` as follows:
+//!
+//! | Byte | Value                                       |
+//! |------|---------------------------------------------|
+//! | 0    | opcode                                      |
+//! | 1    | output register                             |
+//! | 2    | first input register                        |
+//! | 3    | second input register                       |
+//!
+//! Depending on the opcode, the input register bytes may not be used.
+//!
+//! The second word is always `0xFF000000`
+//!
+//! ## Operations with an `f32` immediate
+//!
+//! Operations with an `f32` immediate are packed into two `u32` words.
+//! The first word is similar to before:
+//!
+//! | Byte | Value                                       |
+//! |------|---------------------------------------------|
+//! | 0    | opcode                                      |
+//! | 1    | output register                             |
+//! | 2    | first input register                        |
+//! | 3    | not used                                    |
+//!
+//! The second word is the `f32` reinterpreted as a `u32`.
+//!
+//! ## Operations with an `u32` immediate
+//!
+//! Operations with a `u32` immediate (e.g.
+//! [`Load`](RegOp::Load)) are also packed into two `u32`
+//! words.  The first word is what you'd expect:
+//!
+//! | Byte | Value                                       |
+//! |------|---------------------------------------------|
+//! | 0    | opcode                                      |
+//! | 1    | input or output register                    |
+//! | 2    | not used                                    |
+//! | 3    | not used                                    |
+//!
+//! The second word is the `u32` immediate.
+//!
+//! ## Opcode values
+//!
+//! Opcode values are generated automatically from [`BytecodeOp`]
+//! values, which are one-to-one with [`RegOp`] variants.
+#![warn(missing_docs)]
+
+use fidget_core::{compiler::RegOp, vm::VmData};
+use zerocopy::IntoBytes;
+
+pub use fidget_core::compiler::RegOpDiscriminants as BytecodeOp;
+
+/// Serialized bytecode for external evaluation
+pub struct Bytecode {
+    reg_count: u8,
+    mem_count: u32,
+    data: Vec<u32>,
+}
+
+impl Bytecode {
+    /// Returns the length of the bytecode data (in `u32` words)
+    #[allow(clippy::len_without_is_empty)]
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Raw serialized operations
+    pub fn data(&self) -> &[u32] {
+        &self.data
+    }
+
+    /// Maximum register index used by the tape
+    pub fn reg_count(&self) -> u8 {
+        self.reg_count
+    }
+
+    /// Maximum memory slot used for `Load` / `Store` operations
+    pub fn mem_count(&self) -> u32 {
+        self.mem_count
+    }
+
+    /// Returns a view of the byte slice
+    pub fn as_bytes(&self) -> &[u8] {
+        self.data.as_bytes()
+    }
+
+    /// Builds a new bytecode object from VM data
+    pub fn new<const N: usize>(t: &VmData<N>) -> Self {
+        // The initial opcode is `OP_JUMP 0x0000_0000`
+        let mut data = vec![u32::MAX, 0u32];
+        let mut reg_count = 0u8;
+        let mut mem_count = 0u32;
+        for op in t.iter_asm() {
+            let r = BytecodeOp::from(op);
+            let mut word = [r as u8, 0xFF, 0xFF, 0xFF];
+            let mut imm = None;
+            let mut store_reg = |i, r| {
+                reg_count = reg_count.max(r); // update the max reg
+                word[i] = r;
+            };
+            match op {
+                RegOp::Input(reg, slot) | RegOp::Output(reg, slot) => {
+                    store_reg(1, reg);
+                    imm = Some(slot);
+                }
+
+                RegOp::Load(reg, slot) | RegOp::Store(reg, slot) => {
+                    store_reg(1, reg);
+                    mem_count = mem_count.max(slot);
+                    imm = Some(slot);
+                }
+
+                RegOp::CopyImm(out, imm_f32) => {
+                    store_reg(1, out);
+                    imm = Some(imm_f32.to_bits());
+                }
+                RegOp::NegReg(out, reg)
+                | RegOp::AbsReg(out, reg)
+                | RegOp::RecipReg(out, reg)
+                | RegOp::SqrtReg(out, reg)
+                | RegOp::SquareReg(out, reg)
+                | RegOp::FloorReg(out, reg)
+                | RegOp::CeilReg(out, reg)
+                | RegOp::RoundReg(out, reg)
+                | RegOp::CopyReg(out, reg)
+                | RegOp::SinReg(out, reg)
+                | RegOp::CosReg(out, reg)
+                | RegOp::TanReg(out, reg)
+                | RegOp::AsinReg(out, reg)
+                | RegOp::AcosReg(out, reg)
+                | RegOp::AtanReg(out, reg)
+                | RegOp::ExpReg(out, reg)
+                | RegOp::LnReg(out, reg)
+                | RegOp::NotReg(out, reg) => {
+                    store_reg(1, out);
+                    store_reg(2, reg);
+                }
+
+                RegOp::AddRegImm(out, reg, imm_f32)
+                | RegOp::MulRegImm(out, reg, imm_f32)
+                | RegOp::DivRegImm(out, reg, imm_f32)
+                | RegOp::DivImmReg(out, reg, imm_f32)
+                | RegOp::SubImmReg(out, reg, imm_f32)
+                | RegOp::SubRegImm(out, reg, imm_f32)
+                | RegOp::AtanRegImm(out, reg, imm_f32)
+                | RegOp::AtanImmReg(out, reg, imm_f32)
+                | RegOp::MinRegImm(out, reg, imm_f32)
+                | RegOp::MaxRegImm(out, reg, imm_f32)
+                | RegOp::CompareRegImm(out, reg, imm_f32)
+                | RegOp::CompareImmReg(out, reg, imm_f32)
+                | RegOp::ModRegImm(out, reg, imm_f32)
+                | RegOp::ModImmReg(out, reg, imm_f32)
+                | RegOp::AndRegImm(out, reg, imm_f32)
+                | RegOp::OrRegImm(out, reg, imm_f32) => {
+                    store_reg(1, out);
+                    store_reg(2, reg);
+                    imm = Some(imm_f32.to_bits());
+                }
+
+                RegOp::AddRegReg(out, lhs, rhs)
+                | RegOp::MulRegReg(out, lhs, rhs)
+                | RegOp::DivRegReg(out, lhs, rhs)
+                | RegOp::SubRegReg(out, lhs, rhs)
+                | RegOp::AtanRegReg(out, lhs, rhs)
+                | RegOp::MinRegReg(out, lhs, rhs)
+                | RegOp::MaxRegReg(out, lhs, rhs)
+                | RegOp::CompareRegReg(out, lhs, rhs)
+                | RegOp::ModRegReg(out, lhs, rhs)
+                | RegOp::AndRegReg(out, lhs, rhs)
+                | RegOp::OrRegReg(out, lhs, rhs) => {
+                    store_reg(1, out);
+                    store_reg(2, lhs);
+                    store_reg(3, rhs);
+                }
+            }
+            data.push(u32::from_le_bytes(word));
+            data.push(imm.unwrap_or(0xFF000000));
+        }
+        // Add the final `OP_JUMP 0xFFFF_FFFF`
+        data.extend([u32::MAX, u32::MAX]);
+
+        Bytecode {
+            data,
+            mem_count,
+            reg_count,
+        }
+    }
+}
+
+/// Iterates over opcode `(names, value)` tuples, with names in `CamelCase`
+///
+/// This is a helper function for defining constants in a VM interpreter
+pub fn iter_ops<'a>() -> impl Iterator<Item = (&'a str, u8)> {
+    use strum::IntoEnumIterator;
+
+    BytecodeOp::iter().enumerate().map(|(i, op)| {
+        let s: &'static str = op.into();
+        (s, i as u8)
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn simple_bytecode() {
+        let mut ctx = fidget_core::Context::new();
+        let x = ctx.x();
+        let c = ctx.constant(1.0);
+        let out = ctx.add(x, c).unwrap();
+        let data = VmData::<255>::new(&ctx, &[out]).unwrap();
+        let bc = Bytecode::new(&data);
+        let mut iter = bc.data.iter();
+        let mut next = || *iter.next().unwrap();
+        assert_eq!(next(), 0xFFFFFFFF); // start marker
+        assert_eq!(next(), 0);
+        assert_eq!(
+            next().to_le_bytes(),
+            [BytecodeOp::Input as u8, 0, 0xFF, 0xFF]
+        );
+        assert_eq!(next(), 0); // input slot 0
+        assert_eq!(
+            next().to_le_bytes(),
+            [BytecodeOp::AddRegImm as u8, 0, 0, 0xFF]
+        );
+        assert_eq!(f32::from_bits(next()), 1.0);
+        assert_eq!(
+            next().to_le_bytes(),
+            [BytecodeOp::Output as u8, 0, 0xFF, 0xFF]
+        );
+        assert_eq!(next(), 0); // output slot 0
+        assert_eq!(next(), 0xFFFFFFFF); // end marker
+        assert_eq!(next(), 0xFFFFFFFF);
+        assert!(iter.next().is_none());
+    }
+}

--- a/fidget-core/Cargo.toml
+++ b/fidget-core/Cargo.toml
@@ -2,8 +2,8 @@
 name = "fidget-core"
 description = "Core infrastructure for Fidget"
 readme = "README.md"
+version = "0.4.0"
 
-version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -17,6 +17,7 @@ ordered-float.workspace = true
 rand.workspace = true
 rayon.workspace = true
 serde.workspace = true
+strum.workspace = true
 thiserror.workspace = true
 
 workspace-hack.workspace = true

--- a/fidget-core/src/compiler/mod.rs
+++ b/fidget-core/src/compiler/mod.rs
@@ -14,7 +14,7 @@ mod op;
 
 mod lru;
 pub(crate) use lru::Lru;
-pub use op::{RegOp, SsaOp};
+pub use op::{RegOp, RegOpDiscriminants, SsaOp};
 
 mod reg_tape;
 mod ssa_tape;

--- a/fidget-core/src/compiler/op.rs
+++ b/fidget-core/src/compiler/op.rs
@@ -275,7 +275,22 @@ opcodes!(
     ///
     /// We have a maximum of 256 registers, though some tapes (e.g. ones
     /// targeting physical hardware) may choose to use fewer.
-    #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+    #[derive(
+        Copy,
+        Clone,
+        Debug,
+        PartialEq,
+        Serialize,
+        Deserialize,
+        strum::EnumDiscriminants,
+    )]
+    #[strum_discriminants(derive(
+        strum::EnumIter,
+        strum::EnumCount,
+        strum::IntoStaticStr,
+        strum::FromRepr,
+    ))]
+    #[strum_discriminants(doc = "[`RegOp`] discriminant value")]
     pub enum RegOp<u8> {
         // default variants
         /// Read from a memory slot to a register

--- a/fidget-core/src/lib.rs
+++ b/fidget-core/src/lib.rs
@@ -53,6 +53,8 @@
 //! //           ##########
 //! # Ok::<(), fidget_core::Error>(())
 //! ```
+#![warn(missing_docs)]
+
 pub mod context;
 pub use context::Context;
 

--- a/fidget-gui/Cargo.toml
+++ b/fidget-gui/Cargo.toml
@@ -2,8 +2,8 @@
 name = "fidget-gui"
 description = "Platform-independent GUI abstractions for Fidget"
 readme = "README.md"
+version = "0.4.0"
 
-version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/fidget-gui/src/lib.rs
+++ b/fidget-gui/src/lib.rs
@@ -1,4 +1,5 @@
 //! Platform-independent GUI abstractions
+#![warn(missing_docs)]
 use fidget_core::render::{ImageSize, VoxelSize};
 use nalgebra::{
     Const, DefaultAllocator, DimNameAdd, DimNameSum, Matrix3, Matrix4, OMatrix,

--- a/fidget-jit/Cargo.toml
+++ b/fidget-jit/Cargo.toml
@@ -2,8 +2,8 @@
 name = "fidget-jit"
 description = "Native JIT compiler for Fidget"
 readme = "README.md"
+version = "0.4.0"
 
-version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/fidget-mesh/Cargo.toml
+++ b/fidget-mesh/Cargo.toml
@@ -2,8 +2,8 @@
 name = "fidget-mesh"
 description = "Meshing of complex closed-form implicit surfaces"
 readme = "README.md"
+version = "0.4.0"
 
-version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/fidget-mesh/src/lib.rs
+++ b/fidget-mesh/src/lib.rs
@@ -42,6 +42,7 @@
 //! mesh.write_stl(&mut f)?;
 //! # Ok::<(), std::io::Error>(())
 //! ```
+#![warn(missing_docs)]
 
 mod builder;
 mod cell;

--- a/fidget-raster/Cargo.toml
+++ b/fidget-raster/Cargo.toml
@@ -2,8 +2,8 @@
 name = "fidget-raster"
 description = "Bitmap and heightmap rendering for Fidget"
 readme = "README.md"
+version = "0.4.0"
 
-version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/fidget-raster/src/lib.rs
+++ b/fidget-raster/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! To render something, build a configuration object then call its `run`
 //! function, e.g. [`ImageRenderConfig::run`] and [`VoxelRenderConfig::run`].
+#![warn(missing_docs)]
 use crate::config::Tile;
 use fidget_core::{
     eval::Function,

--- a/fidget-rhai/Cargo.toml
+++ b/fidget-rhai/Cargo.toml
@@ -2,8 +2,8 @@
 name = "fidget-rhai"
 description = "Rhai script evaluation for complex closed-form implicit surfaces"
 readme = "README.md"
+version = "0.4.0"
 
-version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/fidget-rhai/src/lib.rs
+++ b/fidget-rhai/src/lib.rs
@@ -222,6 +222,8 @@
 //! .move(#{ offset: [1, 1] });
 //! # ").unwrap();
 //! ```
+#![warn(missing_docs)]
+
 pub mod constants;
 pub mod shapes;
 pub mod tree;

--- a/fidget-shapes/src/lib.rs
+++ b/fidget-shapes/src/lib.rs
@@ -14,6 +14,7 @@
 //! For an example of binding shapes into a dynamic language, look at the
 //! implementation of `fidget_rhai::shapes` (specifically the internal
 //! `register_shape` function).
+#![warn(missing_docs)]
 use facet::Facet;
 use fidget_core::context::Tree;
 

--- a/fidget-solver/Cargo.toml
+++ b/fidget-solver/Cargo.toml
@@ -2,8 +2,8 @@
 name = "fidget-solver"
 description = "Constraint solver using Fidget as a backend"
 readme = "README.md"
+version = "0.4.0"
 
-version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/fidget-solver/src/lib.rs
+++ b/fidget-solver/src/lib.rs
@@ -1,4 +1,5 @@
 //! Solver for systems of equations expressed as sets of [Function] objects
+#![warn(missing_docs)]
 use fidget_core::{
     Error,
     eval::{BulkEvaluator, Function, Tape, TracingEvaluator},

--- a/fidget/Cargo.toml
+++ b/fidget/Cargo.toml
@@ -2,8 +2,8 @@
 name = "fidget"
 description = "Infrastructure for complex closed-form implicit surfaces"
 readme = "../README.md"
+version = "0.4.1"
 
-version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -11,12 +11,14 @@ authors.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-fidget-core   = { workspace = true }
-fidget-gui    = { workspace = true, optional = true }
-fidget-mesh   = { workspace = true, optional = true }
-fidget-raster = { workspace = true, optional = true }
-fidget-rhai   = { workspace = true, optional = true }
-fidget-solver = { workspace = true, optional = true }
+fidget-core     = { workspace = true }
+
+fidget-bytecode = { workspace = true, optional = true }
+fidget-gui      = { workspace = true, optional = true }
+fidget-mesh     = { workspace = true, optional = true }
+fidget-raster   = { workspace = true, optional = true }
+fidget-rhai     = { workspace = true, optional = true }
+fidget-solver   = { workspace = true, optional = true }
 
 document-features.workspace = true
 workspace-hack.workspace = true
@@ -25,7 +27,15 @@ workspace-hack.workspace = true
 fidget-jit = { workspace = true, optional = true }
 
 [features]
-default = ["jit", "rhai", "mesh", "solver", "raster", "gui"]
+default = [
+    "bytecode",
+    "gui",
+    "jit",
+    "mesh",
+    "raster",
+    "rhai",
+    "solver",
+]
 
 ## Enables fast evaluation via a JIT compiler.  This is exposed in the
 ## [`fidget::jit`](crate::jit) module, and is supported on macOS, Linux, and
@@ -41,6 +51,9 @@ mesh = ["dep:fidget-mesh"]
 
 ## Enables constraint solving in the [`fidget::solver`](crate::solver) module
 solver = ["dep:fidget-solver"]
+
+## Enables bytecode generation in the [`fidget::bytecode`](crate::bytecode) module
+bytecode = ["dep:fidget-bytecode"]
 
 ## Enables image rendering in the [`fidget::raster`](crate::raster) module
 raster = ["dep:fidget-raster"]

--- a/fidget/src/lib.rs
+++ b/fidget/src/lib.rs
@@ -293,6 +293,9 @@ pub use fidget_core::*;
 #[cfg(feature = "rhai")]
 pub use fidget_rhai as rhai;
 
+#[cfg(feature = "bytecode")]
+pub use fidget_bytecode as bytecode;
+
 #[cfg(feature = "mesh")]
 pub use fidget_mesh as mesh;
 


### PR DESCRIPTION
This is a binary representation of instruction tapes, for use in non-Rust targets (right now, the only one I have in mind is a GPU interpreter).