### PR TITLE
Add `commit_local` call to x86_64 interval `build_or` function

### DIFF
--- a/fidget-jit/src/x86_64/interval.rs
+++ b/fidget-jit/src/x86_64/interval.rs
@@ -683,6 +683,7 @@ impl Assembler for IntervalAssembler {
             ; E: // exit
             ; add rsi, 1
         );
+        self.0.ops.commit_local().unwrap();
     }
     fn build_compare(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
         // TODO: Godbolt uses unpcklps ?


### PR DESCRIPTION
Fixes [this comment](https://github.com/mkeeter/fidget/issues/393#issuecomment-4164510284) in #393.