### PR TITLE
Introduce new `BoundShape` type; use it for meshing and rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,9 +51,12 @@
 - Add `output_count()` to `Function` trait
 - Add `ShapeVars::check` and `ShapeVars::contains_key` to check whether the
   variable map is sufficient to evaluate a particular shape.
-- Change `fidget_raster` render functions to return a `Result<Option<Image>,
-  RenderError>`, because it's possible for callers to provide shapes without a
-  suitable `ShapeVar` map.  `Ok(None)` still means cancellation.
+- Change `fidget_raster` and `fidget_mesh` functions to take a `BoundShape<F>`,
+  which represents a shape and all of its associated variables.  A `BoundShape`
+  may be constructed using `TryFrom` for shapes with no variables other than X,
+  Y, Z; otherwise, `Shape::bind` must be used.  This removes a potential
+  `unwrap()` during rendering, because evaluation requires all variables to be
+  present.
 
 # 0.4.3
 - Fixed bug in x86 interval `OR` function ([#395](https://github.com/mkeeter/fidget/pull/395)),

--- a/demos/cli/src/main.rs
+++ b/demos/cli/src/main.rs
@@ -280,14 +280,14 @@ fn run3d<F: fidget::eval::Function + fidget::render::RenderHints>(
     };
 
     let mut image = Default::default();
-    let bound_shape = fidget::shape::BoundShape::try_from(shape).unwrap();
+    let bound_shape =
+        fidget::shape::BoundShape::try_from(shape).expect("no vars allowed");
 
     let start = std::time::Instant::now();
     for _ in 0..settings.n {
         // Unwrap both cancellation and errors
         image = cfg
             .run(bound_shape.clone())
-            .expect("rendering should not fail")
             .expect("rendering should not be cancelled");
     }
     info!(
@@ -472,6 +472,8 @@ fn run2d<F: fidget::eval::Function + fidget::render::RenderHints>(
             .flat_map(|i| i.into_iter())
             .collect()
     } else {
+        let bound_shape = fidget::shape::BoundShape::try_from(shape)
+            .expect("no vars allowed");
         let threads = match settings.threads {
             Some(n) if n.get() == 1 => None,
             Some(n) => Some(fidget::render::ThreadPool::Custom(
@@ -492,8 +494,7 @@ fn run2d<F: fidget::eval::Function + fidget::render::RenderHints>(
         let mut image = fidget::raster::Image::default();
         for _ in 0..settings.n {
             let tmp = cfg
-                .run::<_>(shape.clone())
-                .expect("render should not fail")
+                .run::<_>(bound_shape.clone())
                 .expect("render should not be cancelled");
             match mode {
                 RenderMode2D::Mono => {

--- a/demos/cli/src/main.rs
+++ b/demos/cli/src/main.rs
@@ -280,12 +280,13 @@ fn run3d<F: fidget::eval::Function + fidget::render::RenderHints>(
     };
 
     let mut image = Default::default();
+    let bound_shape = fidget::shape::BoundShape::try_from(shape).unwrap();
 
     let start = std::time::Instant::now();
     for _ in 0..settings.n {
         // Unwrap both cancellation and errors
         image = cfg
-            .run(shape.clone())
+            .run(bound_shape.clone())
             .expect("rendering should not fail")
             .expect("rendering should not be cancelled");
     }

--- a/demos/cli/src/main.rs
+++ b/demos/cli/src/main.rs
@@ -528,6 +528,7 @@ fn run_mesh<F: fidget::eval::Function + fidget::render::RenderHints>(
     settings: &MeshSettings,
 ) -> (fidget::mesh::Mesh, std::time::Duration, std::time::Duration) {
     let mut mesh = fidget::mesh::Mesh::new();
+    let shape = shape.try_into().expect("no variables");
 
     // Transform the shape based on our render settings
     let s = 1.0 / settings.scale;

--- a/demos/viewer/src/main.rs
+++ b/demos/viewer/src/main.rs
@@ -182,9 +182,9 @@ fn render_2d<F: fidget::eval::Function + fidget::render::RenderHints>(
         ..Default::default()
     };
 
+    let bound_shape = shape.try_into().expect("no vars allowed");
     let tmp = config
-        .run(shape)
-        .expect("rendering should not fail")
+        .run(bound_shape)
         .expect("rendering should not be cancelled");
     let out = match mode {
         Mode2D::Color => {

--- a/demos/viewer/src/main.rs
+++ b/demos/viewer/src/main.rs
@@ -216,10 +216,9 @@ fn render_3d<F: fidget::eval::Function + fidget::render::RenderHints>(
     };
 
     // Get the geometry buffer from the voxel rendering process
-    let bound_shape = shape.try_into().unwrap();
+    let bound_shape = shape.try_into().expect("no variables allowed");
     let geometry_buffer = config
         .run(bound_shape)
-        .expect("rendering should not fail")
         .expect("rendering should not be cancelled");
 
     // For both rendering modes, we'll just pass the GeometryPixel data

--- a/demos/viewer/src/main.rs
+++ b/demos/viewer/src/main.rs
@@ -216,8 +216,9 @@ fn render_3d<F: fidget::eval::Function + fidget::render::RenderHints>(
     };
 
     // Get the geometry buffer from the voxel rendering process
+    let bound_shape = shape.try_into().unwrap();
     let geometry_buffer = config
-        .run(shape)
+        .run(bound_shape)
         .expect("rendering should not fail")
         .expect("rendering should not be cancelled");
 

--- a/demos/web-editor/crate/src/lib.rs
+++ b/demos/web-editor/crate/src/lib.rs
@@ -67,7 +67,8 @@ pub fn render_2d(
         };
 
         // Unwrap errors, propagate cancellation
-        let tmp = cfg.run(shape).unwrap()?;
+        let bound_shape = shape.try_into().expect("no vars");
+        let tmp = cfg.run(bound_shape)?;
         let out =
             fidget::raster::effects::to_rgba_bitmap(tmp, false, cfg.threads);
         Some(out.into_iter().flatten().collect())
@@ -132,7 +133,8 @@ fn render_3d_inner(
         cancel,
     };
     // Unwrap errors, propagate cancellation
-    cfg.run(shape.clone()).unwrap()
+    let bound_shape = shape.try_into().expect("no vars");
+    cfg.run(bound_shape)
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/fidget-core/src/shape/mod.rs
+++ b/fidget-core/src/shape/mod.rs
@@ -164,6 +164,15 @@ impl<F: Function + Clone> Shape<F> {
     pub fn size(&self) -> usize {
         self.f.size()
     }
+
+    /// Binds a shape to a set of variable values
+    #[inline]
+    pub fn bind<'a, D>(
+        &self,
+        vars: &'a ShapeVars<D>,
+    ) -> Result<BoundShape<'a, F, D>, MissingVar> {
+        BoundShape::new(self.clone(), vars)
+    }
 }
 
 impl<F> Shape<F> {
@@ -793,6 +802,84 @@ where
     }
 }
 
+/// Shape with bound variables
+///
+/// By construction, the [`vars`](Self::vars) member is guaranteed to be
+/// populated for every (non-XYZ) variable in the shape.
+pub struct BoundShape<'a, F, D> {
+    shape: Shape<F>,
+    vars: BorrowedOrDefault<'a, ShapeVars<D>>,
+}
+
+/// Helper object which either borrows or builds a default value
+enum BorrowedOrDefault<'a, T: Default> {
+    Borrowed(&'a T),
+    Default(T),
+}
+
+impl<'a, T: Default> std::ops::Deref for BorrowedOrDefault<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        match self {
+            Self::Borrowed(t) => t,
+            Self::Default(t) => t,
+        }
+    }
+}
+
+impl<T: Default> Default for BorrowedOrDefault<'_, T> {
+    fn default() -> Self {
+        Self::Default(T::default())
+    }
+}
+
+impl<'a, F: Function, D> BoundShape<'a, F, D> {
+    /// Builds a new object, checking that all variables are present
+    pub fn new(
+        shape: Shape<F>,
+        vars: &'a ShapeVars<D>,
+    ) -> Result<Self, MissingVar> {
+        vars.check(&shape)?;
+        Ok(Self {
+            shape,
+            vars: BorrowedOrDefault::Borrowed(vars),
+        })
+    }
+
+    /// Returns the shape handle
+    pub fn shape(&self) -> &Shape<F> {
+        &self.shape
+    }
+
+    /// Returns the variables map
+    pub fn vars(&self) -> &ShapeVars<D> {
+        &self.vars
+    }
+}
+
+impl<'a, F: Function> TryFrom<Shape<F>> for BoundShape<'a, F, f32> {
+    type Error = MissingVar;
+    fn try_from(shape: Shape<F>) -> Result<Self, Self::Error> {
+        if let Some(v) = shape
+            .inner()
+            .vars()
+            .iter()
+            .flat_map(|(v, _i)| match v {
+                Var::X | Var::Y | Var::Z => None,
+                Var::V(i) => Some(i),
+            })
+            .next()
+        {
+            Err(MissingVar { var: v })
+        } else {
+            Ok(BoundShape {
+                shape,
+                vars: BorrowedOrDefault::default(),
+            })
+        }
+    }
+}
+
 /// Trait for types that can be transformed by a 4x4 homogeneous transform matrix
 pub trait Transformable {
     /// Apply the given transform to an `(x, y, z)` position
@@ -877,6 +964,41 @@ mod test {
             seen[vs[&v]] = true;
         }
         assert!(seen.iter().all(|i| *i));
+    }
+
+    #[test]
+    fn shape_bind() {
+        let v = Var::new();
+        let s = Tree::x() + Tree::y() + v;
+
+        let mut ctx = Context::new();
+        let s = ctx.import(&s);
+
+        // Try the TryFrom conversion, which will fail
+        let s = VmShape::new(&ctx, s).unwrap();
+        let Err(e) = BoundShape::try_from(s.clone()) else {
+            panic!("expected error");
+        };
+        let vi = v.index().unwrap();
+        assert_eq!(e, MissingVar { var: vi });
+
+        // Bind to a map with no vars
+        let mut m = ShapeVars::new();
+        let Err(e) = s.bind(&m) else {
+            panic!("expected error");
+        };
+        assert_eq!(e, MissingVar { var: vi });
+
+        // Add an unrelated var
+        m.insert(Var::new().index().unwrap(), 1.0f32);
+        let Err(e) = s.bind(&m) else {
+            panic!("expected error");
+        };
+        assert_eq!(e, MissingVar { var: vi });
+
+        // Finally, bind to a map with the target var
+        m.insert(vi, 2.0f32);
+        assert!(s.bind(&m).is_ok());
     }
 
     #[test]

--- a/fidget-core/src/shape/mod.rs
+++ b/fidget-core/src/shape/mod.rs
@@ -806,6 +806,7 @@ where
 ///
 /// By construction, the [`vars`](Self::vars) member is guaranteed to be
 /// populated for every (non-XYZ) variable in the shape.
+#[derive(Clone)]
 pub struct BoundShape<'a, F, D> {
     shape: Shape<F>,
     vars: BorrowedOrDefault<'a, ShapeVars<D>>,
@@ -815,6 +816,15 @@ pub struct BoundShape<'a, F, D> {
 enum BorrowedOrDefault<'a, T: Default> {
     Borrowed(&'a T),
     Default(T),
+}
+
+impl<'a, T: Default> Clone for BorrowedOrDefault<'a, T> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Borrowed(b) => Self::Borrowed(b),
+            Self::Default(..) => Self::Default(T::default()),
+        }
+    }
 }
 
 impl<'a, T: Default> std::ops::Deref for BorrowedOrDefault<'a, T> {

--- a/fidget-mesh/src/lib.rs
+++ b/fidget-mesh/src/lib.rs
@@ -29,11 +29,12 @@
 //!     + Tree::z().square();
 //! let tree: Tree = radius_squared.sqrt() - 0.6;
 //! let shape = VmShape::from(tree);
+//! let bound_shape = shape.try_into().expect("no extra vars");
 //! let settings = Settings {
 //!     depth: 4,
 //!     ..Default::default()
 //! };
-//! let o = Octree::build(&shape, &settings).unwrap();
+//! let o = Octree::build(&bound_shape, &settings).unwrap();
 //! let mesh = o.walk_dual();
 //!
 //! // Open a file to write, e.g.

--- a/fidget-mesh/src/octree.rs
+++ b/fidget-mesh/src/octree.rs
@@ -12,7 +12,10 @@ use super::{
 use fidget_core::{
     eval::Function,
     render::{RenderHandle, RenderHints, ThreadPool},
-    shape::{BoundShape, Shape, ShapeBulkEval, ShapeTracingEval, ShapeVars},
+    shape::{
+        BoundShape, Shape, ShapeBulkEval, ShapeBulkEvalError, ShapeTracingEval,
+        ShapeTracingEvalError, ShapeVars,
+    },
     types::Grad,
 };
 use std::collections::VecDeque;
@@ -50,9 +53,7 @@ impl Octree {
         b: &BoundShape<F, f32>,
         settings: &Settings,
     ) -> Option<Self> {
-        let shape = b.shape();
-        let vars = b.vars();
-        let mut out = Self::build_inner(shape, vars, settings)?;
+        let mut out = Self::build_inner(b, settings)?;
 
         // Apply the transform from [-1, +1] back to model space
         if settings.world_to_model != nalgebra::Matrix4::identity() {
@@ -70,11 +71,11 @@ impl Octree {
     /// # Panics
     /// If `shape` and `vars` are not compatible
     fn build_inner<F: Function + RenderHints + Clone>(
-        shape: &Shape<F>,
-        vars: &ShapeVars<f32>,
+        b: &BoundShape<F, f32>,
         settings: &Settings,
     ) -> Option<Self> {
-        vars.check(shape).unwrap();
+        let shape = b.shape();
+        let vars = b.vars();
         if let Some(threads) = settings.threads {
             Self::build_inner_mt(shape, settings, vars, threads)
         } else {
@@ -526,17 +527,17 @@ impl<'a, F: Function + RenderHints> OctreeBuilder<'a, F> {
         if self.cancel.is_cancelled() {
             return false;
         }
-        let (i, r) = self
-            .eval_interval
-            .eval_raw(
-                eval.i_tape(&mut self.tape_storage),
-                cell.bounds[crate::types::X],
-                cell.bounds[crate::types::Y],
-                cell.bounds[crate::types::Z],
-                self.world_to_model,
-                self.vars,
-            )
-            .unwrap();
+        let (i, r) = match self.eval_interval.eval_raw(
+            eval.i_tape(&mut self.tape_storage),
+            cell.bounds[crate::types::X],
+            cell.bounds[crate::types::Y],
+            cell.bounds[crate::types::Z],
+            self.world_to_model,
+            self.vars,
+        ) {
+            Ok(v) => v,
+            Err(ShapeTracingEvalError::MissingVar(..)) => unreachable!(),
+        };
         self.octree[cell] = if i.upper() < 0.0 {
             Cell::Full
         } else if i.lower() > 0.0 {
@@ -602,17 +603,20 @@ impl<'a, F: Function + RenderHints> OctreeBuilder<'a, F> {
             zs[i.index()] = z;
         }
 
-        let out = self
-            .eval_float_slice
-            .eval_raw(
-                eval.f_tape(&mut self.tape_storage),
-                &xs,
-                &ys,
-                &zs,
-                self.world_to_model,
-                ShapeBulkEval::<F::FloatSliceEval>::var_value(self.vars),
-            )
-            .unwrap();
+        let out = match self.eval_float_slice.eval_raw(
+            eval.f_tape(&mut self.tape_storage),
+            &xs,
+            &ys,
+            &zs,
+            self.world_to_model,
+            ShapeBulkEval::<F::FloatSliceEval>::var_value(self.vars),
+        ) {
+            Ok(v) => v,
+            Err(
+                ShapeBulkEvalError::MissingVar(..)
+                | ShapeBulkEvalError::MismatchedVarSlices { .. },
+            ) => unreachable!(),
+        };
         debug_assert_eq!(out.len(), 8);
 
         // Build a mask of active corners, which determines cell
@@ -712,17 +716,20 @@ impl<'a, F: Function + RenderHints> OctreeBuilder<'a, F> {
             debug_assert_eq!(i, EDGE_SEARCH_SIZE * edge_count);
 
             // Do the actual evaluation
-            let out = self
-                .eval_float_slice
-                .eval_raw(
-                    eval.f_tape(&mut self.tape_storage),
-                    xs,
-                    ys,
-                    zs,
-                    self.world_to_model,
-                    ShapeBulkEval::<F::FloatSliceEval>::var_value(self.vars),
-                )
-                .unwrap();
+            let out = match self.eval_float_slice.eval_raw(
+                eval.f_tape(&mut self.tape_storage),
+                xs,
+                ys,
+                zs,
+                self.world_to_model,
+                ShapeBulkEval::<F::FloatSliceEval>::var_value(self.vars),
+            ) {
+                Ok(v) => v,
+                Err(
+                    ShapeBulkEvalError::MissingVar(..)
+                    | ShapeBulkEvalError::MismatchedVarSlices { .. },
+                ) => unreachable!(),
+            };
 
             // Update start and end positions based on evaluation
             for ((start, end), search) in start
@@ -785,17 +792,20 @@ impl<'a, F: Function + RenderHints> OctreeBuilder<'a, F> {
         }
 
         // TODO: special case for cells with multiple gradients ("features")
-        let grads = self
-            .eval_grad_slice
-            .eval_raw(
-                eval.g_tape(&mut self.tape_storage),
-                xs,
-                ys,
-                zs,
-                self.world_to_model,
-                ShapeBulkEval::<F::GradSliceEval>::var_value(self.vars),
-            )
-            .unwrap();
+        let grads = match self.eval_grad_slice.eval_raw(
+            eval.g_tape(&mut self.tape_storage),
+            xs,
+            ys,
+            zs,
+            self.world_to_model,
+            ShapeBulkEval::<F::GradSliceEval>::var_value(self.vars),
+        ) {
+            Ok(v) => v,
+            Err(
+                ShapeBulkEvalError::MissingVar(..)
+                | ShapeBulkEvalError::MismatchedVarSlices { .. },
+            ) => unreachable!(),
+        };
 
         let mut verts: arrayvec::ArrayVec<_, 4> = arrayvec::ArrayVec::new();
         let mut i = 0;

--- a/fidget-mesh/src/octree.rs
+++ b/fidget-mesh/src/octree.rs
@@ -12,7 +12,7 @@ use super::{
 use fidget_core::{
     eval::Function,
     render::{RenderHandle, RenderHints, ThreadPool},
-    shape::{Shape, ShapeBulkEval, ShapeTracingEval, ShapeVars},
+    shape::{BoundShape, Shape, ShapeBulkEval, ShapeTracingEval, ShapeVars},
     types::Grad,
 };
 use std::collections::VecDeque;
@@ -40,17 +40,18 @@ impl Octree {
         }
     }
 
-    /// Builds an octree to the given depth, with user-provided variables
+    /// Builds an octree to the given depth
     ///
     /// The shape is evaluated on the region specified by `settings.bounds`.
     ///
     /// Returns `None` if processing is cancelled by the
     /// [`CancelToken`](fidget_core::render::CancelToken) in [`Settings`].
-    pub fn build_with_vars<F: Function + RenderHints + Clone>(
-        shape: &Shape<F>,
-        vars: &ShapeVars<f32>,
+    pub fn build<F: Function + RenderHints + Clone>(
+        b: &BoundShape<F, f32>,
         settings: &Settings,
     ) -> Option<Self> {
+        let shape = b.shape();
+        let vars = b.vars();
         let mut out = Self::build_inner(shape, vars, settings)?;
 
         // Apply the transform from [-1, +1] back to model space
@@ -64,25 +65,16 @@ impl Octree {
         Some(out)
     }
 
-    /// Builds an octree to the given depth
+    /// Performs the inner work of evaluation
     ///
-    /// If the shape uses variables other than `x`, `y`, `z`, then
-    /// [`build_with_vars`](Octree::build_with_vars) should be used instead (and
-    /// this function will return an error).
-    ///
-    /// The shape is evaluated on the region specified by `settings.bounds`.
-    pub fn build<F: Function + RenderHints + Clone>(
-        shape: &Shape<F>,
-        settings: &Settings,
-    ) -> Option<Self> {
-        Self::build_with_vars(shape, &ShapeVars::new(), settings)
-    }
-
+    /// # Panics
+    /// If `shape` and `vars` are not compatible
     fn build_inner<F: Function + RenderHints + Clone>(
         shape: &Shape<F>,
         vars: &ShapeVars<f32>,
         settings: &Settings,
     ) -> Option<Self> {
+        vars.check(shape).unwrap();
         if let Some(threads) = settings.threads {
             Self::build_inner_mt(shape, settings, vars, threads)
         } else {
@@ -1042,7 +1034,7 @@ mod test {
         render::ThreadPool,
         shape::EzShape,
         var::Var,
-        vm::VmShape,
+        vm::{VmFunction, VmShape},
     };
     use std::collections::BTreeMap;
 
@@ -1060,6 +1052,14 @@ mod test {
             threads: None,
             ..Default::default()
         }
+    }
+
+    /// Converts a [`Tree`] with no extra variables to a [`BoundShape`]
+    ///
+    /// # Panics
+    /// If the tree uses variables
+    fn tree_to_shape(t: Tree) -> BoundShape<'static, VmFunction, f32> {
+        VmShape::from(t).try_into().expect("no variables allowed")
     }
 
     fn sphere(center: [f32; 3], radius: f32) -> Tree {
@@ -1083,7 +1083,7 @@ mod test {
     fn test_cube_edge() {
         const EPSILON: f32 = 1e-3;
         let f = 2.0;
-        let shape = VmShape::from(cube([-f, f], [-f, 0.3], [-f, 0.6]));
+        let shape = tree_to_shape(cube([-f, f], [-f, 0.3], [-f, 0.6]));
         // This should be a cube with a single edge running through the root
         // node of the octree, with an edge vertex at [0, 0.3, 0.6]
         let octree = Octree::build(&shape, &depth0_single_thread()).unwrap();
@@ -1132,7 +1132,7 @@ mod test {
 
     #[test]
     fn test_mesh_basic() {
-        let shape = VmShape::from(sphere([0.0; 3], 0.2));
+        let shape = tree_to_shape(sphere([0.0; 3], 0.2));
 
         // If we only build a depth-0 octree, then it's a leaf without any
         // vertices (since all the corners are empty)
@@ -1169,7 +1169,7 @@ mod test {
 
     #[test]
     fn test_sphere_verts() {
-        let shape = VmShape::from(sphere([0.0; 3], 0.2));
+        let shape = tree_to_shape(sphere([0.0; 3], 0.2));
 
         let octree = Octree::build(&shape, &depth1_single_thread()).unwrap();
         let sphere_mesh = octree.walk_dual();
@@ -1205,7 +1205,7 @@ mod test {
 
     #[test]
     fn test_sphere_manifold() {
-        let shape = VmShape::from(sphere([0.0; 3], 0.85));
+        let shape = tree_to_shape(sphere([0.0; 3], 0.85));
 
         for threads in [None, Some(&ThreadPool::Global)] {
             let settings = Settings {
@@ -1223,7 +1223,7 @@ mod test {
 
     #[test]
     fn test_cube_verts() {
-        let shape = VmShape::from(cube([-0.1, 0.6], [-0.2, 0.75], [-0.3, 0.4]));
+        let shape = tree_to_shape(cube([-0.1, 0.6], [-0.2, 0.75], [-0.3, 0.4]));
 
         let octree = Octree::build(&shape, &depth1_single_thread()).unwrap();
         let mesh = octree.walk_dual();
@@ -1273,7 +1273,7 @@ mod test {
                 for offset in [0.0, -0.2, 0.2] {
                     let (x, y, z) = Tree::axes();
                     let f = x * dx + y * dy + z + offset;
-                    let shape = VmShape::from(f);
+                    let shape = tree_to_shape(f);
                     let octree =
                         Octree::build(&shape, &depth0_single_thread()).unwrap();
 
@@ -1290,7 +1290,7 @@ mod test {
                          offset: {offset} => {pos:?} != {mass_point:?}"
                     );
                     let mut eval = VmShape::new_point_eval();
-                    let tape = shape.ez_point_tape();
+                    let tape = shape.shape().ez_point_tape();
                     for v in &octree.verts {
                         let v = v.pos;
                         let (r, _) = eval.eval(&tape, v.x, v.y, v.z).unwrap();
@@ -1309,10 +1309,10 @@ mod test {
             nalgebra::Vector3::new(1.2, 1.3, 1.4),
         ] {
             let corner = nalgebra::Vector3::new(-1.0, -1.0, -1.0);
-            let shape = VmShape::from(cone(corner, tip, 0.1));
+            let shape = tree_to_shape(cone(corner, tip, 0.1));
 
             let mut eval = VmShape::new_point_eval();
-            let tape = shape.ez_point_tape();
+            let tape = shape.shape().ez_point_tape();
             let (v, _) = eval.eval(&tape, tip.x, tip.y, tip.z).unwrap();
             assert!(v.abs() < 1e-6, "bad tip value: {v}");
             let (v, _) =
@@ -1351,7 +1351,7 @@ mod test {
 
         // Now, we have our shape, which is 0-8 spheres placed at the
         // corners of the cell spanning [0, 0.25]
-        let shape = VmShape::from(shape);
+        let shape = tree_to_shape(shape);
         let settings = Settings {
             depth: 2,
             threads,
@@ -1389,13 +1389,13 @@ mod test {
 
     #[test]
     fn test_collapsible() {
-        let shape = VmShape::from(sphere([0.0; 3], 0.1));
+        let shape = tree_to_shape(sphere([0.0; 3], 0.1));
         let octree = Octree::build(&shape, &depth1_single_thread()).unwrap();
         assert!(octree.collapsible(0).is_none());
 
         // If we have a single corner sphere, then the builder will collapse the
         // branch for us, leaving just a leaf.
-        let shape = VmShape::from(sphere([-1.0; 3], 0.1));
+        let shape = tree_to_shape(sphere([-1.0; 3], 0.1));
         let octree = Octree::build(&shape, &depth1_single_thread()).unwrap();
         assert!(matches!(octree.root, Cell::Leaf { .. }));
 
@@ -1431,13 +1431,13 @@ mod test {
             octree.root
         );
 
-        let shape = VmShape::from(sphere([-1.0, 0.0, 1.0], 0.1));
+        let shape = tree_to_shape(sphere([-1.0, 0.0, 1.0], 0.1));
         let octree = Octree::build(&shape, &depth1_single_thread()).unwrap();
         assert!(octree.collapsible(0).is_none());
 
         let a = sphere([-1.0; 3], 0.1);
         let b = sphere([1.0; 3], 0.1);
-        let shape = VmShape::from(a.min(b));
+        let shape = tree_to_shape(a.min(b));
         let octree = Octree::build(&shape, &depth1_single_thread()).unwrap();
         assert!(octree.collapsible(0).is_none());
     }
@@ -1445,7 +1445,7 @@ mod test {
     #[test]
     fn test_empty_collapse() {
         // Make a very smol sphere that won't be sampled
-        let shape = VmShape::from(sphere([0.1; 3], 0.05));
+        let shape = tree_to_shape(sphere([0.1; 3], 0.05));
 
         for threads in [None, Some(&ThreadPool::Global)] {
             let settings = Settings {
@@ -1468,6 +1468,7 @@ mod test {
         const COLONNADE: &str = include_str!("../../models/colonnade.vm");
         let (ctx, root) = Context::from_text(COLONNADE.as_bytes()).unwrap();
         let tape = VmShape::new(&ctx, root).unwrap();
+        let shape = tape.try_into().unwrap();
 
         for threads in [None, Some(&ThreadPool::Global)] {
             let settings = Settings {
@@ -1475,7 +1476,7 @@ mod test {
                 threads,
                 ..Default::default()
             };
-            let octree = Octree::build(&tape, &settings).unwrap();
+            let octree = Octree::build(&shape, &settings).unwrap();
             let mesh = octree.walk_dual();
             // Note: the model has duplicate vertices!
             if let Err(e) = check_for_edge_matching(&mesh) {
@@ -1492,6 +1493,7 @@ mod test {
         const COLONNADE: &str = include_str!("../../models/colonnade.vm");
         let (ctx, root) = Context::from_text(COLONNADE.as_bytes()).unwrap();
         let tape = VmShape::new(&ctx, root).unwrap();
+        let shape = tape.try_into().unwrap();
 
         for threads in [None, Some(&ThreadPool::Global)] {
             let settings = Settings {
@@ -1499,7 +1501,7 @@ mod test {
                 threads,
                 ..Default::default()
             };
-            let octree = Octree::build(&tape, &settings).unwrap();
+            let octree = Octree::build(&shape, &settings).unwrap();
             let mesh = octree.walk_dual();
             for v in mesh.vertices.iter() {
                 assert!(
@@ -1521,6 +1523,7 @@ mod test {
         const COLONNADE: &str = include_str!("../../models/bear.vm");
         let (ctx, root) = Context::from_text(COLONNADE.as_bytes()).unwrap();
         let tape = VmShape::new(&ctx, root).unwrap();
+        let shape = tape.try_into().unwrap();
 
         for threads in [None, Some(&ThreadPool::Global)] {
             let settings = Settings {
@@ -1528,7 +1531,7 @@ mod test {
                 threads,
                 ..Default::default()
             };
-            let octree = Octree::build(&tape, &settings).unwrap();
+            let octree = Octree::build(&shape, &settings).unwrap();
             let mesh = octree.walk_dual();
             for v in mesh.vertices.iter() {
                 assert!(
@@ -1624,7 +1627,7 @@ mod test {
 
     #[test]
     fn test_qef_near_planar() {
-        let shape = VmShape::from(sphere([0.0; 3], 0.75));
+        let shape = tree_to_shape(sphere([0.0; 3], 0.75));
 
         let settings = Settings {
             depth: 4,
@@ -1656,9 +1659,9 @@ mod test {
             for r in [0.5, 0.75] {
                 let mut vars = ShapeVars::new();
                 vars.insert(v.index().unwrap(), r);
-                let octree = Octree::build_with_vars(&shape, &vars, &settings)
-                    .unwrap()
-                    .walk_dual();
+                let shape = shape.bind(&vars).unwrap();
+                let octree =
+                    Octree::build(&shape, &settings).unwrap().walk_dual();
                 for v in octree.vertices.iter() {
                     let n = v.norm();
                     assert!(
@@ -1675,7 +1678,7 @@ mod test {
     fn test_octree_cancel() {
         let (x, y, z) = Tree::axes();
         let sphere = (x.square() + y.square() + z.square()).sqrt() - 1.0;
-        let shape = VmShape::from(sphere);
+        let shape = tree_to_shape(sphere);
 
         for threads in [None, Some(&ThreadPool::Global)] {
             let settings = Settings {

--- a/fidget-raster/src/lib.rs
+++ b/fidget-raster/src/lib.rs
@@ -475,14 +475,6 @@ pub struct BadPixelCount {
     pub height: u32,
 }
 
-/// Error type for render operations
-#[derive(thiserror::Error, Debug, PartialEq)]
-pub enum RenderError {
-    /// Missing variable in the [`ShapeVars`] map
-    #[error(transparent)]
-    MissingVar(#[from] fidget_core::shape::MissingVar),
-}
-
 #[cfg(test)]
 mod test {
     use super::*;

--- a/fidget-raster/src/pixel.rs
+++ b/fidget-raster/src/pixel.rs
@@ -407,18 +407,13 @@ impl<F: Function> Worker<'_, F> {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-/// Renders the given tape into a 2D image at Z = 0 according to the provided
-/// configuration.
+/// Renders a shape into a 2D image at Z = 0, with the provided configuration
 ///
-/// The tape provides the shape; the configuration supplies resolution,
-/// transforms, etc.
+/// The shape provides the evaluator backend (`F`) and bound variables; the
+/// configuration supplies resolution, transforms, etc.
 ///
-/// This function is parameterized by shape type (which determines how we
-/// perform evaluation).
-///
-/// Returns an [`Ok(Some(Image))`](Image) of pixel data if rendering succeeds,
-/// `Ok(None)` if rendering was cancelled (using the [`RenderConfig::cancel`]
-/// token), or an error.
+/// Returns [`Some(Image)`](Image) of pixel data if rendering succeeds, or
+/// `None` if rendering was cancelled (using the [`RenderConfig::cancel`].
 pub fn render<F: Function + RenderHints>(
     b: BoundShape<F, f32>,
     config: &RenderConfig,

--- a/fidget-raster/src/pixel.rs
+++ b/fidget-raster/src/pixel.rs
@@ -1,14 +1,14 @@
 //! 2D bitmap rendering / rasterization
 use super::RenderHandle;
 use crate::{
-    Image as GenericImage, RenderConfig as RenderConfigLike, RenderError,
-    RenderWorker, Tile, TileSizesRef,
+    Image as GenericImage, RenderConfig as RenderConfigLike, RenderWorker,
+    Tile, TileSizesRef,
 };
 use fidget_core::{
     eval::Function,
     render::{CancelToken, RenderHints, ThreadPool, TileSizes},
     shape::{
-        Shape, ShapeBulkEval, ShapeBulkEvalError, ShapeTracingEval,
+        BoundShape, ShapeBulkEval, ShapeBulkEvalError, ShapeTracingEval,
         ShapeTracingEvalError, ShapeVars,
     },
     types::Interval,
@@ -81,23 +81,13 @@ impl RenderConfigLike for RenderConfig<'_> {
 impl RenderConfig<'_> {
     /// Render a shape in 2D using this configuration
     ///
-    ///
-    /// Returns [`Ok(Some(Image))`](Image) of pixel data on success, `Ok(None)`
-    /// if the render was cancelled, or an error.
+    /// Returns [`Some(Image)`](Image) of pixel data on success, or `None`
+    /// if the render was cancelled.
     pub fn run<F: Function + RenderHints>(
         &self,
-        shape: Shape<F>,
-    ) -> Result<Option<Image>, RenderError> {
-        self.run_with_vars::<F>(shape, &ShapeVars::new())
-    }
-
-    /// Render a shape in 2D using this configuration and variables
-    pub fn run_with_vars<F: Function + RenderHints>(
-        &self,
-        shape: Shape<F>,
-        vars: &ShapeVars<f32>,
-    ) -> Result<Option<Image>, RenderError> {
-        render(shape, vars, self)
+        shape: BoundShape<F, f32>,
+    ) -> Option<Image> {
+        render(shape, self)
     }
 
     /// Returns the combined screen-to-model transform matrix
@@ -430,11 +420,11 @@ impl<F: Function> Worker<'_, F> {
 /// `Ok(None)` if rendering was cancelled (using the [`RenderConfig::cancel`]
 /// token), or an error.
 pub fn render<F: Function + RenderHints>(
-    shape: Shape<F>,
-    vars: &ShapeVars<f32>,
+    b: BoundShape<F, f32>,
     config: &RenderConfig,
-) -> Result<Option<Image>, RenderError> {
-    vars.check(&shape)?;
+) -> Option<Image> {
+    let shape = b.shape();
+    let vars = b.vars();
     let max_size = config.width().max(config.height()) as usize;
     let default_tile_sizes;
     let tile_sizes = if let Some(ts) = &config.tile_sizes {
@@ -443,15 +433,12 @@ pub fn render<F: Function + RenderHints>(
         default_tile_sizes = F::tile_sizes_2d();
         TileSizesRef::new(&default_tile_sizes, max_size)
     };
-    let tiles = match super::render_tiles::<F, Worker<F>>(
+    let tiles = super::render_tiles::<F, Worker<F>>(
         shape.clone(),
         vars,
         config,
         tile_sizes,
-    ) {
-        Some(t) => t,
-        None => return Ok(None),
-    };
+    )?;
 
     let width = config.image_size.width() as usize;
     let height = config.image_size.height() as usize;
@@ -469,7 +456,7 @@ pub fn render<F: Function + RenderHints>(
             }
         }
     }
-    Ok(Some(image))
+    Some(image)
 }
 
 #[cfg(test)]
@@ -488,7 +475,10 @@ mod test {
     #[test]
     fn render2d_cancel() {
         let (ctx, root) = Context::from_text(HI.as_bytes()).unwrap();
-        let shape = Shape::<VmFunction>::new(&ctx, root).unwrap();
+        let shape = Shape::<VmFunction>::new(&ctx, root)
+            .unwrap()
+            .try_into()
+            .expect("no vars");
 
         let cfg = RenderConfig {
             image_size: RenderSize::new(64, 64),
@@ -496,14 +486,15 @@ mod test {
         };
         let cancel = cfg.cancel.clone();
         cancel.cancel();
-        assert!(cfg.run(shape).unwrap().is_none());
+        assert!(cfg.run(shape).is_none());
     }
 
     #[test]
-    fn missing_var() {
+    fn shape_with_var() {
         let mut ctx = Context::new();
         let x = ctx.x();
-        let v = ctx.var(Var::new());
+        let var = Var::new();
+        let v = ctx.var(var);
         let s = ctx.sub(x, v).unwrap();
         let shape = VmShape::new(&ctx, s).unwrap();
 
@@ -511,20 +502,10 @@ mod test {
             image_size: RenderSize::new(64, 64),
             ..Default::default()
         };
-        let Err(out) = cfg.run::<_>(shape.clone()) else {
-            panic!("expected error")
-        };
-        let var = ctx.get_var(v).unwrap();
-        let i = var.index().expect("expected Var::V");
-        assert_eq!(
-            out,
-            RenderError::MissingVar(fidget_core::shape::MissingVar { var: i })
-        );
-
         let mut vars = ShapeVars::new();
+        let i = var.index().expect("expected Var::V");
         vars.insert(i, 1.0);
-        cfg.run_with_vars::<_>(shape, &vars)
-            .expect("rendering worked")
+        cfg.run::<_>(shape.bind(&vars).expect("all vars present"))
             .expect("not cancelled");
     }
 

--- a/fidget-raster/src/pixel.rs
+++ b/fidget-raster/src/pixel.rs
@@ -515,9 +515,7 @@ mod test {
             panic!("expected error")
         };
         let var = ctx.get_var(v).unwrap();
-        let Var::V(i) = var else {
-            panic!("expected Var::V")
-        };
+        let i = var.index().expect("expected Var::V");
         assert_eq!(
             out,
             RenderError::MissingVar(fidget_core::shape::MissingVar { var: i })

--- a/fidget-raster/src/voxel.rs
+++ b/fidget-raster/src/voxel.rs
@@ -7,7 +7,7 @@ use crate::{
 use fidget_core::{
     eval::Function,
     render::{CancelToken, RenderHints, ThreadPool, TileSizes},
-    shape::{Shape, ShapeBulkEval, ShapeTracingEval, ShapeVars},
+    shape::{BoundShape, ShapeBulkEval, ShapeTracingEval, ShapeVars},
     types::{Grad, Interval},
 };
 
@@ -80,26 +80,14 @@ impl RenderConfigLike for RenderConfig<'_> {
 impl RenderConfig<'_> {
     /// Render a shape in 3D using this configuration
     ///
-    /// Returns [`Ok(Some(Image))`](Image) of pixel data on success, `Ok(None)`
-    /// if the render was cancelled, or an error.
-    ///
     /// In the resulting image, saturated pixels (i.e. pixels in the image which
     /// are fully occupied up to the camera) are represented with `depth =
     /// self.image_size.depth()` and a normal of `[0, 0, 1]`.
     pub fn run<F: Function + RenderHints>(
         &self,
-        shape: Shape<F>,
+        shape: BoundShape<F, f32>,
     ) -> Result<Option<Image>, RenderError> {
-        self.run_with_vars::<F>(shape, &ShapeVars::new())
-    }
-
-    /// Render a shape in 3D using this configuration and variables
-    pub fn run_with_vars<F: Function + RenderHints>(
-        &self,
-        shape: Shape<F>,
-        vars: &ShapeVars<f32>,
-    ) -> Result<Option<Image>, RenderError> {
-        render(shape, vars, self)
+        render(shape, self)
     }
 
     /// Returns the combined screen-to-model transform matrix
@@ -491,10 +479,11 @@ impl<F: Function> Worker<'_, F> {
 /// Returns [`Ok(Some(Image))`](Image) of pixel data on success, `Ok(None)` if
 /// the render was cancelled, or an error.
 pub fn render<F: Function + RenderHints>(
-    shape: Shape<F>,
-    vars: &ShapeVars<f32>,
+    b: BoundShape<F, f32>,
     config: &RenderConfig,
 ) -> Result<Option<Image>, RenderError> {
+    let shape = b.shape().clone();
+    let vars = b.vars();
     vars.check(&shape)?;
     let max_size = config.width().max(config.height()) as usize;
     let default_tile_sizes;
@@ -553,7 +542,7 @@ mod test {
     fn test_tile_queues() {
         let mut ctx = Context::new();
         let x = ctx.x();
-        let shape = VmShape::new(&ctx, x).unwrap();
+        let shape = VmShape::new(&ctx, x).unwrap().try_into().unwrap();
 
         let cfg = RenderConfig {
             image_size: RenderSize::from(128), // very small!
@@ -570,7 +559,7 @@ mod test {
     fn cancel_render() {
         let mut ctx = Context::new();
         let x = ctx.x();
-        let shape = VmShape::new(&ctx, x).unwrap();
+        let shape = VmShape::new(&ctx, x).unwrap().try_into().unwrap();
 
         let cfg = RenderConfig {
             image_size: RenderSize::new(64, 64, 64),
@@ -582,10 +571,11 @@ mod test {
     }
 
     #[test]
-    fn missing_var() {
+    fn shape_with_var() {
         let mut ctx = Context::new();
         let x = ctx.x();
-        let v = ctx.var(Var::new());
+        let var = Var::new();
+        let v = ctx.var(var);
         let s = ctx.sub(x, v).unwrap();
         let shape = VmShape::new(&ctx, s).unwrap();
 
@@ -593,19 +583,11 @@ mod test {
             image_size: RenderSize::new(64, 64, 64),
             ..Default::default()
         };
-        let Err(out) = cfg.run::<_>(shape.clone()) else {
-            panic!("expected error")
-        };
-        let var = ctx.get_var(v).unwrap();
-        let i = var.index().expect("expected Var::V");
-        assert_eq!(
-            out,
-            RenderError::MissingVar(fidget_core::shape::MissingVar { var: i })
-        );
 
         let mut vars = ShapeVars::new();
+        let i = var.index().expect("expected Var::V");
         vars.insert(i, 1.0);
-        cfg.run_with_vars::<_>(shape, &vars)
+        cfg.run::<_>(shape.bind(&vars).expect("all vars present"))
             .expect("rendering worked")
             .expect("not cancelled");
     }

--- a/fidget-raster/src/voxel.rs
+++ b/fidget-raster/src/voxel.rs
@@ -1,8 +1,8 @@
 //! 3D bitmap rendering / rasterization
 use super::RenderHandle;
 use crate::{
-    Image as GenericImage, RenderConfig as RenderConfigLike, RenderError,
-    RenderWorker, Tile, TileSizesRef,
+    Image as GenericImage, RenderConfig as RenderConfigLike, RenderWorker,
+    Tile, TileSizesRef,
 };
 use fidget_core::{
     eval::Function,
@@ -86,7 +86,7 @@ impl RenderConfig<'_> {
     pub fn run<F: Function + RenderHints>(
         &self,
         shape: BoundShape<F, f32>,
-    ) -> Result<Option<Image>, RenderError> {
+    ) -> Option<Image> {
         render(shape, self)
     }
 
@@ -481,10 +481,9 @@ impl<F: Function> Worker<'_, F> {
 pub fn render<F: Function + RenderHints>(
     b: BoundShape<F, f32>,
     config: &RenderConfig,
-) -> Result<Option<Image>, RenderError> {
+) -> Option<Image> {
     let shape = b.shape().clone();
     let vars = b.vars();
-    vars.check(&shape)?;
     let max_size = config.width().max(config.height()) as usize;
     let default_tile_sizes;
 
@@ -494,12 +493,8 @@ pub fn render<F: Function + RenderHints>(
         default_tile_sizes = F::tile_sizes_3d();
         TileSizesRef::new(&default_tile_sizes, max_size)
     };
-    let tiles = match super::render_tiles::<F, Worker<F>>(
-        shape, vars, config, tile_sizes,
-    ) {
-        Some(t) => t,
-        None => return Ok(None),
-    };
+    let tiles =
+        super::render_tiles::<F, Worker<F>>(shape, vars, config, tile_sizes)?;
 
     let width = config.image_size.width() as usize;
     let height = config.image_size.height() as usize;
@@ -529,7 +524,7 @@ pub fn render<F: Function + RenderHints>(
             }
         }
     }
-    Ok(Some(image))
+    Some(image)
 }
 
 #[cfg(test)]
@@ -548,10 +543,7 @@ mod test {
             image_size: RenderSize::from(128), // very small!
             ..Default::default()
         };
-        let image = cfg
-            .run(shape)
-            .expect("rendering should not fail")
-            .expect("rendering should not be cancelled");
+        let image = cfg.run(shape).expect("rendering should not be cancelled");
         assert_eq!(image.len(), 128 * 128);
     }
 
@@ -567,7 +559,7 @@ mod test {
         };
         let cancel = cfg.cancel.clone();
         cancel.cancel();
-        assert!(cfg.run::<_>(shape).unwrap().is_none());
+        assert!(cfg.run::<_>(shape).is_none());
     }
 
     #[test]
@@ -588,7 +580,6 @@ mod test {
         let i = var.index().expect("expected Var::V");
         vars.insert(i, 1.0);
         cfg.run::<_>(shape.bind(&vars).expect("all vars present"))
-            .expect("rendering worked")
             .expect("not cancelled");
     }
 }

--- a/fidget-raster/src/voxel.rs
+++ b/fidget-raster/src/voxel.rs
@@ -597,9 +597,7 @@ mod test {
             panic!("expected error")
         };
         let var = ctx.get_var(v).unwrap();
-        let Var::V(i) = var else {
-            panic!("expected Var::V")
-        };
+        let i = var.index().expect("expected Var::V");
         assert_eq!(
             out,
             RenderError::MissingVar(fidget_core::shape::MissingVar { var: i })

--- a/fidget-raster/src/voxel.rs
+++ b/fidget-raster/src/voxel.rs
@@ -467,17 +467,14 @@ impl<F: Function> Worker<'_, F> {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-/// Renders the given tape into a 3D image according to the provided
+/// Renders the given shape into a 3D image with a particular configuration
 /// configuration.
 ///
-/// The tape provides the shape; the configuration supplies resolution,
-/// transforms, etc.
+/// The shape provides the evaluator backend (`F`) and bound variables; the
+/// configuration supplies resolution, transforms, etc.
 ///
-/// This function is parameterized by shape type, which determines how we
-/// perform evaluation.
-///
-/// Returns [`Ok(Some(Image))`](Image) of pixel data on success, `Ok(None)` if
-/// the render was cancelled, or an error.
+/// Returns [`Some(Image)`](Image) of pixel data on success, or `None` if
+/// the render was cancelled.
 pub fn render<F: Function + RenderHints>(
     b: BoundShape<F, f32>,
     config: &RenderConfig,

--- a/fidget/benches/mesh.rs
+++ b/fidget/benches/mesh.rs
@@ -5,9 +5,15 @@ const COLONNADE: &str = include_str!("../../models/colonnade.vm");
 
 pub fn colonnade_octree_thread_sweep(c: &mut Criterion) {
     let (ctx, root) = fidget::Context::from_text(COLONNADE.as_bytes()).unwrap();
-    let shape_vm = &fidget::vm::VmShape::new(&ctx, root).unwrap();
+    let shape_vm = &fidget::vm::VmShape::new(&ctx, root)
+        .unwrap()
+        .try_into()
+        .unwrap();
     #[cfg(feature = "jit")]
-    let shape_jit = &fidget::jit::JitShape::new(&ctx, root).unwrap();
+    let shape_jit = &fidget::jit::JitShape::new(&ctx, root)
+        .unwrap()
+        .try_into()
+        .unwrap();
 
     let mut group =
         c.benchmark_group("speed vs threads (colonnade, octree) (depth 6)");
@@ -40,7 +46,10 @@ pub fn colonnade_octree_thread_sweep(c: &mut Criterion) {
 
 pub fn colonnade_mesh(c: &mut Criterion) {
     let (ctx, root) = fidget::Context::from_text(COLONNADE.as_bytes()).unwrap();
-    let shape_vm = &fidget::vm::VmShape::new(&ctx, root).unwrap();
+    let shape_vm = &fidget::vm::VmShape::new(&ctx, root)
+        .unwrap()
+        .try_into()
+        .unwrap();
     let cfg = fidget::mesh::Settings {
         depth: 8,
         ..Default::default()

--- a/fidget/benches/render.rs
+++ b/fidget/benches/render.rs
@@ -1,15 +1,22 @@
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use fidget::render::{ImageSize, ThreadPool};
+use fidget::{
+    render::{ImageSize, ThreadPool},
+    shape::BoundShape,
+};
 use std::hint::black_box;
 
 const PROSPERO: &str = include_str!("../../models/prospero.vm");
 
 pub fn prospero_size_sweep(c: &mut Criterion) {
     let (ctx, root) = fidget::Context::from_text(PROSPERO.as_bytes()).unwrap();
-    let shape_vm = &fidget::vm::VmShape::new(&ctx, root).unwrap();
+    let shape_vm =
+        &BoundShape::try_from(fidget::vm::VmShape::new(&ctx, root).unwrap())
+            .unwrap();
 
     #[cfg(feature = "jit")]
-    let shape_jit = &fidget::jit::JitShape::new(&ctx, root).unwrap();
+    let shape_jit =
+        &BoundShape::try_from(fidget::jit::JitShape::new(&ctx, root).unwrap())
+            .unwrap();
 
     let mut group =
         c.benchmark_group("speed vs image size (prospero, 2d) (8 threads)");
@@ -43,10 +50,14 @@ pub fn prospero_size_sweep(c: &mut Criterion) {
 
 pub fn prospero_thread_sweep(c: &mut Criterion) {
     let (ctx, root) = fidget::Context::from_text(PROSPERO.as_bytes()).unwrap();
-    let shape_vm = &fidget::vm::VmShape::new(&ctx, root).unwrap();
+    let shape_vm =
+        &BoundShape::try_from(fidget::vm::VmShape::new(&ctx, root).unwrap())
+            .unwrap();
 
     #[cfg(feature = "jit")]
-    let shape_jit = &fidget::jit::JitShape::new(&ctx, root).unwrap();
+    let shape_jit =
+        &BoundShape::try_from(fidget::jit::JitShape::new(&ctx, root).unwrap())
+            .unwrap();
 
     let mut group =
         c.benchmark_group("speed vs threads (prospero, 2d) (1024 x 1024)");

--- a/fidget/src/lib.rs
+++ b/fidget/src/lib.rs
@@ -220,9 +220,9 @@
 //!     ..Default::default()
 //! };
 //! let shape = VmShape::from(tree);
+//! let bound_shape = shape.try_into().expect("shape has no vars");
 //! let out = cfg
-//!     .run(shape)
-//!     .expect("render should succeed")
+//!     .run(bound_shape)
 //!     .expect("render is not cancelled");
 //! let mut iter = out.iter();
 //! for y in 0..cfg.image_size.height() {

--- a/fidget/tests/octree.rs
+++ b/fidget/tests/octree.rs
@@ -11,7 +11,7 @@ fn test_octree_camera() {
     let sphere = ((x - 1.0).square() + (y - 1.0).square() + (z - 1.0).square())
         .sqrt()
         - 0.25;
-    let shape = VmShape::from(sphere);
+    let shape = VmShape::from(sphere).try_into().unwrap();
 
     let center = Vector3::new(1.0, 1.0, 1.0);
     let settings = Settings {

--- a/fidget/tests/pixel_render.rs
+++ b/fidget/tests/pixel_render.rs
@@ -43,9 +43,9 @@ impl Cfg {
             world_to_model: world_to_model * self.view.world_to_model(),
             ..Default::default()
         };
+        let bound_shape = shape.bind(&self.vars).expect("all vars present");
         let out = cfg
-            .run_with_vars(shape, &self.vars)
-            .expect("rendering should not fail")
+            .run(bound_shape)
             .expect("rendering should not be cancelled");
         let mut img_str = String::new();
         for (i, b) in out.iter().enumerate() {
@@ -372,7 +372,7 @@ fn check_circle_var<F: Function + MathFunction + RenderHints>() {
 fn check_neg_infinity<F: Function + MathFunction + RenderHints>() {
     let mut ctx = Context::new();
     let root = ctx.constant(-f64::INFINITY);
-    let shape = Shape::<F>::new(&ctx, root).unwrap();
+    let shape = Shape::<F>::new(&ctx, root).unwrap().try_into().unwrap();
 
     let cfg = RenderConfig {
         image_size: RenderSize::new(256, 256),
@@ -380,10 +380,7 @@ fn check_neg_infinity<F: Function + MathFunction + RenderHints>() {
         threads: None,
         ..Default::default()
     };
-    let out = cfg
-        .run(shape)
-        .expect("rendering should not fail")
-        .expect("rendering should not be cancelled");
+    let out = cfg.run(shape).expect("rendering should not be cancelled");
     assert!(out.into_iter().all(|i| i.inside()));
 }
 

--- a/fidget/tests/voxel_render.rs
+++ b/fidget/tests/voxel_render.rs
@@ -32,7 +32,7 @@ fn sphere_var<F: Function + MathFunction + RenderHints>() {
             let mut vars = ShapeVars::new();
             vars.insert(v.index().unwrap(), r);
             let image = cfg
-                .run_with_vars::<_>(shape.clone(), &vars)
+                .run::<_>(shape.bind(&vars).unwrap())
                 .expect("rendering should not fail")
                 .expect("rendering should not be cancelled");
 

--- a/fidget/tests/voxel_render.rs
+++ b/fidget/tests/voxel_render.rs
@@ -33,7 +33,6 @@ fn sphere_var<F: Function + MathFunction + RenderHints>() {
             vars.insert(v.index().unwrap(), r);
             let image = cfg
                 .run::<_>(shape.bind(&vars).unwrap())
-                .expect("rendering should not fail")
                 .expect("rendering should not be cancelled");
 
             check_sphere(image, size, scale, r);


### PR DESCRIPTION
This partially reverts #418 by adding a new `BoundShape<F>` type which combines a `Shape<F>` and a set of free variables.  Once a `BoundShape` is constructed, we know that it may be evaluated, because the fallible constructor checks that all variables are present.  This lets us remove error handling from meshing and render functions.

Note that I deliberately didn't make this change for the WebGPU module, because we want later binding (after the expensive `RenderShape` is constructed).