### PR TITLE
Improve denoising

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 - Rename `trait ImageSizeLike` to `trait RenderSize` in `fidget_raster`; remove
   `width` and `height` from `trait RenderConfig` and add a `RenderConfig:
   RenderSize` bound
+- Improve denoising pass: back-facing normals are now removed from candidates
 
 # 0.4.3
 - Fixed bug in x86 interval `OR` function ([#395](https://github.com/mkeeter/fidget/pull/395)),

--- a/fidget-raster/src/effects.rs
+++ b/fidget-raster/src/effects.rs
@@ -258,7 +258,7 @@ fn denoise_pixel(
                     && (ty as usize) < image.height()
                 {
                     let pos = (ty as usize, tx as usize);
-                    if image[pos].depth != 0.0 {
+                    if image[pos].depth != 0.0 && image[pos].normal[2] > 0.0 {
                         let n = image[pos].normal;
                         sum += Vector3::new(n[0], n[1], n[2]);
                         count += 1;


### PR DESCRIPTION
Back-facing normals should not be included when picking candidates for denoising

Before:
<img width="651" height="614" alt="Screenshot 2026-07-24 at 9 42 49 AM" src="https://github.com/user-attachments/assets/c4f9f93b-f265-4352-8d41-56da1fc8d4a1" />

After:
<img width="510" height="482" alt="Screenshot 2026-07-24 at 9 42 34 AM" src="https://github.com/user-attachments/assets/1380a401-de62-471d-866c-f629606e5145" />
