### PR TITLE
Remove Default from RenderConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,10 @@
     - Transposed `ssao_kernel` and `ssao_noise` matrices so that they can be
       directly uploaded to the GPU as `array<array<f32, 3>>` and `array<vec2f>`
       buffers respectively
+- Remove `Default` from `fidget_raster::{voxel, pixel}::RenderConfig`, because
+  baking in a size is a questionable API choice.  Added
+  `RenderConfig::from_size` as a replacement, which can similarly be used as a
+  base for constructing a semi-custom instance.
 
 # 0.4.3
 - Fixed bug in x86 interval `OR` function ([#395](https://github.com/mkeeter/fidget/pull/395)),

--- a/demos/cli/src/main.rs
+++ b/demos/cli/src/main.rs
@@ -318,10 +318,11 @@ fn run3d<F: fidget::eval::Function + fidget::render::RenderHints>(
     threads: Option<&fidget::render::ThreadPool>,
 ) -> fidget::raster::voxel::Image {
     let cfg = fidget::raster::voxel::RenderConfig {
-        image_size: settings.voxel_size(depth),
         threads,
         world_to_model,
-        ..Default::default()
+        ..fidget::raster::voxel::RenderConfig::from_size(
+            settings.voxel_size(depth),
+        )
     };
 
     let mut image = Default::default();
@@ -588,11 +589,10 @@ fn run2d<F: fidget::eval::Function + fidget::render::RenderHints>(
             None => Some(fidget::render::ThreadPool::Global),
         };
         let cfg = fidget::raster::pixel::RenderConfig {
-            image_size: size,
             threads: threads.as_ref(),
             pixel_perfect: matches!(mode, RenderMode2D::Sdf),
             world_to_model,
-            ..Default::default()
+            ..fidget::raster::pixel::RenderConfig::from_size(size)
         };
         let mut image = fidget::raster::Image::default();
         for _ in 0..settings.n {

--- a/demos/viewer/src/main.rs
+++ b/demos/viewer/src/main.rs
@@ -176,10 +176,9 @@ fn render_2d<F: fidget::eval::Function + fidget::render::RenderHints>(
     color: [u8; 3],
 ) -> Vec<[u8; 4]> {
     let config = ImageRenderConfig {
-        image_size,
         world_to_model: view.world_to_model(),
         pixel_perfect: matches!(mode, Mode2D::Sdf),
-        ..Default::default()
+        ..ImageRenderConfig::from_size(image_size)
     };
 
     let bound_shape = shape.try_into().expect("no vars allowed");
@@ -210,9 +209,8 @@ fn render_3d<F: fidget::eval::Function + fidget::render::RenderHints>(
     image_size: fidget::render::VoxelSize,
 ) -> Vec<draw3d::FloatPixel> {
     let config = VoxelRenderConfig {
-        image_size,
         world_to_model: view.world_to_model(),
-        ..Default::default()
+        ..VoxelRenderConfig::from_size(image_size)
     };
 
     // Get the geometry buffer from the voxel rendering process

--- a/fidget-raster/src/pixel.rs
+++ b/fidget-raster/src/pixel.rs
@@ -49,19 +49,6 @@ pub struct RenderConfig<'a> {
     pub cancel: CancelToken,
 }
 
-impl Default for RenderConfig<'_> {
-    fn default() -> Self {
-        Self {
-            image_size: RenderSize::from(512),
-            tile_sizes: None,
-            world_to_model: Matrix3::identity(),
-            pixel_perfect: false,
-            threads: Some(&ThreadPool::Global),
-            cancel: CancelToken::new(),
-        }
-    }
-}
-
 impl crate::RenderConfig for RenderConfig<'_> {
     fn threads(&self) -> Option<&ThreadPool> {
         self.threads
@@ -81,6 +68,33 @@ impl crate::RenderSize for RenderConfig<'_> {
 }
 
 impl RenderConfig<'_> {
+    /// Constructs a [`RenderConfig`] with reasonable defaults
+    ///
+    /// This config uses the global thread pool for rendering, has an identity
+    /// transform matrix, uses render hints to choose tile sizes, and is not
+    /// pixel-perfect.
+    ///
+    /// To build a somewhat-customized `RenderConfig`, it's typical to use this
+    /// as the base object, then replace individual fields:
+    ///
+    /// ```
+    /// # use fidget_raster::pixel::RenderConfig;
+    /// let cfg = RenderConfig {
+    ///     pixel_perfect: true, // override field
+    ///     ..RenderConfig::from_size(1024.into()) // base
+    /// };
+    /// ```
+    pub fn from_size(image_size: RenderSize) -> Self {
+        Self {
+            image_size,
+            tile_sizes: None,
+            world_to_model: Matrix3::identity(),
+            pixel_perfect: false,
+            threads: Some(&ThreadPool::Global),
+            cancel: CancelToken::new(),
+        }
+    }
+
     /// Render a shape in 2D using this configuration
     ///
     /// Returns [`Some(Image)`](Image) of pixel data on success, or `None`
@@ -477,10 +491,7 @@ mod test {
             .try_into()
             .expect("no vars");
 
-        let cfg = RenderConfig {
-            image_size: RenderSize::new(64, 64),
-            ..Default::default()
-        };
+        let cfg = RenderConfig::from_size(64.into());
         let cancel = cfg.cancel.clone();
         cancel.cancel();
         assert!(cfg.run(shape).is_none());
@@ -495,10 +506,7 @@ mod test {
         let s = ctx.sub(x, v).unwrap();
         let shape = VmShape::new(&ctx, s).unwrap();
 
-        let cfg = RenderConfig {
-            image_size: RenderSize::new(64, 64),
-            ..Default::default()
-        };
+        let cfg = RenderConfig::from_size(64.into());
         let mut vars = ShapeVars::new();
         let i = var.index().expect("expected Var::V");
         vars.insert(i, 1.0);
@@ -507,11 +515,8 @@ mod test {
     }
 
     #[test]
-    fn test_default_render_config() {
-        let config = RenderConfig {
-            image_size: RenderSize::from(512),
-            ..Default::default()
-        };
+    fn test_render_config_transforms() {
+        let config = RenderConfig::from_size(512.into());
         let mat = config.mat();
         assert_eq!(
             mat.transform_point(&Point2::new(0.0, -1.0)),
@@ -526,10 +531,7 @@ mod test {
             Point2::new(1.0, -1.0)
         );
 
-        let config = RenderConfig {
-            image_size: RenderSize::from(575),
-            ..Default::default()
-        };
+        let config = RenderConfig::from_size(575.into());
         let mat = config.mat();
         assert_eq!(
             mat.transform_point(&Point2::new(0.0, -1.0)),

--- a/fidget-raster/src/voxel.rs
+++ b/fidget-raster/src/voxel.rs
@@ -49,18 +49,6 @@ pub struct RenderConfig<'a> {
     pub cancel: CancelToken,
 }
 
-impl Default for RenderConfig<'_> {
-    fn default() -> Self {
-        Self {
-            image_size: RenderSize::from(512),
-            tile_sizes: None,
-            world_to_model: Matrix4::identity(),
-            threads: Some(&ThreadPool::Global),
-            cancel: CancelToken::new(),
-        }
-    }
-}
-
 impl crate::RenderConfig for RenderConfig<'_> {
     fn threads(&self) -> Option<&ThreadPool> {
         self.threads
@@ -80,6 +68,30 @@ impl crate::RenderSize for RenderConfig<'_> {
 }
 
 impl RenderConfig<'_> {
+    /// Constructs a [`RenderConfig`] with reasonable defaults
+    ///
+    /// This config uses the global thread pool for rendering, has an identity
+    /// transform matrix, and uses the render hints to choose tile sizes.
+    ///
+    /// To build a somewhat-customized `RenderConfig`, it's typical to use this
+    /// as the base object, then replace individual fields:
+    ///
+    /// ```
+    /// # use fidget_raster::voxel::RenderConfig;
+    /// let cfg = RenderConfig {
+    ///     threads: None, // override field
+    ///     ..RenderConfig::from_size(1024.into()) // base
+    /// };
+    /// ```
+    pub fn from_size(image_size: RenderSize) -> Self {
+        Self {
+            image_size,
+            tile_sizes: None,
+            world_to_model: Matrix4::identity(),
+            threads: Some(&ThreadPool::Global),
+            cancel: CancelToken::new(),
+        }
+    }
     /// Render a shape in 3D using this configuration
     ///
     /// In the resulting image, saturated pixels (i.e. pixels in the image which
@@ -543,10 +555,7 @@ mod test {
         let x = ctx.x();
         let shape = VmShape::new(&ctx, x).unwrap().try_into().unwrap();
 
-        let cfg = RenderConfig {
-            image_size: RenderSize::from(128), // very small!
-            ..Default::default()
-        };
+        let cfg = RenderConfig::from_size(128.into()); // very small
         let image = cfg.run(shape).expect("rendering should not be cancelled");
         assert_eq!(image.len(), 128 * 128);
     }
@@ -557,10 +566,7 @@ mod test {
         let x = ctx.x();
         let shape = VmShape::new(&ctx, x).unwrap().try_into().unwrap();
 
-        let cfg = RenderConfig {
-            image_size: RenderSize::new(64, 64, 64),
-            ..Default::default()
-        };
+        let cfg = RenderConfig::from_size(64.into());
         let cancel = cfg.cancel.clone();
         cancel.cancel();
         assert!(cfg.run::<_>(shape).is_none());
@@ -575,10 +581,7 @@ mod test {
         let s = ctx.sub(x, v).unwrap();
         let shape = VmShape::new(&ctx, s).unwrap();
 
-        let cfg = RenderConfig {
-            image_size: RenderSize::new(64, 64, 64),
-            ..Default::default()
-        };
+        let cfg = RenderConfig::from_size(64.into());
 
         let mut vars = ShapeVars::new();
         let i = var.index().expect("expected Var::V");

--- a/fidget/benches/pixel.rs
+++ b/fidget/benches/pixel.rs
@@ -1,8 +1,5 @@
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use fidget::{
-    render::{ImageSize, ThreadPool},
-    shape::BoundShape,
-};
+use fidget::{render::ThreadPool, shape::BoundShape};
 use std::hint::black_box;
 
 const PROSPERO: &str = include_str!("../../models/prospero.vm");
@@ -14,10 +11,7 @@ pub fn prospero_exemplary(c: &mut Criterion) {
             .unwrap();
 
     let mut group = c.benchmark_group("prospero-exemplary");
-    let cfg = &fidget::raster::pixel::RenderConfig {
-        image_size: fidget::render::ImageSize::from(1024),
-        ..Default::default()
-    };
+    let cfg = &fidget::raster::pixel::RenderConfig::from_size(1024.into());
     group.bench_function("vm", move |b| {
         b.iter(|| {
             let tape = shape_vm.clone();
@@ -54,10 +48,7 @@ pub fn prospero_size_sweep(c: &mut Criterion) {
     let mut group =
         c.benchmark_group("speed vs image size (prospero, 2d) (8 threads)");
     for size in [256, 512, 768, 1024, 1280, 1546, 1792, 2048] {
-        let cfg = &fidget::raster::pixel::RenderConfig {
-            image_size: fidget::render::ImageSize::from(size),
-            ..Default::default()
-        };
+        let cfg = &fidget::raster::pixel::RenderConfig::from_size(size.into());
         group.bench_function(BenchmarkId::new("vm", size), move |b| {
             b.iter(|| {
                 let tape = shape_vm.clone();
@@ -67,10 +58,8 @@ pub fn prospero_size_sweep(c: &mut Criterion) {
 
         #[cfg(feature = "jit")]
         {
-            let cfg = &fidget::raster::pixel::RenderConfig {
-                image_size: fidget::render::ImageSize::from(size),
-                ..Default::default()
-            };
+            let cfg =
+                &fidget::raster::pixel::RenderConfig::from_size(size.into());
             group.bench_function(BenchmarkId::new("jit", size), move |b| {
                 b.iter(|| {
                     let tape = shape_jit.clone();
@@ -110,9 +99,8 @@ pub fn prospero_thread_sweep(c: &mut Criterion) {
             Some(ThreadPool::Global) => "N".to_string(),
         };
         let cfg = &fidget::raster::pixel::RenderConfig {
-            image_size: ImageSize::from(1024),
             threads,
-            ..Default::default()
+            ..fidget::raster::pixel::RenderConfig::from_size(1024.into())
         };
         group.bench_function(BenchmarkId::new("vm", &name), move |b| {
             b.iter(|| {
@@ -123,9 +111,8 @@ pub fn prospero_thread_sweep(c: &mut Criterion) {
         #[cfg(feature = "jit")]
         {
             let cfg = &fidget::raster::pixel::RenderConfig {
-                image_size: ImageSize::from(1024),
                 threads,
-                ..Default::default()
+                ..fidget::raster::pixel::RenderConfig::from_size(1024.into())
             };
             group.bench_function(BenchmarkId::new("jit", &name), move |b| {
                 b.iter(|| {

--- a/fidget/benches/voxel.rs
+++ b/fidget/benches/voxel.rs
@@ -30,8 +30,7 @@ pub fn colonnade_voxel_exemplary(c: &mut Criterion) {
 
     let cfg = &fidget::raster::voxel::RenderConfig {
         world_to_model: t,
-        image_size: fidget::render::VoxelSize::from(1024),
-        ..Default::default()
+        ..fidget::raster::voxel::RenderConfig::from_size(1024.into())
     };
     group.bench_function("vm", move |b| {
         b.iter(|| {

--- a/fidget/src/lib.rs
+++ b/fidget/src/lib.rs
@@ -215,10 +215,7 @@
 //! let x = Tree::x();
 //! let y = Tree::y();
 //! let tree = (x.square() + y.square()).sqrt() - 1.0;
-//! let cfg = RenderConfig {
-//!     image_size: RenderSize::from(32),
-//!     ..Default::default()
-//! };
+//! let cfg = RenderConfig::from_size(RenderSize::from(32));
 //! let shape = VmShape::from(tree);
 //! let bound_shape = shape.try_into().expect("shape has no vars");
 //! let out = cfg

--- a/fidget/tests/pixel_render.rs
+++ b/fidget/tests/pixel_render.rs
@@ -39,9 +39,8 @@ impl Cfg {
     ) {
         let width = if self.wide { 64 } else { 32 };
         let cfg = RenderConfig {
-            image_size: RenderSize::new(width, 32),
             world_to_model: world_to_model * self.view.world_to_model(),
-            ..Default::default()
+            ..RenderConfig::from_size(RenderSize::new(width, 32))
         };
         let bound_shape = shape.bind(&self.vars).expect("all vars present");
         let out = cfg
@@ -375,10 +374,9 @@ fn check_neg_infinity<F: Function + MathFunction + RenderHints>() {
     let shape = Shape::<F>::new(&ctx, root).unwrap().try_into().unwrap();
 
     let cfg = RenderConfig {
-        image_size: RenderSize::new(256, 256),
         pixel_perfect: true,
         threads: None,
-        ..Default::default()
+        ..RenderConfig::from_size(256.into())
     };
     let out = cfg.run(shape).expect("rendering should not be cancelled");
     assert!(out.into_iter().all(|i| i.inside()));
@@ -429,13 +427,12 @@ render_tests!(jit, fidget::jit::JitFunction);
 #[test]
 fn test_camera_render_config() {
     let config = RenderConfig {
-        image_size: RenderSize::from(512),
         world_to_model: View2::from_center_and_scale(
             nalgebra::Vector2::new(0.5, 0.5),
             0.5,
         )
         .world_to_model(),
-        ..Default::default()
+        ..RenderConfig::from_size(512.into())
     };
     let mat = config.mat();
     assert_eq!(
@@ -452,13 +449,12 @@ fn test_camera_render_config() {
     );
 
     let config = RenderConfig {
-        image_size: RenderSize::from(512),
         world_to_model: View2::from_center_and_scale(
             nalgebra::Vector2::new(0.5, 0.5),
             0.25,
         )
         .world_to_model(),
-        ..Default::default()
+        ..RenderConfig::from_size(512.into())
     };
     let mat = config.mat();
     assert_eq!(

--- a/fidget/tests/voxel_render.rs
+++ b/fidget/tests/voxel_render.rs
@@ -20,13 +20,12 @@ fn sphere_var<F: Function + MathFunction + RenderHints>() {
     let size = 32;
     for scale in [1.0, 0.5] {
         let cfg = RenderConfig {
-            image_size: RenderSize::from(size),
             world_to_model: View3::from_center_and_scale(
                 Vector3::zeros(),
                 scale,
             )
             .world_to_model(),
-            ..Default::default()
+            ..RenderConfig::from_size(size.into())
         };
         for r in [0.5, 0.75] {
             let mut vars = ShapeVars::new();


### PR DESCRIPTION
It doesn't make sense to bake in a hard-coded size.  This is used as a base for semi-custom instantiations, so let's make an explicit function for that purpose.
