### PR TITLE
Add errors to `fidget-raster` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,11 @@
       `eval_with_vars`, and there's a separate `eval_with_transform` (along with
       `eval_with_transform_and_vars`).  These all return new error types too!
 - Add `output_count()` to `Function` trait
+- Add `ShapeVars::check` and `ShapeVars::contains_key` to check whether the
+  variable map is sufficient to evaluate a particular shape.
+- Change `fidget_raster` render functions to return a `Result<Image,
+  RenderError>`, where the `RenderError` is either a `MissingVar` or a
+  `Cancelled` flag.  Callers are likely to treat these differently!
 
 # 0.4.3
 - Fixed bug in x86 interval `OR` function ([#395](https://github.com/mkeeter/fidget/pull/395)),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,9 +51,9 @@
 - Add `output_count()` to `Function` trait
 - Add `ShapeVars::check` and `ShapeVars::contains_key` to check whether the
   variable map is sufficient to evaluate a particular shape.
-- Change `fidget_raster` render functions to return a `Result<Image,
-  RenderError>`, where the `RenderError` is either a `MissingVar` or a
-  `Cancelled` flag.  Callers are likely to treat these differently!
+- Change `fidget_raster` render functions to return a `Result<Option<Image>,
+  RenderError>`, because it's possible for callers to provide shapes without a
+  suitable `ShapeVar` map.  `Ok(None)` still means cancellation.
 
 # 0.4.3
 - Fixed bug in x86 interval `OR` function ([#395](https://github.com/mkeeter/fidget/pull/395)),

--- a/demos/cli/src/main.rs
+++ b/demos/cli/src/main.rs
@@ -283,7 +283,11 @@ fn run3d<F: fidget::eval::Function + fidget::render::RenderHints>(
 
     let start = std::time::Instant::now();
     for _ in 0..settings.n {
-        image = cfg.run(shape.clone()).unwrap();
+        // Unwrap both cancellation and errors
+        image = cfg
+            .run(shape.clone())
+            .expect("rendering should not fail")
+            .expect("rendering should not be cancelled");
     }
     info!(
         "Rendered {}× at {:?} ms/frame",
@@ -485,36 +489,33 @@ fn run2d<F: fidget::eval::Function + fidget::render::RenderHints>(
             ..Default::default()
         };
         let mut image = fidget::raster::Image::default();
-        match mode {
-            RenderMode2D::Mono => {
-                for _ in 0..settings.n {
-                    let tmp = cfg.run::<_>(shape.clone()).unwrap();
+        for _ in 0..settings.n {
+            let tmp = cfg
+                .run::<_>(shape.clone())
+                .expect("render should not fail")
+                .expect("render should not be cancelled");
+            match mode {
+                RenderMode2D::Mono => {
                     image = fidget::raster::effects::to_rgba_bitmap(
                         tmp,
                         false,
                         cfg.threads,
                     );
                 }
-            }
-            RenderMode2D::Sdf => {
-                for _ in 0..settings.n {
-                    let tmp = cfg.run(shape.clone()).unwrap();
+                RenderMode2D::Sdf => {
                     image = fidget::raster::effects::to_rgba_distance(
                         tmp,
                         cfg.threads,
                     );
                 }
-            }
-            RenderMode2D::Debug => {
-                for _ in 0..settings.n {
-                    let tmp = cfg.run::<_>(shape.clone()).unwrap();
+                RenderMode2D::Debug => {
                     image = fidget::raster::effects::to_debug_bitmap(
                         tmp,
                         cfg.threads,
                     );
                 }
+                RenderMode2D::Brute => unreachable!(),
             }
-            RenderMode2D::Brute => unreachable!(),
         }
         image.into_iter().flatten().collect()
     }

--- a/demos/viewer/src/main.rs
+++ b/demos/viewer/src/main.rs
@@ -182,20 +182,21 @@ fn render_2d<F: fidget::eval::Function + fidget::render::RenderHints>(
         ..Default::default()
     };
 
+    let tmp = config
+        .run(shape)
+        .expect("rendering should not fail")
+        .expect("rendering should not be cancelled");
     let out = match mode {
         Mode2D::Color => {
-            let tmp = config.run(shape).unwrap();
             let c = [color[0], color[1], color[2], u8::MAX];
             tmp.map(|p| if p.inside() { c } else { [0u8; 4] })
         }
 
         Mode2D::Sdf => {
-            let tmp = config.run(shape).unwrap();
             fidget::raster::effects::to_rgba_distance(tmp, config.threads)
         }
 
         Mode2D::Debug => {
-            let tmp = config.run(shape).unwrap();
             fidget::raster::effects::to_debug_bitmap(tmp, config.threads)
         }
     };
@@ -215,7 +216,10 @@ fn render_3d<F: fidget::eval::Function + fidget::render::RenderHints>(
     };
 
     // Get the geometry buffer from the voxel rendering process
-    let geometry_buffer = config.run(shape).unwrap();
+    let geometry_buffer = config
+        .run(shape)
+        .expect("rendering should not fail")
+        .expect("rendering should not be cancelled");
 
     // For both rendering modes, we'll just pass the GeometryPixel data
     // to the GPU, which will apply the appropriate rendering effect

--- a/demos/web-editor/crate/src/lib.rs
+++ b/demos/web-editor/crate/src/lib.rs
@@ -1,7 +1,7 @@
 use fidget::{
     context::{Context, Tree},
     gui::{Canvas2, Canvas3, DragMode, View2, View3},
-    raster::{pixel, voxel},
+    raster::{RenderError, pixel, voxel},
     render::{CancelToken, ImageSize, ThreadPool, TileSizes, VoxelSize},
     vm::{VmData, VmShape},
 };
@@ -66,7 +66,11 @@ pub fn render_2d(
             cancel,
         };
 
-        let tmp = cfg.run(shape)?;
+        let tmp = match cfg.run(shape) {
+            Ok(v) => v,
+            Err(RenderError::Cancelled) => return None,
+            Err(RenderError::MissingVar(..)) => panic!(),
+        };
         let out =
             fidget::raster::effects::to_rgba_bitmap(tmp, false, cfg.threads);
         Some(out.into_iter().flatten().collect())
@@ -130,7 +134,11 @@ fn render_3d_inner(
         world_to_model: view.world_to_model(),
         cancel,
     };
-    cfg.run(shape.clone())
+    match cfg.run(shape.clone()) {
+        Ok(v) => Some(v),
+        Err(RenderError::Cancelled) => None,
+        Err(RenderError::MissingVar(..)) => panic!(),
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/demos/web-editor/crate/src/lib.rs
+++ b/demos/web-editor/crate/src/lib.rs
@@ -1,7 +1,7 @@
 use fidget::{
     context::{Context, Tree},
     gui::{Canvas2, Canvas3, DragMode, View2, View3},
-    raster::{RenderError, pixel, voxel},
+    raster::{pixel, voxel},
     render::{CancelToken, ImageSize, ThreadPool, TileSizes, VoxelSize},
     vm::{VmData, VmShape},
 };
@@ -66,11 +66,8 @@ pub fn render_2d(
             cancel,
         };
 
-        let tmp = match cfg.run(shape) {
-            Ok(v) => v,
-            Err(RenderError::Cancelled) => return None,
-            Err(RenderError::MissingVar(..)) => panic!(),
-        };
+        // Unwrap errors, propagate cancellation
+        let tmp = cfg.run(shape).unwrap()?;
         let out =
             fidget::raster::effects::to_rgba_bitmap(tmp, false, cfg.threads);
         Some(out.into_iter().flatten().collect())
@@ -134,11 +131,8 @@ fn render_3d_inner(
         world_to_model: view.world_to_model(),
         cancel,
     };
-    match cfg.run(shape.clone()) {
-        Ok(v) => Some(v),
-        Err(RenderError::Cancelled) => None,
-        Err(RenderError::MissingVar(..)) => panic!(),
-    }
+    // Unwrap errors, propagate cancellation
+    cfg.run(shape.clone()).unwrap()
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/fidget-core/src/shape/mod.rs
+++ b/fidget-core/src/shape/mod.rs
@@ -215,6 +215,29 @@ impl<F> ShapeVars<F> {
     pub fn get(&self, i: VarIndex) -> Option<&F> {
         self.0.get(&i)
     }
+
+    /// Checks whether the given [`VarIndex`] is present in the map
+    pub fn contains_key(&self, i: VarIndex) -> bool {
+        self.0.contains_key(&i)
+    }
+
+    /// Checks that this map contains all variables needed to render a shape
+    pub fn check<G: Function>(
+        &self,
+        shape: &Shape<G>,
+    ) -> Result<(), MissingVar> {
+        for (v, _) in shape.inner().vars().iter() {
+            match v {
+                Var::X | Var::Y | Var::Z => (),
+                Var::V(i) => {
+                    if !self.contains_key(i) {
+                        return Err(MissingVar { var: i });
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
 }
 
 impl<'a, F> IntoIterator for &'a ShapeVars<F> {

--- a/fidget-raster/src/lib.rs
+++ b/fidget-raster/src/lib.rs
@@ -475,6 +475,18 @@ pub struct BadPixelCount {
     pub height: u32,
 }
 
+/// Error type for render operations builder
+#[derive(thiserror::Error, Debug, PartialEq)]
+pub enum RenderError {
+    /// Missing variable in the [`ShapeVars`](fidget_core::shape::ShapeVars) map
+    #[error(transparent)]
+    MissingVar(#[from] fidget_core::shape::MissingVar),
+
+    /// Render was cancelled
+    #[error("render was cancelled")]
+    Cancelled,
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/fidget-raster/src/lib.rs
+++ b/fidget-raster/src/lib.rs
@@ -475,16 +475,12 @@ pub struct BadPixelCount {
     pub height: u32,
 }
 
-/// Error type for render operations builder
+/// Error type for render operations
 #[derive(thiserror::Error, Debug, PartialEq)]
 pub enum RenderError {
-    /// Missing variable in the [`ShapeVars`](fidget_core::shape::ShapeVars) map
+    /// Missing variable in the [`ShapeVars`] map
     #[error(transparent)]
     MissingVar(#[from] fidget_core::shape::MissingVar),
-
-    /// Render was cancelled
-    #[error("render was cancelled")]
-    Cancelled,
 }
 
 #[cfg(test)]

--- a/fidget-raster/src/pixel.rs
+++ b/fidget-raster/src/pixel.rs
@@ -1,13 +1,16 @@
 //! 2D bitmap rendering / rasterization
 use super::RenderHandle;
 use crate::{
-    Image as GenericImage, RenderConfig as RenderConfigLike, RenderWorker,
-    Tile, TileSizesRef,
+    Image as GenericImage, RenderConfig as RenderConfigLike, RenderError,
+    RenderWorker, Tile, TileSizesRef,
 };
 use fidget_core::{
     eval::Function,
     render::{CancelToken, RenderHints, ThreadPool, TileSizes},
-    shape::{Shape, ShapeBulkEval, ShapeTracingEval, ShapeVars},
+    shape::{
+        Shape, ShapeBulkEval, ShapeBulkEvalError, ShapeTracingEval,
+        ShapeTracingEvalError, ShapeVars,
+    },
     types::Interval,
 };
 use nalgebra::{Matrix3, Point2, Vector2};
@@ -80,7 +83,7 @@ impl RenderConfig<'_> {
     pub fn run<F: Function + RenderHints>(
         &self,
         shape: Shape<F>,
-    ) -> Option<Image> {
+    ) -> Result<Image, RenderError> {
         self.run_with_vars::<F>(shape, &ShapeVars::new())
     }
 
@@ -89,7 +92,7 @@ impl RenderConfig<'_> {
         &self,
         shape: Shape<F>,
         vars: &ShapeVars<f32>,
-    ) -> Option<Image> {
+    ) -> Result<Image, RenderError> {
         render(shape, vars, self)
     }
 
@@ -296,18 +299,20 @@ impl<F: Function> Worker<'_, F> {
         let y = Interval::new(base.y, base.y + tile_size as f32);
         let z = Interval::new(0.0, 0.0);
 
-        // The shape applies the screen-to-model transform
-        let (i, simplify) = self
-            .eval_interval
-            .eval_with_transform_and_vars(
+        // Evaluation applies the world-to-model transform.  We know that vars
+        // are valid because we check them at the top of `render`
+        let (i, simplify) =
+            match self.eval_interval.eval_with_transform_and_vars(
                 shape.i_tape(&mut self.tape_storage),
                 x,
                 y,
                 z,
                 &self.transform,
                 self.vars,
-            )
-            .unwrap();
+            ) {
+                Ok(v) => v,
+                Err(ShapeTracingEvalError::MissingVar(..)) => unreachable!(),
+            };
 
         if !self.pixel_perfect {
             let pixel = if i.upper() < 0.0 {
@@ -379,17 +384,21 @@ impl<F: Function> Worker<'_, F> {
             }
         }
 
-        let out = self
-            .eval_float_slice
-            .eval_with_transform_and_vars(
-                shape.f_tape(&mut self.tape_storage),
-                &self.scratch.x,
-                &self.scratch.y,
-                &self.scratch.z,
-                &self.transform,
-                self.vars,
-            )
-            .unwrap();
+        let out = match self.eval_float_slice.eval_with_transform_and_vars(
+            shape.f_tape(&mut self.tape_storage),
+            &self.scratch.x,
+            &self.scratch.y,
+            &self.scratch.z,
+            &self.transform,
+            self.vars,
+        ) {
+            Ok(v) => v,
+            // We checked the var map at the beginning of `render`
+            Err(ShapeBulkEvalError::MissingVar(..))
+            // We know that our X/Y/Z slices are all the same length
+            | Err(ShapeBulkEvalError::MismatchedVarSlices { .. })
+                => unreachable!(),
+        };
 
         let mut index = 0;
         for j in 0..tile_size {
@@ -420,7 +429,8 @@ pub fn render<F: Function + RenderHints>(
     shape: Shape<F>,
     vars: &ShapeVars<f32>,
     config: &RenderConfig,
-) -> Option<Image> {
+) -> Result<Image, RenderError> {
+    vars.check(&shape)?;
     let max_size = config.width().max(config.height()) as usize;
     let default_tile_sizes;
     let tile_sizes = if let Some(ts) = &config.tile_sizes {
@@ -434,7 +444,8 @@ pub fn render<F: Function + RenderHints>(
         vars,
         config,
         tile_sizes,
-    )?;
+    )
+    .ok_or(RenderError::Cancelled)?;
 
     let width = config.image_size.width() as usize;
     let height = config.image_size.height() as usize;
@@ -452,13 +463,18 @@ pub fn render<F: Function + RenderHints>(
             }
         }
     }
-    Some(image)
+    Ok(image)
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use fidget_core::{Context, shape::Shape, vm::VmFunction};
+    use fidget_core::{
+        Context,
+        shape::Shape,
+        var::Var,
+        vm::{VmFunction, VmShape},
+    };
 
     const HI: &str =
         include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../models/hi.vm"));
@@ -474,8 +490,39 @@ mod test {
         };
         let cancel = cfg.cancel.clone();
         cancel.cancel();
-        let out = cfg.run(shape);
-        assert!(out.is_none());
+        let Err(out) = cfg.run(shape) else {
+            panic!("expected error")
+        };
+        assert_eq!(out, RenderError::Cancelled);
+    }
+
+    #[test]
+    fn missing_var() {
+        let mut ctx = Context::new();
+        let x = ctx.x();
+        let v = ctx.var(Var::new());
+        let s = ctx.sub(x, v).unwrap();
+        let shape = VmShape::new(&ctx, s).unwrap();
+
+        let cfg = RenderConfig {
+            image_size: RenderSize::new(64, 64),
+            ..Default::default()
+        };
+        let Err(out) = cfg.run::<_>(shape.clone()) else {
+            panic!("expected error")
+        };
+        let var = ctx.get_var(v).unwrap();
+        let Var::V(i) = var else {
+            panic!("expected Var::V")
+        };
+        assert_eq!(
+            out,
+            RenderError::MissingVar(fidget_core::shape::MissingVar { var: i })
+        );
+
+        let mut vars = ShapeVars::new();
+        vars.insert(i, 1.0);
+        assert!(cfg.run_with_vars::<_>(shape, &vars).is_ok());
     }
 
     #[test]

--- a/fidget-raster/src/pixel.rs
+++ b/fidget-raster/src/pixel.rs
@@ -80,10 +80,14 @@ impl RenderConfigLike for RenderConfig<'_> {
 
 impl RenderConfig<'_> {
     /// Render a shape in 2D using this configuration
+    ///
+    ///
+    /// Returns [`Ok(Some(Image))`](Image) of pixel data on success, `Ok(None)`
+    /// if the render was cancelled, or an error.
     pub fn run<F: Function + RenderHints>(
         &self,
         shape: Shape<F>,
-    ) -> Result<Image, RenderError> {
+    ) -> Result<Option<Image>, RenderError> {
         self.run_with_vars::<F>(shape, &ShapeVars::new())
     }
 
@@ -92,7 +96,7 @@ impl RenderConfig<'_> {
         &self,
         shape: Shape<F>,
         vars: &ShapeVars<f32>,
-    ) -> Result<Image, RenderError> {
+    ) -> Result<Option<Image>, RenderError> {
         render(shape, vars, self)
     }
 
@@ -422,14 +426,14 @@ impl<F: Function> Worker<'_, F> {
 /// This function is parameterized by shape type (which determines how we
 /// perform evaluation).
 ///
-/// Returns an `Image<DistancePixel>` of pixel data if rendering succeeds, or
-/// `None` if rendering was cancelled (using the [`RenderConfig::cancel`]
-/// token)
+/// Returns an [`Ok(Some(Image))`](Image) of pixel data if rendering succeeds,
+/// `Ok(None)` if rendering was cancelled (using the [`RenderConfig::cancel`]
+/// token), or an error.
 pub fn render<F: Function + RenderHints>(
     shape: Shape<F>,
     vars: &ShapeVars<f32>,
     config: &RenderConfig,
-) -> Result<Image, RenderError> {
+) -> Result<Option<Image>, RenderError> {
     vars.check(&shape)?;
     let max_size = config.width().max(config.height()) as usize;
     let default_tile_sizes;
@@ -439,13 +443,15 @@ pub fn render<F: Function + RenderHints>(
         default_tile_sizes = F::tile_sizes_2d();
         TileSizesRef::new(&default_tile_sizes, max_size)
     };
-    let tiles = super::render_tiles::<F, Worker<F>>(
+    let tiles = match super::render_tiles::<F, Worker<F>>(
         shape.clone(),
         vars,
         config,
         tile_sizes,
-    )
-    .ok_or(RenderError::Cancelled)?;
+    ) {
+        Some(t) => t,
+        None => return Ok(None),
+    };
 
     let width = config.image_size.width() as usize;
     let height = config.image_size.height() as usize;
@@ -463,7 +469,7 @@ pub fn render<F: Function + RenderHints>(
             }
         }
     }
-    Ok(image)
+    Ok(Some(image))
 }
 
 #[cfg(test)]
@@ -490,10 +496,7 @@ mod test {
         };
         let cancel = cfg.cancel.clone();
         cancel.cancel();
-        let Err(out) = cfg.run(shape) else {
-            panic!("expected error")
-        };
-        assert_eq!(out, RenderError::Cancelled);
+        assert!(cfg.run(shape).unwrap().is_none());
     }
 
     #[test]
@@ -522,7 +525,9 @@ mod test {
 
         let mut vars = ShapeVars::new();
         vars.insert(i, 1.0);
-        assert!(cfg.run_with_vars::<_>(shape, &vars).is_ok());
+        cfg.run_with_vars::<_>(shape, &vars)
+            .expect("rendering worked")
+            .expect("not cancelled");
     }
 
     #[test]

--- a/fidget-raster/src/voxel.rs
+++ b/fidget-raster/src/voxel.rs
@@ -80,8 +80,8 @@ impl RenderConfigLike for RenderConfig<'_> {
 impl RenderConfig<'_> {
     /// Render a shape in 3D using this configuration
     ///
-    /// Returns an [`Image`] of pixel data, or `None` if rendering was
-    /// cancelled.
+    /// Returns [`Ok(Some(Image))`](Image) of pixel data on success, `Ok(None)`
+    /// if the render was cancelled, or an error.
     ///
     /// In the resulting image, saturated pixels (i.e. pixels in the image which
     /// are fully occupied up to the camera) are represented with `depth =
@@ -89,7 +89,7 @@ impl RenderConfig<'_> {
     pub fn run<F: Function + RenderHints>(
         &self,
         shape: Shape<F>,
-    ) -> Result<Image, RenderError> {
+    ) -> Result<Option<Image>, RenderError> {
         self.run_with_vars::<F>(shape, &ShapeVars::new())
     }
 
@@ -98,7 +98,7 @@ impl RenderConfig<'_> {
         &self,
         shape: Shape<F>,
         vars: &ShapeVars<f32>,
-    ) -> Result<Image, RenderError> {
+    ) -> Result<Option<Image>, RenderError> {
         render(shape, vars, self)
     }
 
@@ -488,13 +488,13 @@ impl<F: Function> Worker<'_, F> {
 /// This function is parameterized by shape type, which determines how we
 /// perform evaluation.
 ///
-/// Returns a [`Image`] of pixels, or `None` if rendering was cancelled
-/// (using the [`RenderConfig::cancel`] token)
+/// Returns [`Ok(Some(Image))`](Image) of pixel data on success, `Ok(None)` if
+/// the render was cancelled, or an error.
 pub fn render<F: Function + RenderHints>(
     shape: Shape<F>,
     vars: &ShapeVars<f32>,
     config: &RenderConfig,
-) -> Result<Image, RenderError> {
+) -> Result<Option<Image>, RenderError> {
     vars.check(&shape)?;
     let max_size = config.width().max(config.height()) as usize;
     let default_tile_sizes;
@@ -505,9 +505,12 @@ pub fn render<F: Function + RenderHints>(
         default_tile_sizes = F::tile_sizes_3d();
         TileSizesRef::new(&default_tile_sizes, max_size)
     };
-    let tiles =
-        super::render_tiles::<F, Worker<F>>(shape, vars, config, tile_sizes)
-            .ok_or(RenderError::Cancelled)?;
+    let tiles = match super::render_tiles::<F, Worker<F>>(
+        shape, vars, config, tile_sizes,
+    ) {
+        Some(t) => t,
+        None => return Ok(None),
+    };
 
     let width = config.image_size.width() as usize;
     let height = config.image_size.height() as usize;
@@ -537,7 +540,7 @@ pub fn render<F: Function + RenderHints>(
             }
         }
     }
-    Ok(image)
+    Ok(Some(image))
 }
 
 #[cfg(test)]
@@ -556,7 +559,10 @@ mod test {
             image_size: RenderSize::from(128), // very small!
             ..Default::default()
         };
-        let image = cfg.run(shape).unwrap();
+        let image = cfg
+            .run(shape)
+            .expect("rendering should not fail")
+            .expect("rendering should not be cancelled");
         assert_eq!(image.len(), 128 * 128);
     }
 
@@ -572,10 +578,7 @@ mod test {
         };
         let cancel = cfg.cancel.clone();
         cancel.cancel();
-        let Err(out) = cfg.run::<_>(shape) else {
-            panic!("expected error")
-        };
-        assert_eq!(out, RenderError::Cancelled);
+        assert!(cfg.run::<_>(shape).unwrap().is_none());
     }
 
     #[test]
@@ -604,6 +607,8 @@ mod test {
 
         let mut vars = ShapeVars::new();
         vars.insert(i, 1.0);
-        assert!(cfg.run_with_vars::<_>(shape, &vars).is_ok());
+        cfg.run_with_vars::<_>(shape, &vars)
+            .expect("rendering worked")
+            .expect("not cancelled");
     }
 }

--- a/fidget-raster/src/voxel.rs
+++ b/fidget-raster/src/voxel.rs
@@ -1,8 +1,8 @@
 //! 3D bitmap rendering / rasterization
 use super::RenderHandle;
 use crate::{
-    Image as GenericImage, RenderConfig as RenderConfigLike, RenderWorker,
-    Tile, TileSizesRef,
+    Image as GenericImage, RenderConfig as RenderConfigLike, RenderError,
+    RenderWorker, Tile, TileSizesRef,
 };
 use fidget_core::{
     eval::Function,
@@ -89,7 +89,7 @@ impl RenderConfig<'_> {
     pub fn run<F: Function + RenderHints>(
         &self,
         shape: Shape<F>,
-    ) -> Option<Image> {
+    ) -> Result<Image, RenderError> {
         self.run_with_vars::<F>(shape, &ShapeVars::new())
     }
 
@@ -98,7 +98,7 @@ impl RenderConfig<'_> {
         &self,
         shape: Shape<F>,
         vars: &ShapeVars<f32>,
-    ) -> Option<Image> {
+    ) -> Result<Image, RenderError> {
         render(shape, vars, self)
     }
 
@@ -494,9 +494,11 @@ pub fn render<F: Function + RenderHints>(
     shape: Shape<F>,
     vars: &ShapeVars<f32>,
     config: &RenderConfig,
-) -> Option<Image> {
+) -> Result<Image, RenderError> {
+    vars.check(&shape)?;
     let max_size = config.width().max(config.height()) as usize;
     let default_tile_sizes;
+
     let tile_sizes = if let Some(ts) = &config.tile_sizes {
         TileSizesRef::new(ts, max_size)
     } else {
@@ -504,7 +506,8 @@ pub fn render<F: Function + RenderHints>(
         TileSizesRef::new(&default_tile_sizes, max_size)
     };
     let tiles =
-        super::render_tiles::<F, Worker<F>>(shape, vars, config, tile_sizes)?;
+        super::render_tiles::<F, Worker<F>>(shape, vars, config, tile_sizes)
+            .ok_or(RenderError::Cancelled)?;
 
     let width = config.image_size.width() as usize;
     let height = config.image_size.height() as usize;
@@ -534,13 +537,13 @@ pub fn render<F: Function + RenderHints>(
             }
         }
     }
-    Some(image)
+    Ok(image)
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use fidget_core::{Context, vm::VmShape};
+    use fidget_core::{Context, var::Var, vm::VmShape};
 
     /// Make sure we don't crash if there's only a single tile
     #[test]
@@ -569,7 +572,38 @@ mod test {
         };
         let cancel = cfg.cancel.clone();
         cancel.cancel();
-        let out = cfg.run::<_>(shape);
-        assert!(out.is_none());
+        let Err(out) = cfg.run::<_>(shape) else {
+            panic!("expected error")
+        };
+        assert_eq!(out, RenderError::Cancelled);
+    }
+
+    #[test]
+    fn missing_var() {
+        let mut ctx = Context::new();
+        let x = ctx.x();
+        let v = ctx.var(Var::new());
+        let s = ctx.sub(x, v).unwrap();
+        let shape = VmShape::new(&ctx, s).unwrap();
+
+        let cfg = RenderConfig {
+            image_size: RenderSize::new(64, 64, 64),
+            ..Default::default()
+        };
+        let Err(out) = cfg.run::<_>(shape.clone()) else {
+            panic!("expected error")
+        };
+        let var = ctx.get_var(v).unwrap();
+        let Var::V(i) = var else {
+            panic!("expected Var::V")
+        };
+        assert_eq!(
+            out,
+            RenderError::MissingVar(fidget_core::shape::MissingVar { var: i })
+        );
+
+        let mut vars = ShapeVars::new();
+        vars.insert(i, 1.0);
+        assert!(cfg.run_with_vars::<_>(shape, &vars).is_ok());
     }
 }

--- a/fidget/src/lib.rs
+++ b/fidget/src/lib.rs
@@ -220,7 +220,10 @@
 //!     ..Default::default()
 //! };
 //! let shape = VmShape::from(tree);
-//! let out = cfg.run(shape).unwrap();
+//! let out = cfg
+//!     .run(shape)
+//!     .expect("render should succeed")
+//!     .expect("render is not cancelled");
 //! let mut iter = out.iter();
 //! for y in 0..cfg.image_size.height() {
 //!     for x in 0..cfg.image_size.width() {

--- a/fidget/tests/pixel_render.rs
+++ b/fidget/tests/pixel_render.rs
@@ -45,6 +45,7 @@ impl Cfg {
         };
         let out = cfg
             .run_with_vars(shape, &self.vars)
+            .expect("rendering should not fail")
             .expect("rendering should not be cancelled");
         let mut img_str = String::new();
         for (i, b) in out.iter().enumerate() {
@@ -379,7 +380,10 @@ fn check_neg_infinity<F: Function + MathFunction + RenderHints>() {
         threads: None,
         ..Default::default()
     };
-    let out = cfg.run(shape).unwrap();
+    let out = cfg
+        .run(shape)
+        .expect("rendering should not fail")
+        .expect("rendering should not be cancelled");
     assert!(out.into_iter().all(|i| i.inside()));
 }
 

--- a/fidget/tests/voxel_render.rs
+++ b/fidget/tests/voxel_render.rs
@@ -31,7 +31,10 @@ fn sphere_var<F: Function + MathFunction + RenderHints>() {
         for r in [0.5, 0.75] {
             let mut vars = ShapeVars::new();
             vars.insert(v.index().unwrap(), r);
-            let image = cfg.run_with_vars::<_>(shape.clone(), &vars).unwrap();
+            let image = cfg
+                .run_with_vars::<_>(shape.clone(), &vars)
+                .expect("rendering should not fail")
+                .expect("rendering should not be cancelled");
 
             check_sphere(image, size, scale, r);
         }


### PR DESCRIPTION
Previously, these could panic if given a shape with missing vars.