### PR TITLE
Put vars and transform matrix into raster workers

### DIFF
--- a/fidget-raster/src/lib.rs
+++ b/fidget-raster/src/lib.rs
@@ -97,8 +97,7 @@ impl TileSizesRef<'_> {
 /// It returns a set of output tiles, or `None` if rendering has been cancelled
 pub(crate) fn render_tiles<'a, F: Function, W: RenderWorker<'a, F>>(
     shape: Shape<F>,
-    transform: &nalgebra::Matrix4<f32>,
-    vars: &ShapeVars<f32>,
+    vars: &'a ShapeVars<f32>,
     config: &'a W::Config,
     tile_sizes: TileSizesRef<'a>,
 ) -> Option<Vec<(Tile<2>, W::Output)>>
@@ -126,21 +125,20 @@ where
     let ts = tile_sizes;
     let init = || {
         let rh = rh.clone();
-        let worker = W::new(config, ts);
+        let worker = W::new(config, ts, vars);
         (worker, rh)
     };
 
     match config.threads() {
         None => {
-            let mut worker = W::new(config, tile_sizes);
+            let mut worker = W::new(config, tile_sizes, vars);
             tiles
                 .into_iter()
                 .map(|tile| {
                     if config.is_cancelled() {
                         Err(())
                     } else {
-                        let pixels =
-                            worker.render_tile(&mut rh, transform, vars, tile);
+                        let pixels = worker.render_tile(&mut rh, tile);
                         Ok((tile, pixels))
                     }
                 })
@@ -155,7 +153,7 @@ where
                     if config.is_cancelled() {
                         Err(())
                     } else {
-                        let pixels = w.render_tile(rh, transform, vars, tile);
+                        let pixels = w.render_tile(rh, tile);
                         Ok((tile, pixels))
                     }
                 })
@@ -181,14 +179,16 @@ pub(crate) trait RenderWorker<'a, F: Function> {
     /// Build a new worker
     ///
     /// Workers are typically built on a per-thread basis
-    fn new(cfg: &'a Self::Config, tile_sizes: TileSizesRef<'a>) -> Self;
+    fn new(
+        cfg: &'a Self::Config,
+        tile_sizes: TileSizesRef<'a>,
+        vars: &'a ShapeVars<f32>,
+    ) -> Self;
 
     /// Render a single tile, returning a worker-dependent output
     fn render_tile(
         &mut self,
         shape: &mut RenderHandle<F>,
-        transform: &nalgebra::Matrix4<f32>,
-        vars: &ShapeVars<f32>,
         tile: Tile<2>,
     ) -> Self::Output;
 }

--- a/fidget-raster/src/pixel.rs
+++ b/fidget-raster/src/pixel.rs
@@ -217,8 +217,11 @@ impl From<f32> for RawDistancePixel {
 /// Per-thread worker
 struct Worker<'a, F: Function> {
     tile_sizes: TileSizesRef<'a>,
+    vars: &'a ShapeVars<f32>,
+
     pixel_perfect: bool,
     scratch: Scratch,
+    transform: nalgebra::Matrix4<f32>,
 
     eval_float_slice: ShapeBulkEval<F::FloatSliceEval>,
     eval_interval: ShapeTracingEval<F::IntervalEval>,
@@ -241,12 +244,24 @@ struct Worker<'a, F: Function> {
 impl<'a, F: Function> RenderWorker<'a, F> for Worker<'a, F> {
     type Config = RenderConfig<'a>;
     type Output = Image;
-    fn new(cfg: &'a Self::Config, tile_sizes: TileSizesRef<'a>) -> Self {
+    fn new(
+        cfg: &'a Self::Config,
+        tile_sizes: TileSizesRef<'a>,
+        vars: &'a ShapeVars<f32>,
+    ) -> Self {
+        // Convert to a 4x4 matrix and apply to the shape
+        let transform = cfg.mat();
+        let transform = transform.insert_row(2, 0.0);
+        let transform = transform.insert_column(2, 0.0);
+
         Worker::<F> {
+            tile_sizes,
+            transform,
+            vars,
+
             scratch: Scratch::new(tile_sizes.last().pow(2)),
             pixel_perfect: cfg.pixel_perfect,
             image: Default::default(),
-            tile_sizes,
             eval_float_slice: Default::default(),
             eval_interval: Default::default(),
             tape_storage: vec![],
@@ -258,12 +273,10 @@ impl<'a, F: Function> RenderWorker<'a, F> for Worker<'a, F> {
     fn render_tile(
         &mut self,
         shape: &mut RenderHandle<F>,
-        transform: &nalgebra::Matrix4<f32>,
-        vars: &ShapeVars<f32>,
         tile: Tile<2>,
     ) -> Self::Output {
         self.image = Image::new((self.tile_sizes[0] as u32).into());
-        self.render_tile_recurse(shape, transform, vars, 0, tile);
+        self.render_tile_recurse(shape, 0, tile);
         std::mem::take(&mut self.image)
     }
 }
@@ -272,8 +285,6 @@ impl<F: Function> Worker<'_, F> {
     fn render_tile_recurse(
         &mut self,
         shape: &mut RenderHandle<F>,
-        transform: &nalgebra::Matrix4<f32>,
-        vars: &ShapeVars<f32>,
         depth: usize,
         tile: Tile<2>,
     ) {
@@ -293,8 +304,8 @@ impl<F: Function> Worker<'_, F> {
                 x,
                 y,
                 z,
-                transform,
-                vars,
+                &self.transform,
+                self.vars,
             )
             .unwrap();
 
@@ -341,8 +352,6 @@ impl<F: Function> Worker<'_, F> {
                 for i in 0..n {
                     self.render_tile_recurse(
                         sub_tape,
-                        transform,
-                        vars,
                         depth + 1,
                         Tile::new(
                             tile.corner + Vector2::new(i, j) * next_tile_size,
@@ -351,15 +360,13 @@ impl<F: Function> Worker<'_, F> {
                 }
             }
         } else {
-            self.render_tile_pixels(sub_tape, transform, vars, tile_size, tile);
+            self.render_tile_pixels(sub_tape, tile_size, tile);
         }
     }
 
     fn render_tile_pixels(
         &mut self,
         shape: &mut RenderHandle<F>,
-        transform: &nalgebra::Matrix4<f32>,
-        vars: &ShapeVars<f32>,
         tile_size: usize,
         tile: Tile<2>,
     ) {
@@ -379,8 +386,8 @@ impl<F: Function> Worker<'_, F> {
                 &self.scratch.x,
                 &self.scratch.y,
                 &self.scratch.z,
-                transform,
-                vars,
+                &self.transform,
+                self.vars,
             )
             .unwrap();
 
@@ -414,11 +421,6 @@ pub fn render<F: Function + RenderHints>(
     vars: &ShapeVars<f32>,
     config: &RenderConfig,
 ) -> Option<Image> {
-    // Convert to a 4x4 matrix and apply to the shape
-    let mat = config.mat();
-    let mat = mat.insert_row(2, 0.0);
-    let mat = mat.insert_column(2, 0.0);
-
     let max_size = config.width().max(config.height()) as usize;
     let default_tile_sizes;
     let tile_sizes = if let Some(ts) = &config.tile_sizes {
@@ -429,7 +431,6 @@ pub fn render<F: Function + RenderHints>(
     };
     let tiles = super::render_tiles::<F, Worker<F>>(
         shape.clone(),
-        &mat,
         vars,
         config,
         tile_sizes,

--- a/fidget-raster/src/voxel.rs
+++ b/fidget-raster/src/voxel.rs
@@ -183,6 +183,9 @@ impl Scratch {
 
 struct Worker<'a, F: Function> {
     tile_sizes: TileSizesRef<'a>,
+    vars: &'a ShapeVars<f32>,
+
+    transform: nalgebra::Matrix4<f32>,
     image_size: RenderSize,
 
     /// Reusable workspace for evaluation, to minimize allocation
@@ -204,13 +207,22 @@ impl<'a, F: Function> RenderWorker<'a, F> for Worker<'a, F> {
     type Config = RenderConfig<'a>;
     type Output = Image;
 
-    fn new(cfg: &'a Self::Config, tile_sizes: TileSizesRef<'a>) -> Self {
+    fn new(
+        cfg: &'a Self::Config,
+        tile_sizes: TileSizesRef<'a>,
+        vars: &'a ShapeVars<f32>,
+    ) -> Self {
+        let transform = cfg.mat();
         let buf_size = tile_sizes.last();
         let scratch = Scratch::new(buf_size);
         Worker {
+            tile_sizes,
+            vars,
+
             scratch,
             out: Default::default(),
-            tile_sizes,
+
+            transform,
             image_size: cfg.image_size,
 
             eval_float_slice: Default::default(),
@@ -226,8 +238,6 @@ impl<'a, F: Function> RenderWorker<'a, F> for Worker<'a, F> {
     fn render_tile(
         &mut self,
         shape: &mut RenderHandle<F>,
-        transform: &nalgebra::Matrix4<f32>,
-        vars: &ShapeVars<f32>,
         tile: Tile<2>,
     ) -> Self::Output {
         // Prepare local tile data to fill out
@@ -239,7 +249,7 @@ impl<'a, F: Function> RenderWorker<'a, F> for Worker<'a, F> {
                 tile.corner.y,
                 k as usize * root_tile_size,
             ));
-            if !self.render_tile_recurse(shape, transform, vars, 0, tile) {
+            if !self.render_tile_recurse(shape, 0, tile) {
                 break;
             }
         }
@@ -259,8 +269,6 @@ impl<F: Function> Worker<'_, F> {
     fn render_tile_recurse(
         &mut self,
         shape: &mut RenderHandle<F>,
-        transform: &nalgebra::Matrix4<f32>,
-        vars: &ShapeVars<f32>,
         depth: usize,
         tile: Tile<3>,
     ) -> bool {
@@ -286,8 +294,8 @@ impl<F: Function> Worker<'_, F> {
                 x,
                 y,
                 z,
-                transform,
-                vars,
+                &self.transform,
+                self.vars,
             )
             .unwrap();
 
@@ -326,8 +334,6 @@ impl<F: Function> Worker<'_, F> {
                     for k in (0..n).rev() {
                         self.render_tile_recurse(
                             sub_tape,
-                            transform,
-                            vars,
                             depth + 1,
                             Tile::new(
                                 tile.corner
@@ -338,7 +344,7 @@ impl<F: Function> Worker<'_, F> {
                 }
             }
         } else {
-            self.render_tile_pixels(sub_tape, transform, vars, tile_size, tile);
+            self.render_tile_pixels(sub_tape, tile_size, tile);
         };
         // TODO recycle something here?
         true // keep going
@@ -347,8 +353,6 @@ impl<F: Function> Worker<'_, F> {
     fn render_tile_pixels(
         &mut self,
         shape: &mut RenderHandle<F>,
-        transform: &nalgebra::Matrix4<f32>,
-        vars: &ShapeVars<f32>,
         tile_size: usize,
         tile: Tile<3>,
     ) {
@@ -400,8 +404,8 @@ impl<F: Function> Worker<'_, F> {
                 &self.scratch.x[..index],
                 &self.scratch.y[..index],
                 &self.scratch.z[..index],
-                transform,
-                vars,
+                &self.transform,
+                self.vars,
             )
             .unwrap();
 
@@ -460,8 +464,8 @@ impl<F: Function> Worker<'_, F> {
                     &self.scratch.xg[..grad],
                     &self.scratch.yg[..grad],
                     &self.scratch.zg[..grad],
-                    transform,
-                    vars,
+                    &self.transform,
+                    self.vars,
                 )
                 .unwrap();
 
@@ -499,13 +503,8 @@ pub fn render<F: Function + RenderHints>(
         default_tile_sizes = F::tile_sizes_3d();
         TileSizesRef::new(&default_tile_sizes, max_size)
     };
-    let tiles = super::render_tiles::<F, Worker<F>>(
-        shape,
-        &config.mat(),
-        vars,
-        config,
-        tile_sizes,
-    )?;
+    let tiles =
+        super::render_tiles::<F, Worker<F>>(shape, vars, config, tile_sizes)?;
 
     let width = config.image_size.width() as usize;
     let height = config.image_size.height() as usize;


### PR DESCRIPTION
This reduces the number of arguments passed around in the hot evaluation loop.  Overfitting on a single benchmark, this is a 4% speedup for `speed vs image size (prospero, 2d) (8 threads)/vm/256`.