### PR TITLE
Fix relying on custom `From<T> for f32` fallback behavior

### DIFF
--- a/fidget-core/src/eval/test/point.rs
+++ b/fidget-core/src/eval/test/point.rs
@@ -236,7 +236,7 @@ where
         let tape = shape.point_tape(Default::default());
         let vs = bind_xy(&tape);
 
-        for (x, y) in [(0.0, 1.0), (1.0, 3.0), (2.0, 8.0)] {
+        for (x, y) in [(0.0f32, 1.0f32), (1.0, 3.0), (2.0, 8.0)] {
             let (r, trace) = eval.eval(&tape, &vs(x, y)).unwrap();
             assert_eq!(r[0], x.sin() + y);
             assert!(trace.is_none());
@@ -253,9 +253,9 @@ where
         let tape = shape.point_tape(Default::default());
         let vs = bind_xy(&tape);
         let mut eval = F::new_point_eval();
-        assert_eq!(eval.eval(&tape, &vs(1.0, 2.0)).unwrap().0, [2.0]);
-        assert_eq!(eval.eval(&tape, &vs(1.0, 3.0)).unwrap().0, [2.0]);
-        assert_eq!(eval.eval(&tape, &vs(3.0, 3.5)).unwrap().0, [3.5]);
+        assert_eq!(eval.eval(&tape, &vs(1.0f32, 2.0)).unwrap().0, [2.0]);
+        assert_eq!(eval.eval(&tape, &vs(1.0f32, 3.0)).unwrap().0, [2.0]);
+        assert_eq!(eval.eval(&tape, &vs(3.0f32, 3.5)).unwrap().0, [3.5]);
     }
 
     pub fn test_push() {
@@ -268,8 +268,8 @@ where
         let tape = shape.point_tape(Default::default());
         let vs = bind_xy(&tape);
         let mut eval = F::new_point_eval();
-        assert_eq!(eval.eval(&tape, &vs(1.0, 2.0)).unwrap().0, [1.0]);
-        assert_eq!(eval.eval(&tape, &vs(3.0, 2.0)).unwrap().0, [2.0]);
+        assert_eq!(eval.eval(&tape, &vs(1.0f32, 2.0)).unwrap().0, [1.0]);
+        assert_eq!(eval.eval(&tape, &vs(3.0f32, 2.0)).unwrap().0, [2.0]);
 
         let next = shape
             .simplify(
@@ -280,8 +280,8 @@ where
             .unwrap();
         let tape = next.point_tape(Default::default());
         let vs = bind_xy(&tape);
-        assert_eq!(eval.eval(&tape, &vs(1.0, 2.0)).unwrap().0, [1.0]);
-        assert_eq!(eval.eval(&tape, &vs(3.0, 2.0)).unwrap().0, [3.0]);
+        assert_eq!(eval.eval(&tape, &vs(1.0f32, 2.0)).unwrap().0, [1.0]);
+        assert_eq!(eval.eval(&tape, &vs(3.0f32, 2.0)).unwrap().0, [3.0]);
 
         let next = shape
             .simplify(
@@ -292,8 +292,8 @@ where
             .unwrap();
         let tape = next.point_tape(Default::default());
         let vs = bind_xy(&tape);
-        assert_eq!(eval.eval(&tape, &vs(1.0, 2.0)).unwrap().0, [2.0]);
-        assert_eq!(eval.eval(&tape, &vs(3.0, 2.0)).unwrap().0, [2.0]);
+        assert_eq!(eval.eval(&tape, &vs(1.0f32, 2.0)).unwrap().0, [2.0]);
+        assert_eq!(eval.eval(&tape, &vs(3.0f32, 2.0)).unwrap().0, [2.0]);
 
         let min = ctx.min(x, 1.0).unwrap();
         let shape = F::new(&ctx, &[min]).unwrap();
@@ -349,7 +349,7 @@ where
         let tape = shape.point_tape(Default::default());
         let vs = bind_xy(&tape);
         let mut eval = F::new_point_eval();
-        assert_eq!(eval.eval(&tape, &vs(1.0, 2.0)).unwrap().0, [6.0]);
+        assert_eq!(eval.eval(&tape, &vs(1.0f32, 2.0f32)).unwrap().0, [6.0]);
     }
 
     pub fn test_p_shape_var() {
@@ -366,16 +366,16 @@ where
 
         let mut eval = Shape::<F>::new_point_eval();
         let tape = s.ez_point_tape();
-        assert!(eval.eval(&tape, 1.0, 2.0, 0.0).is_err());
+        assert!(eval.eval(&tape, 1.0f32, 2.0, 0.0).is_err());
 
         let mut h = ShapeVars::new();
-        assert!(eval.eval_v(&tape, 1.0, 2.0, 0.0, &h).is_err());
+        assert!(eval.eval_v(&tape, 1.0f32, 2.0, 0.0, &h).is_err());
 
         let index = v.index().unwrap();
-        h.insert(index, 3.0);
-        assert_eq!(eval.eval_v(&tape, 1.0, 2.0, 0.0, &h).unwrap().0, 6.0);
-        h.insert(index, 4.0);
-        assert_eq!(eval.eval_v(&tape, 1.0, 2.0, 0.0, &h).unwrap().0, 7.0);
+        h.insert(index, 3.0f32);
+        assert_eq!(eval.eval_v(&tape, 1.0f32, 2.0, 0.0, &h).unwrap().0, 6.0);
+        h.insert(index, 4.0f32);
+        assert_eq!(eval.eval_v(&tape, 1.0f32, 2.0, 0.0, &h).unwrap().0, 7.0);
     }
 
     pub fn test_p_stress_n(depth: usize) {
@@ -617,7 +617,7 @@ where
         let tape = shape.point_tape(Default::default());
         let vs = bind_xy(&tape);
 
-        let (out, _trace) = eval.eval(&tape, &vs(1.0, 2.0)).unwrap();
+        let (out, _trace) = eval.eval(&tape, &vs(1.0f32, 2.0f32)).unwrap();
         assert_eq!(out[0], 1.0);
         assert_eq!(out[1], 2.0);
     }


### PR DESCRIPTION
In https://github.com/rust-lang/rust/pull/139087 we're adding a `From<f16> for f32` implementation, one of the final requirements for stabilizing the `f16` type. This second instance breaks type inference in cases like `f32::from(1.0)`. With just one instance (the trivial `From<f32> for f32`) the type checker is able to resolve this, but with two there is an ambiguity: what is the concrete type of that `1.0` literal.

We do implement a custom fallback to not break existing code, but also add a lint for cases where this (somewhat hacky) fallback behavior triggers. 

```
warning: falling back to `f32` as the trait bound `f32: From<f64>` is not satisfied
   --> fidget-core/src/eval/test/point.rs:283:41
    |
283 |         assert_eq!(eval.eval(&tape, &vs(1.0, 2.0)).unwrap().0, [1.0]);
    |                                         ^^^ help: explicitly specify the type as `f32`: `1.0_f32`
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #154024 <https://github.com/rust-lang/rust/issues/154024>
```

This library came up in a crater run https://crater-reports.s3.amazonaws.com/pr-139087-1/index.html as the one root crate that relies on this behavior.

This PR removes occurrences of the lint in this crate. The changes below are just to tests, and relatively minimal, so hopefully that is acceptable.