### PR TITLE
Bump `actions/cache` version

### DIFF
--- a/.github/actions/rust-cache/action.yml
+++ b/.github/actions/rust-cache/action.yml
@@ -11,7 +11,7 @@ runs:
     - name: Update rustup
       run: rustup update
       shell: bash
-    - uses: actions/cache@v4
+    - uses: actions/cache@v6
       with:
         path: |
           ~/.cargo/bin/


### PR DESCRIPTION
This fixes warnings about Node 20 being deprecated