### PR TITLE
Add exemplary benchmarks for quick testing

### DIFF
--- a/fidget/Cargo.toml
+++ b/fidget/Cargo.toml
@@ -72,7 +72,11 @@ gui = ["dep:fidget-gui"]
 wgpu = ["dep:fidget-wgpu"]
 
 [[bench]]
-name = "render"
+name = "pixel"
+harness = false
+
+[[bench]]
+name = "voxel"
 harness = false
 
 [[bench]]

--- a/fidget/benches/mesh.rs
+++ b/fidget/benches/mesh.rs
@@ -63,5 +63,47 @@ pub fn colonnade_mesh(c: &mut Criterion) {
         });
 }
 
-criterion_group!(benches, colonnade_octree_thread_sweep, colonnade_mesh);
+pub fn colonnade_mesh_exemplary(c: &mut Criterion) {
+    let (ctx, root) = fidget::Context::from_text(COLONNADE.as_bytes()).unwrap();
+    let shape_vm = &fidget::vm::VmShape::new(&ctx, root)
+        .unwrap()
+        .try_into()
+        .unwrap();
+    let cfg = fidget::mesh::Settings {
+        depth: 8,
+        ..Default::default()
+    };
+    let cfg_ref = &cfg;
+
+    let mut group = c.benchmark_group("colonnade-mesh-exemplary");
+    group.bench_function("vm", move |b| {
+        b.iter(|| {
+            let octree =
+                &fidget::mesh::Octree::build(shape_vm, cfg_ref).unwrap();
+            black_box(octree.walk_dual())
+        })
+    });
+
+    #[cfg(feature = "jit")]
+    {
+        let shape_jit = &fidget::jit::JitShape::new(&ctx, root)
+            .unwrap()
+            .try_into()
+            .unwrap();
+        group.bench_function("jit", move |b| {
+            b.iter(|| {
+                let octree =
+                    &fidget::mesh::Octree::build(shape_jit, cfg_ref).unwrap();
+                black_box(octree.walk_dual())
+            })
+        });
+    }
+}
+
+criterion_group!(
+    benches,
+    colonnade_octree_thread_sweep,
+    colonnade_mesh,
+    colonnade_mesh_exemplary
+);
 criterion_main!(benches);

--- a/fidget/benches/pixel.rs
+++ b/fidget/benches/pixel.rs
@@ -7,6 +7,39 @@ use std::hint::black_box;
 
 const PROSPERO: &str = include_str!("../../models/prospero.vm");
 
+pub fn prospero_exemplary(c: &mut Criterion) {
+    let (ctx, root) = fidget::Context::from_text(PROSPERO.as_bytes()).unwrap();
+    let shape_vm =
+        &BoundShape::try_from(fidget::vm::VmShape::new(&ctx, root).unwrap())
+            .unwrap();
+
+    let mut group = c.benchmark_group("prospero-exemplary");
+    let cfg = &fidget::raster::pixel::RenderConfig {
+        image_size: fidget::render::ImageSize::from(1024),
+        ..Default::default()
+    };
+    group.bench_function("vm", move |b| {
+        b.iter(|| {
+            let tape = shape_vm.clone();
+            black_box(cfg.run(tape))
+        })
+    });
+
+    #[cfg(feature = "jit")]
+    {
+        let shape_jit = &BoundShape::try_from(
+            fidget::jit::JitShape::new(&ctx, root).unwrap(),
+        )
+        .unwrap();
+        group.bench_function("jit", move |b| {
+            b.iter(|| {
+                let tape = shape_jit.clone();
+                black_box(cfg.run(tape))
+            })
+        });
+    }
+}
+
 pub fn prospero_size_sweep(c: &mut Criterion) {
     let (ctx, root) = fidget::Context::from_text(PROSPERO.as_bytes()).unwrap();
     let shape_vm =
@@ -104,5 +137,10 @@ pub fn prospero_thread_sweep(c: &mut Criterion) {
     }
 }
 
-criterion_group!(benches, prospero_size_sweep, prospero_thread_sweep);
+criterion_group!(
+    benches,
+    prospero_size_sweep,
+    prospero_thread_sweep,
+    prospero_exemplary,
+);
 criterion_main!(benches);

--- a/fidget/benches/voxel.rs
+++ b/fidget/benches/voxel.rs
@@ -1,0 +1,57 @@
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
+
+const COLONNADE: &str = include_str!("../../models/colonnade.vm");
+
+pub fn colonnade_voxel_exemplary(c: &mut Criterion) {
+    let (ctx, root) = fidget::Context::from_text(COLONNADE.as_bytes()).unwrap();
+    let vars = Default::default();
+    let shape_vm = &fidget::vm::VmShape::new(&ctx, root).unwrap();
+    let shape_vm = shape_vm.bind(&vars).unwrap();
+
+    let mut group = c.benchmark_group("colonnade-voxel-exemplary");
+
+    // Pick the standard scale / pitch / roll to generate a nice image
+    let s = 1.0 / 0.7;
+    let scale = nalgebra::Scale3::new(s, s, s);
+    let pitch = nalgebra::Rotation3::new(
+        nalgebra::Vector3::x() * 60.0 * std::f32::consts::PI / 180.0,
+    );
+    let roll = nalgebra::Rotation3::new(
+        nalgebra::Vector3::z() * 30.0 * std::f32::consts::PI / 180.0,
+    );
+    let perspective = 0.3;
+    let mut camera = nalgebra::Transform3::identity();
+    *camera.matrix_mut().get_mut((3, 2)).unwrap() = perspective;
+    let t = roll.to_homogeneous()
+        * pitch.to_homogeneous()
+        * scale.to_homogeneous()
+        * camera.to_homogeneous();
+
+    let cfg = &fidget::raster::voxel::RenderConfig {
+        world_to_model: t,
+        image_size: fidget::render::VoxelSize::from(1024),
+        ..Default::default()
+    };
+    group.bench_function("vm", move |b| {
+        b.iter(|| {
+            let tape = shape_vm.clone();
+            black_box(cfg.run(tape))
+        })
+    });
+
+    #[cfg(feature = "jit")]
+    {
+        let shape_jit = fidget::jit::JitShape::new(&ctx, root).unwrap();
+        let shape_jit = shape_jit.bind(&vars).unwrap();
+        group.bench_function("jit", move |b| {
+            b.iter(|| {
+                let tape = shape_jit.clone();
+                black_box(cfg.run(tape))
+            })
+        });
+    }
+}
+
+criterion_group!(benches, colonnade_voxel_exemplary);
+criterion_main!(benches);


### PR DESCRIPTION
Running a full benchmark suite is slow, because it does a sweep across threads and image sizes.  This PR adds "exemplary" benchmarks for quick checks of our three main pathways (meshing, 2D rendering, and 3D rendering).