### PR TITLE
Switch depth back to `u32` in `GeometryPixel`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@
   `width` and `height` from `trait RenderConfig` and add a `RenderConfig:
   RenderSize` bound
 - Improve denoising pass: back-facing normals are now removed from candidates
+- Switched `GeometryPixel` back to having a `u32` for depth; we are planning to
+  move more post-processing to the GPU, so it's helpful to keep pixels lossless
+  for as long as possible.
 
 # 0.4.3
 - Fixed bug in x86 interval `OR` function ([#395](https://github.com/mkeeter/fidget/pull/395)),

--- a/demos/cli/src/main.rs
+++ b/demos/cli/src/main.rs
@@ -347,7 +347,7 @@ fn postprocess3d(
             image
                 .into_iter()
                 .flat_map(|p| {
-                    if p.depth > 0.0 {
+                    if p.depth > 0 {
                         let c = p.to_color();
                         [c[0], c[1], c[2], 255]
                     } else {
@@ -368,7 +368,7 @@ fn postprocess3d(
                 .into_iter()
                 .zip(color)
                 .flat_map(|(p, c)| {
-                    if p.depth > 0.0 {
+                    if p.depth > 0 {
                         [c[0], c[1], c[2], 255]
                     } else {
                         [0, 0, 0, 0]
@@ -415,17 +415,12 @@ fn postprocess3d(
                 .collect()
         }
         RenderMode3D::Heightmap => {
-            let z_max = image
-                .iter()
-                .map(|p| ordered_float::OrderedFloat(p.depth))
-                .max()
-                .map(|p| p.0)
-                .unwrap_or(1.0);
+            let z_max = image.iter().map(|p| p.depth).max().unwrap_or(1);
             image
                 .into_iter()
                 .flat_map(|p| {
-                    if p.depth > 0.0 {
-                        let z = (p.depth * 255.0 / z_max).round() as u8;
+                    if p.depth > 0 {
+                        let z = (p.depth * 255 / z_max) as u8;
                         [z, z, z, 255]
                     } else {
                         [0, 0, 0, 0]

--- a/demos/cli/src/main.rs
+++ b/demos/cli/src/main.rs
@@ -415,12 +415,13 @@ fn postprocess3d(
                 .collect()
         }
         RenderMode3D::Heightmap => {
-            let z_max = image.iter().map(|p| p.depth).max().unwrap_or(1);
+            let z_max =
+                u64::from(image.iter().map(|p| p.depth).max().unwrap_or(1));
             image
                 .into_iter()
                 .flat_map(|p| {
                     if p.depth > 0 {
-                        let z = (p.depth * 255 / z_max) as u8;
+                        let z = (u64::from(p.depth) * 255 / z_max) as u8;
                         [z, z, z, 255]
                     } else {
                         [0, 0, 0, 0]

--- a/demos/viewer/src/draw3d.rs
+++ b/demos/viewer/src/draw3d.rs
@@ -3,8 +3,7 @@ use eframe::{
     egui,
     egui_wgpu::{self, wgpu},
 };
-use fidget::raster::voxel::GeometryPixel;
-use zerocopy::{Immutable, IntoBytes};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 /// Configuration for 3D rendering with geometry data
 #[repr(C)]
@@ -167,7 +166,7 @@ impl Resources {
         &mut self,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
-        images: &[Vec<GeometryPixel>],
+        images: &[Vec<FloatPixel>],
         image_size: fidget::render::ImageSize,
         mode: Mode3D,
         max_depth: u32,
@@ -276,7 +275,7 @@ impl Resources {
                 image_data.as_bytes(),
                 wgpu::TexelCopyBufferLayout {
                     offset: 0,
-                    bytes_per_row: Some(16 * width), // 16 bytes per GeometryPixel (4 u32 values)
+                    bytes_per_row: Some(16 * width), // 16 bytes per FloatPixel (4 f32 values)
                     rows_per_image: Some(height),
                 },
                 texture_size,
@@ -298,16 +297,23 @@ impl Resources {
     }
 }
 
+/// Helper type representing a `GeometryPixel` with a floating-point depth
+#[derive(Copy, Clone, FromBytes, IntoBytes, KnownLayout, Immutable)]
+pub(crate) struct FloatPixel {
+    pub depth: f32,
+    pub normal: [f32; 3],
+}
+
 /// GPU callback to render 3D images in a particular mode
 pub(crate) struct Draw3D {
-    data: Option<(Vec<Vec<GeometryPixel>>, fidget::render::ImageSize)>,
+    data: Option<(Vec<Vec<FloatPixel>>, fidget::render::ImageSize)>,
     mode: Mode3D,
     max_depth: u32,
 }
 
 impl Draw3D {
     pub fn new(
-        data: Option<(Vec<Vec<GeometryPixel>>, fidget::render::ImageSize)>,
+        data: Option<(Vec<Vec<FloatPixel>>, fidget::render::ImageSize)>,
         mode: Mode3D,
         max_depth: u32,
     ) -> Self {

--- a/demos/viewer/src/draw3d.rs
+++ b/demos/viewer/src/draw3d.rs
@@ -298,6 +298,7 @@ impl Resources {
 }
 
 /// Helper type representing a `GeometryPixel` with a floating-point depth
+#[repr(C)]
 #[derive(Copy, Clone, FromBytes, IntoBytes, KnownLayout, Immutable)]
 pub(crate) struct FloatPixel {
     pub depth: f32,

--- a/demos/viewer/src/main.rs
+++ b/demos/viewer/src/main.rs
@@ -14,7 +14,7 @@ use fidget::{
     gui::{Canvas2, Canvas3, CursorState, DragMode, View2, View3},
     raster::{
         pixel::RenderConfig as ImageRenderConfig,
-        voxel::{GeometryPixel, RenderConfig as VoxelRenderConfig},
+        voxel::RenderConfig as VoxelRenderConfig,
     },
 };
 
@@ -41,7 +41,7 @@ struct RenderSettings {
 enum ImageData {
     Rgba(Vec<Vec<[u8; 4]>>),
     Geometry {
-        images: Vec<Vec<GeometryPixel>>,
+        images: Vec<Vec<draw3d::FloatPixel>>,
         mode: Mode3D,
         max_depth: u32,
     },
@@ -208,7 +208,7 @@ fn render_3d<F: fidget::eval::Function + fidget::render::RenderHints>(
     view: View3,
     shape: fidget::shape::Shape<F>,
     image_size: fidget::render::VoxelSize,
-) -> Vec<GeometryPixel> {
+) -> Vec<draw3d::FloatPixel> {
     let config = VoxelRenderConfig {
         image_size,
         world_to_model: view.world_to_model(),
@@ -221,10 +221,16 @@ fn render_3d<F: fidget::eval::Function + fidget::render::RenderHints>(
         .run(bound_shape)
         .expect("rendering should not be cancelled");
 
-    // For both rendering modes, we'll just pass the GeometryPixel data
-    // to the GPU, which will apply the appropriate rendering effect
+    // For both rendering modes, we'll convert the GeometryPixel data into
+    // FloatPixels then pass them to the GPU, which will apply the appropriate
+    // rendering effect
     let (data, _) = geometry_buffer.take();
-    data
+    data.into_iter()
+        .map(|p| draw3d::FloatPixel {
+            depth: p.depth as f32,
+            normal: p.normal,
+        })
+        .collect()
 }
 
 fn main() -> Result<(), Box<dyn Error>> {

--- a/demos/viewer/src/shaders/geometry.wgsl
+++ b/demos/viewer/src/shaders/geometry.wgsl
@@ -37,8 +37,8 @@ fn vs_main(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
 }
 
 struct GeometryPixel {
-    depth: u32,
     normal: vec3<f32>,
+    depth: u32,
 }
 
 struct Light {

--- a/demos/viewer/src/shaders/geometry.wgsl
+++ b/demos/viewer/src/shaders/geometry.wgsl
@@ -36,11 +36,6 @@ fn vs_main(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
     return output;
 }
 
-struct GeometryPixel {
-    normal: vec3<f32>,
-    depth: u32,
-}
-
 struct Light {
     position: vec3<f32>,
     intensity: f32,

--- a/demos/web-editor/crate/src/lib.rs
+++ b/demos/web-editor/crate/src/lib.rs
@@ -113,7 +113,7 @@ pub fn render_normals(
     Ok(image
         .into_iter()
         .flat_map(|p| {
-            let [r, g, b] = if p.depth > 0.0 { p.to_color() } else { [0; 3] };
+            let [r, g, b] = if p.depth > 0 { p.to_color() } else { [0; 3] };
             [r, g, b, 255]
         })
         .collect())

--- a/fidget-raster/src/effects.rs
+++ b/fidget-raster/src/effects.rs
@@ -23,7 +23,7 @@ pub fn denoise_normals(
     out.apply_effect(
         |x, y| {
             let depth = image[(y, x)].depth;
-            let normal = if depth > 0.0 {
+            let normal = if depth > 0 {
                 denoise_pixel(image, x, y, radius)
             } else {
                 [0.0; 3]
@@ -55,7 +55,7 @@ pub fn apply_shading(
     let mut out = ColorImage::new(ImageSize::new(size.width(), size.height()));
     out.apply_effect(
         |x, y| {
-            if image[(y, x)].depth > 0.0 {
+            if image[(y, x)].depth > 0 {
                 shade_pixel(image, ssao.as_ref(), x, y)
             } else {
                 [0u8; 3]
@@ -82,7 +82,7 @@ pub fn compute_ssao(
         Image::<f32>::new(ImageSize::new(size.width(), size.height()));
     out.apply_effect(
         |x, y| {
-            if image[(y, x)].depth > 0.0 {
+            if image[(y, x)].depth > 0 {
                 compute_pixel_ssao(image, x, y, &ssao_kernel, &ssao_noise)
             } else {
                 f32::NAN
@@ -128,7 +128,7 @@ fn shade_pixel(
     let p = Vector3::new(
         2.0 * (x as f32 / image.width() as f32 - 0.5),
         2.0 * (y as f32 / image.height() as f32 - 0.5),
-        2.0 * (image[(y, x)].depth / image.depth() as f32 - 0.5),
+        2.0 * (image[(y, x)].depth as f32 / image.depth() as f32 - 0.5),
     );
 
     let lights = [
@@ -167,7 +167,7 @@ fn compute_pixel_ssao(
         depth: d,
     } = image[pos];
 
-    if d == 0.0 {
+    if d == 0 {
         return f32::NAN;
     }
 
@@ -175,7 +175,7 @@ fn compute_pixel_ssao(
     let p = Vector3::new(
         (((x as f32) / image.width() as f32) - 0.5) * 2.0,
         (((y as f32) / image.height() as f32) - 0.5) * 2.0,
-        ((d / image.depth() as f32) - 0.5) * 2.0,
+        ((d as f32 / image.depth() as f32) - 0.5) * 2.0,
     );
 
     // Get normal from the image
@@ -210,10 +210,10 @@ fn compute_pixel_ssao(
         {
             image[(py as usize, px as usize)].depth
         } else {
-            0.0
+            0
         };
 
-        let actual_z = ((actual_h / image.depth() as f32) - 0.5) * 2.0;
+        let actual_z = ((actual_h as f32 / image.depth() as f32) - 0.5) * 2.0;
 
         let dz = sample_pos.z - actual_z;
         if dz < RADIUS {
@@ -258,7 +258,7 @@ fn denoise_pixel(
                     && (ty as usize) < image.height()
                 {
                     let pos = (ty as usize, tx as usize);
-                    if image[pos].depth != 0.0 && image[pos].normal[2] > 0.0 {
+                    if image[pos].depth != 0 && image[pos].normal[2] > 0.0 {
                         let n = image[pos].normal;
                         sum += Vector3::new(n[0], n[1], n[2]);
                         count += 1;
@@ -281,7 +281,7 @@ fn denoise_pixel(
                     && (ty as usize) < image.height()
                 {
                     let pos = (ty as usize, tx as usize);
-                    if image[pos].depth != 0.0 {
+                    if image[pos].depth != 0 {
                         let n = image[pos].normal;
                         score += Vector3::new(n[0], n[1], n[2]).dot(&mean);
                     }

--- a/fidget-raster/src/voxel.rs
+++ b/fidget-raster/src/voxel.rs
@@ -112,7 +112,7 @@ pub struct GeometryPixel {
     ///
     /// The fractional component is always zero. Empty pixels always have a
     /// depth of 0.
-    pub depth: f32,
+    pub depth: u32,
     /// Function gradients at this pixel
     pub normal: [f32; 3],
 }
@@ -264,7 +264,7 @@ impl<F: Function> Worker<'_, F> {
     ) -> bool {
         // Early exit if every single pixel is filled
         let tile_size = self.tile_sizes[depth];
-        let fill_z = (tile.corner[2] + tile_size + 1) as f32;
+        let fill_z = (tile.corner[2] + tile_size + 1).try_into().unwrap();
         if (0..tile_size).all(|y| {
             let i = self.tile_row_offset(tile, y);
             (0..tile_size).all(|x| self.out[i + x].depth >= fill_z)
@@ -359,7 +359,7 @@ impl<F: Function> Worker<'_, F> {
             let o = self.tile_sizes.pixel_offset(tile.add(Vector2::new(i, j)));
 
             // Skip pixels which are behind the image
-            let zmax = (tile.corner[2] + tile_size) as f32;
+            let zmax = (tile.corner[2] + tile_size).try_into().unwrap();
             if self.out[o].depth >= zmax {
                 continue;
             }
@@ -424,7 +424,7 @@ impl<F: Function> Worker<'_, F> {
 
             // Set the depth of the pixel
             let o = self.tile_sizes.pixel_offset(tile.add(Vector2::new(i, j)));
-            let z = (tile.corner[2] + k + 1) as f32;
+            let z = (tile.corner[2] + k + 1).try_into().unwrap();
             assert!(self.out[o].depth < z);
             self.out[o].depth = z;
 
@@ -508,10 +508,10 @@ pub fn render<F: Function + RenderHints>(
                     let o = y * width + x;
                     if out[index].depth >= image[o].depth {
                         // Clamp voxels to the image depth
-                        let d = (config.image_size.depth() - 1) as f32;
+                        let d = config.image_size.depth() - 1;
                         if out[index].depth >= d {
                             image[o] = GeometryPixel {
-                                depth: d + 1.0,
+                                depth: d + 1,
                                 normal: [0.0, 0.0, 1.0],
                             };
                         } else {

--- a/fidget-raster/src/voxel.rs
+++ b/fidget-raster/src/voxel.rs
@@ -102,19 +102,23 @@ impl RenderConfig<'_> {
 
 /// Pixel type for a [`voxel::Image`](Image)
 ///
-/// This type can be passed directly in a buffer to the GPU.
+/// This type can be passed directly in a buffer to the GPU.  However, it is
+/// **unwise** to load it as a GPU texture: because it mixes `f32` and `u32`,
+/// there's not a reasonable interpolation mode.  Putting the whole thing into
+/// an `f32x4` texture is especially unwise: bitcasting a small `u32` depth to a
+/// `f32` produces a denormalized float, which some GPUs will flush to `0.0`.
 #[repr(C)]
 #[derive(
     Debug, Default, Copy, Clone, IntoBytes, FromBytes, Immutable, PartialEq,
 )]
 pub struct GeometryPixel {
+    /// Function gradients at this pixel
+    pub normal: [f32; 3],
     /// Z position of this pixel, in voxel units
     ///
     /// The fractional component is always zero. Empty pixels always have a
     /// depth of 0.
     pub depth: u32,
-    /// Function gradients at this pixel
-    pub normal: [f32; 3],
 }
 
 impl GeometryPixel {

--- a/fidget-raster/src/voxel.rs
+++ b/fidget-raster/src/voxel.rs
@@ -105,8 +105,9 @@ impl RenderConfig<'_> {
 /// This type can be passed directly in a buffer to the GPU.  However, it is
 /// **unwise** to load it as a GPU texture: because it mixes `f32` and `u32`,
 /// there's not a reasonable interpolation mode.  Putting the whole thing into
-/// an `f32x4` texture is especially unwise: bitcasting a small `u32` depth to a
-/// `f32` produces a denormalized float, which some GPUs will flush to `0.0`.
+/// an `f32x4` texture is **especially unwise**: bitcasting a small `u32` depth
+/// to a `f32` produces a denormalized float, which some GPUs will flush to
+/// `0.0` (surprise!).
 #[repr(C)]
 #[derive(
     Debug, Default, Copy, Clone, IntoBytes, FromBytes, Immutable, PartialEq,

--- a/fidget-wgpu/src/shaders/common.wgsl
+++ b/fidget-wgpu/src/shaders/common.wgsl
@@ -50,6 +50,11 @@ struct TileListInput {
     active_tiles: array<u32>,
 }
 
+struct GeometryPixel {
+    normal: vec3f,
+    depth: u32,
+}
+
 fn nan_f32() -> f32 {
   // Workaround for https://github.com/gpuweb/gpuweb/issues/3749
   let bits = 0xffffffffu;

--- a/fidget-wgpu/src/shaders/normals.wgsl
+++ b/fidget-wgpu/src/shaders/normals.wgsl
@@ -1,5 +1,5 @@
 @group(2) @binding(0) var<storage, read> image_heightmap: array<u32>;
-@group(2) @binding(1) var<storage, read_write> image_out: array<vec4f>;
+@group(2) @binding(1) var<storage, read_write> image_out: array<GeometryPixel>;
 
 @compute @workgroup_size(8, 8)
 fn normals_main(
@@ -15,7 +15,7 @@ fn normals_main(
 
     // If we've already written this pixel, then return; because evaluation
     // happens in Z order, it will necessarily supersede the current pixel
-    if image_out[pixel_index_xy][0] != 0 {
+    if image_out[pixel_index_xy].depth != 0 {
         return;
     }
 
@@ -37,12 +37,7 @@ fn normals_main(
     let tape_start = get_tape_start(vec3u(px, py, z));
     var stack = Stack(); // dummy value
     let out = run_tape(tape_start, m, &stack);
-    image_out[pixel_index_xy] = vec4f(
-        f32(z),
-        out.value.v.x,
-        out.value.v.y,
-        out.value.v.z
-    );
+    image_out[pixel_index_xy] = GeometryPixel(out.value.v.xyz, z);
 }
 
 /// For a given voxel position, return the tape start index

--- a/fidget/tests/voxel_render.rs
+++ b/fidget/tests/voxel_render.rs
@@ -48,7 +48,7 @@ fn check_sphere(image: Image, size: u32, scale: f32, r: f32) {
     let m = RenderSize::from(size).screen_to_world();
     for (i, p) in image.iter().enumerate() {
         let p = p.depth;
-        if p == size as f32 {
+        if p == size {
             // Skip saturated voxels
             continue;
         }
@@ -56,9 +56,9 @@ fn check_sphere(image: Image, size: u32, scale: f32, r: f32) {
         let i = i as i32;
         let x = (i % size) as f32;
         let y = (i / size) as f32;
-        let z = p;
+        let z = p as f32;
         let pos = m.transform_point(&nalgebra::Point3::new(x, y, z)) * scale;
-        if p == 0.0 {
+        if p == 0 {
             let v = (pos.x.powi(2) + pos.y.powi(2)).sqrt();
             assert!(
                 v + epsilon > r,


### PR DESCRIPTION
This reverts #381;  I'm working on more complex GPU-based pipelines, so directly casting the `GeometryPixel` buffer into a texture is less valuable.