### PR TITLE
Separate `RenderConfig` and `EvalConfig` in `fidget::raster`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 0.5.1 (unpublished)
+- In `fidget::raster`, reorganize `RenderConfig` to separate out the render
+  settings (transform, size, etc) from evaluation settings (thread count,
+  cancellation, etc); the latter are now in a new `EvalConfig`.
+- `fidget::wgpu` now uses the `RenderConfig` type from `fidget::raster` instead
+  of its own, slightly-different `RenderConfig`.  This was, in fact, the
+  motivation for the reorganization!
+    - Render size in `fidget::wgpu::voxel` is now set by the `RenderConfig`,
+      instead of by the `Buffers` object.  This means that buffers are generated
+      without a size, and resized when passed to render functions.  Functions
+      which do resizing have a new possible error variant if the render size is
+      too large for WGPU buffers.
+
 # 0.5.0
 This is a large release with a bunch of small features, reorganization, and one
 big new crate (`fidget-wgpu`, re-exported as `fidget::wgpu`).  The goal of

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1626,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "fidget-raster"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "fidget-core",
  "nalgebra",
@@ -1697,7 +1697,7 @@ dependencies = [
 
 [[package]]
 name = "fidget-wgpu"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "fidget-bytecode",
  "fidget-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,9 +92,9 @@ fidget-bytecode = { path = "fidget-bytecode", version = "=0.5.0" }
 fidget-gui      = { path = "fidget-gui",      version = "=0.5.0" }
 fidget-jit      = { path = "fidget-jit",      version = "=0.5.0" }
 fidget-mesh     = { path = "fidget-mesh",     version = "=0.5.0" }
-fidget-raster   = { path = "fidget-raster",   version = "=0.5.0" }
+fidget-raster   = { path = "fidget-raster",   version = "=0.5.1" }
 fidget-rhai     = { path = "fidget-rhai",     version = "=0.5.0" }
 fidget-shapes   = { path = "fidget-shapes",   version = "=0.5.0" }
 fidget-solver   = { path = "fidget-solver",   version = "=0.5.0" }
-fidget-wgpu     = { path = "fidget-wgpu",     version = "=0.5.0" }
+fidget-wgpu     = { path = "fidget-wgpu",     version = "=0.5.1" }
 workspace-hack  = { path = "workspace-hack",  version = "0.1" }

--- a/demos/cli/src/main.rs
+++ b/demos/cli/src/main.rs
@@ -317,12 +317,13 @@ fn run3d<F: fidget::eval::Function + fidget::render::RenderHints>(
     depth: Option<u32>,
     threads: Option<&fidget::render::ThreadPool>,
 ) -> fidget::raster::voxel::Image {
-    let cfg = fidget::raster::voxel::RenderConfig {
-        threads,
+    let render_cfg = fidget::raster::voxel::RenderConfig {
         world_to_model,
-        ..fidget::raster::voxel::RenderConfig::from_size(
-            settings.voxel_size(depth),
-        )
+        image_size: settings.voxel_size(depth),
+    };
+    let eval_cfg = fidget::raster::voxel::EvalConfig {
+        threads,
+        ..Default::default()
     };
 
     let mut image = Default::default();
@@ -332,9 +333,12 @@ fn run3d<F: fidget::eval::Function + fidget::render::RenderHints>(
     let start = std::time::Instant::now();
     for _ in 0..settings.n {
         // Unwrap both cancellation and errors
-        image = cfg
-            .run(bound_shape.clone())
-            .expect("rendering should not be cancelled");
+        image = fidget::raster::voxel::render(
+            bound_shape.clone(),
+            &render_cfg,
+            &eval_cfg,
+        )
+        .expect("rendering should not be cancelled");
     }
     info!(
         "Rendered {}× at {:?} ms/frame",
@@ -370,10 +374,13 @@ fn run3d_wgpu(
 
     let ctx = fidget::wgpu::voxel::Context::new(&gpu);
     let image_size = settings.voxel_size(depth);
-    let cfg = fidget::wgpu::voxel::RenderConfig { world_to_model };
+    let cfg = fidget::wgpu::voxel::RenderConfig {
+        world_to_model,
+        image_size,
+    };
     let mut image = Default::default();
     let start = std::time::Instant::now();
-    let mut buffers = ctx.buffers(image_size)?;
+    let mut buffers = ctx.buffers();
     let mut out = ctx.image_buffer(&buffers);
     let shape = ctx.shape(&shape)?;
     let mut compute_pass_time = std::time::Duration::ZERO;
@@ -588,35 +595,41 @@ fn run2d<F: fidget::eval::Function + fidget::render::RenderHints>(
             )),
             None => Some(fidget::render::ThreadPool::Global),
         };
-        let cfg = fidget::raster::pixel::RenderConfig {
-            threads: threads.as_ref(),
+        let render_cfg = fidget::raster::pixel::RenderConfig {
             pixel_perfect: matches!(mode, RenderMode2D::Sdf),
             world_to_model,
             ..fidget::raster::pixel::RenderConfig::from_size(size)
         };
+        let eval_cfg = fidget::raster::pixel::EvalConfig {
+            threads: threads.as_ref(),
+            ..Default::default()
+        };
         let mut image = fidget::raster::Image::default();
         for _ in 0..settings.n {
-            let tmp = cfg
-                .run::<_>(bound_shape.clone())
-                .expect("render should not be cancelled");
+            let tmp = fidget::raster::pixel::render(
+                bound_shape.clone(),
+                &render_cfg,
+                &eval_cfg,
+            )
+            .expect("render should not be cancelled");
             match mode {
                 RenderMode2D::Mono => {
                     image = fidget::raster::effects::to_rgba_bitmap(
                         tmp,
                         false,
-                        cfg.threads,
+                        eval_cfg.threads,
                     );
                 }
                 RenderMode2D::Sdf => {
                     image = fidget::raster::effects::to_rgba_distance(
                         tmp,
-                        cfg.threads,
+                        eval_cfg.threads,
                     );
                 }
                 RenderMode2D::Debug => {
                     image = fidget::raster::effects::to_debug_bitmap(
                         tmp,
-                        cfg.threads,
+                        eval_cfg.threads,
                     );
                 }
                 RenderMode2D::Brute => unreachable!(),

--- a/demos/viewer/src/main.rs
+++ b/demos/viewer/src/main.rs
@@ -175,16 +175,20 @@ fn render_2d<F: fidget::eval::Function + fidget::render::RenderHints>(
     image_size: fidget::render::ImageSize,
     color: [u8; 3],
 ) -> Vec<[u8; 4]> {
-    let config = ImageRenderConfig {
+    let render_config = ImageRenderConfig {
         world_to_model: view.world_to_model(),
         pixel_perfect: matches!(mode, Mode2D::Sdf),
         ..ImageRenderConfig::from_size(image_size)
     };
+    let eval_config = fidget::raster::pixel::EvalConfig::default();
 
     let bound_shape = shape.try_into().expect("no vars allowed");
-    let tmp = config
-        .run(bound_shape)
-        .expect("rendering should not be cancelled");
+    let tmp = fidget::raster::pixel::render(
+        bound_shape,
+        &render_config,
+        &eval_config,
+    )
+    .expect("rendering should not be cancelled");
     let out = match mode {
         Mode2D::Color => {
             let c = [color[0], color[1], color[2], u8::MAX];
@@ -192,11 +196,11 @@ fn render_2d<F: fidget::eval::Function + fidget::render::RenderHints>(
         }
 
         Mode2D::Sdf => {
-            fidget::raster::effects::to_rgba_distance(tmp, config.threads)
+            fidget::raster::effects::to_rgba_distance(tmp, eval_config.threads)
         }
 
         Mode2D::Debug => {
-            fidget::raster::effects::to_debug_bitmap(tmp, config.threads)
+            fidget::raster::effects::to_debug_bitmap(tmp, eval_config.threads)
         }
     };
     let (data, _) = out.take();
@@ -215,9 +219,7 @@ fn render_3d<F: fidget::eval::Function + fidget::render::RenderHints>(
 
     // Get the geometry buffer from the voxel rendering process
     let bound_shape = shape.try_into().expect("no variables allowed");
-    let geometry_buffer = config
-        .run(bound_shape)
-        .expect("rendering should not be cancelled");
+    let geometry_buffer = config.run(bound_shape);
 
     // For both rendering modes, we'll convert the GeometryPixel data into
     // FloatPixels then pass them to the GPU, which will apply the appropriate

--- a/demos/web-editor/crate/Cargo.lock
+++ b/demos/web-editor/crate/Cargo.lock
@@ -661,7 +661,7 @@ dependencies = [
 
 [[package]]
 name = "fidget-raster"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "fidget-core",
  "nalgebra",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "fidget-wgpu"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "fidget-bytecode",
  "fidget-core",

--- a/demos/web-editor/crate/src/lib.rs
+++ b/demos/web-editor/crate/src/lib.rs
@@ -57,20 +57,25 @@ pub fn render_2d(
         view: View2,
         cancel: CancelToken,
     ) -> Option<Vec<u8>> {
-        let cfg = pixel::RenderConfig {
+        let render_cfg = pixel::RenderConfig {
             image_size: ImageSize::from(image_size as u32),
-            threads: Some(&ThreadPool::Global),
-            tile_sizes: Some(TileSizes::new(&[64, 16, 8]).unwrap()),
             pixel_perfect: false,
             world_to_model: view.world_to_model(),
+        };
+        let eval_cfg = pixel::EvalConfig {
+            threads: Some(&ThreadPool::Global),
+            tile_sizes: Some(TileSizes::new(&[64, 16, 8]).unwrap()),
             cancel,
         };
 
         // Unwrap errors, propagate cancellation
         let bound_shape = shape.try_into().expect("no vars");
-        let tmp = cfg.run(bound_shape)?;
-        let out =
-            fidget::raster::effects::to_rgba_bitmap(tmp, false, cfg.threads);
+        let tmp = pixel::render(bound_shape, &render_cfg, &eval_cfg)?;
+        let out = fidget::raster::effects::to_rgba_bitmap(
+            tmp,
+            false,
+            eval_cfg.threads,
+        );
         Some(out.into_iter().flatten().collect())
     }
     inner(shape.0, image_size, camera.0, cancel.0)
@@ -125,16 +130,18 @@ fn render_3d_inner(
     view: View3,
     cancel: CancelToken,
 ) -> Option<voxel::Image> {
-    let cfg = voxel::RenderConfig {
+    let render_cfg = voxel::RenderConfig {
         image_size: VoxelSize::from(image_size as u32),
+        world_to_model: view.world_to_model(),
+    };
+    let eval_cfg = voxel::EvalConfig {
         threads: Some(&ThreadPool::Global),
         tile_sizes: Some(TileSizes::new(&[128, 64, 32, 16, 8]).unwrap()),
-        world_to_model: view.world_to_model(),
         cancel,
     };
     // Unwrap errors, propagate cancellation
     let bound_shape = shape.try_into().expect("no vars");
-    cfg.run(bound_shape)
+    voxel::render(bound_shape, &render_cfg, &eval_cfg)
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/fidget-raster/Cargo.toml
+++ b/fidget-raster/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fidget-raster"
 description = "Bitmap and heightmap rendering for Fidget"
 readme = "README.md"
-version = "0.5.0"
+version = "0.5.1"
 
 edition.workspace = true
 license.workspace = true

--- a/fidget-raster/src/lib.rs
+++ b/fidget-raster/src/lib.rs
@@ -96,21 +96,23 @@ impl TileSizesRef<'_> {
 /// parallel (using [`rayon`] for parallelism at the tile level).
 ///
 /// It returns a set of output tiles, or `None` if rendering has been cancelled
-pub(crate) fn render_tiles<'a, F: Function, W: RenderWorker<'a, F>>(
+pub(crate) fn render_tiles<'a, F: Function, W: RenderWorker<'a, F>, C>(
     shape: Shape<F>,
     vars: &'a ShapeVars<f32>,
-    config: &'a W::Config,
+    render_config: &'a W::Config,
+    eval_config: &'a C,
     tile_sizes: TileSizesRef<'a>,
 ) -> Option<Vec<(Tile<2>, W::Output)>>
 where
     W::Config: Send + Sync,
+    C: EvalConfig + Send + Sync,
 {
     use rayon::prelude::*;
 
     let mut tiles = vec![];
     let t = tile_sizes[0];
-    let width = config.width() as usize;
-    let height = config.height() as usize;
+    let width = render_config.width() as usize;
+    let height = render_config.height() as usize;
     for i in 0..width.div_ceil(t) {
         for j in 0..height.div_ceil(t) {
             tiles.push(Tile::new(Point2::new(
@@ -126,17 +128,17 @@ where
     let ts = tile_sizes;
     let init = || {
         let rh = rh.clone();
-        let worker = W::new(config, ts, vars);
+        let worker = W::new(render_config, ts, vars);
         (worker, rh)
     };
 
-    match config.threads() {
+    match eval_config.threads() {
         None => {
-            let mut worker = W::new(config, tile_sizes, vars);
+            let mut worker = W::new(render_config, tile_sizes, vars);
             tiles
                 .into_iter()
                 .map(|tile| {
-                    if config.is_cancelled() {
+                    if eval_config.is_cancelled() {
                         Err(())
                     } else {
                         let pixels = worker.render_tile(&mut rh, tile);
@@ -151,7 +153,7 @@ where
             tiles
                 .into_par_iter()
                 .map_init(init, |(w, rh), tile| {
-                    if config.is_cancelled() {
+                    if eval_config.is_cancelled() {
                         Err(())
                     } else {
                         let pixels = w.render_tile(rh, tile);
@@ -165,7 +167,7 @@ where
 }
 
 /// Helper trait for tiled rendering configuration
-pub(crate) trait RenderConfig: RenderSize {
+pub(crate) trait EvalConfig {
     fn threads(&self) -> Option<&ThreadPool>;
     fn is_cancelled(&self) -> bool;
 }
@@ -180,7 +182,7 @@ pub trait RenderSize {
 
 /// Helper trait for a tiled renderer worker
 pub(crate) trait RenderWorker<'a, F: Function> {
-    type Config: RenderConfig;
+    type Config: RenderSize;
     type Output: Send;
 
     /// Build a new worker

--- a/fidget-raster/src/pixel.rs
+++ b/fidget-raster/src/pixel.rs
@@ -23,7 +23,8 @@ pub type Image = GenericImage<RawDistancePixel>;
 pub type RenderSize = fidget_core::render::ImageSize;
 
 /// Settings for 2D rendering
-pub struct RenderConfig<'a> {
+#[derive(Copy, Clone, Debug)]
+pub struct RenderConfig {
     /// Render size
     pub image_size: RenderSize,
 
@@ -32,7 +33,10 @@ pub struct RenderConfig<'a> {
 
     /// Render the distance values of individual pixels
     pub pixel_perfect: bool,
+}
 
+/// Evaluation settings for 2D rendering
+pub struct EvalConfig<'a> {
     /// Tile sizes to use during evaluation.
     ///
     /// If this is `None`, then evaluation will use
@@ -49,7 +53,7 @@ pub struct RenderConfig<'a> {
     pub cancel: CancelToken,
 }
 
-impl crate::RenderConfig for RenderConfig<'_> {
+impl crate::EvalConfig for EvalConfig<'_> {
     fn threads(&self) -> Option<&ThreadPool> {
         self.threads
     }
@@ -58,7 +62,17 @@ impl crate::RenderConfig for RenderConfig<'_> {
     }
 }
 
-impl crate::RenderSize for RenderConfig<'_> {
+impl Default for EvalConfig<'_> {
+    fn default() -> Self {
+        Self {
+            tile_sizes: None,
+            threads: Some(&ThreadPool::Global),
+            cancel: CancelToken::new(),
+        }
+    }
+}
+
+impl crate::RenderSize for RenderConfig {
     fn width(&self) -> u32 {
         self.image_size.width()
     }
@@ -67,12 +81,10 @@ impl crate::RenderSize for RenderConfig<'_> {
     }
 }
 
-impl RenderConfig<'_> {
+impl RenderConfig {
     /// Constructs a [`RenderConfig`] with reasonable defaults
     ///
-    /// This config uses the global thread pool for rendering, has an identity
-    /// transform matrix, uses render hints to choose tile sizes, and is not
-    /// pixel-perfect.
+    /// This config has an identity transform matrix and is not pixel-perfect.
     ///
     /// To build a somewhat-customized `RenderConfig`, it's typical to use this
     /// as the base object, then replace individual fields:
@@ -87,23 +99,18 @@ impl RenderConfig<'_> {
     pub fn from_size(image_size: RenderSize) -> Self {
         Self {
             image_size,
-            tile_sizes: None,
             world_to_model: Matrix3::identity(),
             pixel_perfect: false,
-            threads: Some(&ThreadPool::Global),
-            cancel: CancelToken::new(),
         }
     }
 
-    /// Render a shape in 2D using this configuration
-    ///
-    /// Returns [`Some(Image)`](Image) of pixel data on success, or `None`
-    /// if the render was cancelled.
+    /// Render a shape in 2D using this configuration and default [`EvalConfig`]
     pub fn run<F: Function + RenderHints>(
         &self,
         shape: BoundShape<F, f32>,
-    ) -> Option<Image> {
-        render(shape, self)
+    ) -> Image {
+        render(shape, self, &Default::default())
+            .expect("no cancellation is possible")
     }
 
     /// Returns the combined screen-to-model transform matrix
@@ -255,7 +262,7 @@ struct Worker<'a, F: Function> {
 }
 
 impl<'a, F: Function> RenderWorker<'a, F> for Worker<'a, F> {
-    type Config = RenderConfig<'a>;
+    type Config = RenderConfig;
     type Output = Image;
     fn new(
         cfg: &'a Self::Config,
@@ -429,31 +436,33 @@ impl<F: Function> Worker<'_, F> {
 /// configuration supplies resolution, transforms, etc.
 ///
 /// Returns [`Some(Image)`](Image) of pixel data if rendering succeeds, or
-/// `None` if rendering was cancelled (using the [`RenderConfig::cancel`].
+/// `None` if rendering was cancelled (using the [`EvalConfig::cancel`].
 pub fn render<F: Function + RenderHints>(
     b: BoundShape<F, f32>,
-    config: &RenderConfig,
+    render_config: &RenderConfig,
+    eval_config: &EvalConfig,
 ) -> Option<Image> {
     let shape = b.shape();
     let vars = b.vars();
-    let max_size = config.width().max(config.height()) as usize;
+    let max_size = render_config.width().max(render_config.height()) as usize;
     let default_tile_sizes;
-    let tile_sizes = if let Some(ts) = &config.tile_sizes {
+    let tile_sizes = if let Some(ts) = &eval_config.tile_sizes {
         TileSizesRef::new(ts, max_size)
     } else {
         default_tile_sizes = F::tile_sizes_2d();
         TileSizesRef::new(&default_tile_sizes, max_size)
     };
-    let tiles = super::render_tiles::<F, Worker<F>>(
+    let tiles = super::render_tiles::<F, Worker<F>, _>(
         shape.clone(),
         vars,
-        config,
+        render_config,
+        eval_config,
         tile_sizes,
     )?;
 
-    let width = config.image_size.width() as usize;
-    let height = config.image_size.height() as usize;
-    let mut image = Image::new(config.image_size);
+    let width = render_config.image_size.width() as usize;
+    let height = render_config.image_size.height() as usize;
+    let mut image = Image::new(render_config.image_size);
     for (tile, data) in tiles.iter() {
         let mut index = 0;
         for j in 0..tile_sizes[0] {
@@ -491,10 +500,11 @@ mod test {
             .try_into()
             .expect("no vars");
 
-        let cfg = RenderConfig::from_size(64.into());
-        let cancel = cfg.cancel.clone();
+        let render_cfg = RenderConfig::from_size(128.into());
+        let eval_cfg = EvalConfig::default();
+        let cancel = eval_cfg.cancel.clone();
         cancel.cancel();
-        assert!(cfg.run(shape).is_none());
+        assert!(render(shape, &render_cfg, &eval_cfg).is_none());
     }
 
     #[test]
@@ -510,8 +520,7 @@ mod test {
         let mut vars = ShapeVars::new();
         let i = var.index().expect("expected Var::V");
         vars.insert(i, 1.0);
-        cfg.run::<_>(shape.bind(&vars).expect("all vars present"))
-            .expect("not cancelled");
+        cfg.run(shape.bind(&vars).expect("all vars present"));
     }
 
     #[test]

--- a/fidget-raster/src/voxel.rs
+++ b/fidget-raster/src/voxel.rs
@@ -22,7 +22,8 @@ pub type RenderSize = fidget_core::render::VoxelSize;
 ////////////////////////////////////////////////////////////////////////////////
 
 /// Settings for 3D rendering
-pub struct RenderConfig<'a> {
+#[derive(Copy, Clone, Debug)]
+pub struct RenderConfig {
     /// Render size
     ///
     /// The resulting image will have the given width and height; depth sets the
@@ -32,7 +33,10 @@ pub struct RenderConfig<'a> {
 
     /// World-to-model transform
     pub world_to_model: Matrix4<f32>,
+}
 
+/// Evaluation settings for 3D rendering
+pub struct EvalConfig<'a> {
     /// Tile sizes to use during evaluation.
     ///
     /// If this is `None`, then evaluation will use
@@ -49,7 +53,7 @@ pub struct RenderConfig<'a> {
     pub cancel: CancelToken,
 }
 
-impl crate::RenderConfig for RenderConfig<'_> {
+impl crate::EvalConfig for EvalConfig<'_> {
     fn threads(&self) -> Option<&ThreadPool> {
         self.threads
     }
@@ -58,7 +62,17 @@ impl crate::RenderConfig for RenderConfig<'_> {
     }
 }
 
-impl crate::RenderSize for RenderConfig<'_> {
+impl Default for EvalConfig<'_> {
+    fn default() -> Self {
+        Self {
+            tile_sizes: None,
+            threads: Some(&ThreadPool::Global),
+            cancel: CancelToken::new(),
+        }
+    }
+}
+
+impl crate::RenderSize for RenderConfig {
     fn width(&self) -> u32 {
         self.image_size.width()
     }
@@ -67,32 +81,16 @@ impl crate::RenderSize for RenderConfig<'_> {
     }
 }
 
-impl RenderConfig<'_> {
-    /// Constructs a [`RenderConfig`] with reasonable defaults
-    ///
-    /// This config uses the global thread pool for rendering, has an identity
-    /// transform matrix, and uses the render hints to choose tile sizes.
-    ///
-    /// To build a somewhat-customized `RenderConfig`, it's typical to use this
-    /// as the base object, then replace individual fields:
-    ///
-    /// ```
-    /// # use fidget_raster::voxel::RenderConfig;
-    /// let cfg = RenderConfig {
-    ///     threads: None, // override field
-    ///     ..RenderConfig::from_size(1024.into()) // base
-    /// };
-    /// ```
+impl RenderConfig {
+    /// Constructs a [`RenderConfig`] with an identity transform and given size
     pub fn from_size(image_size: RenderSize) -> Self {
         Self {
             image_size,
-            tile_sizes: None,
             world_to_model: Matrix4::identity(),
-            threads: Some(&ThreadPool::Global),
-            cancel: CancelToken::new(),
         }
     }
-    /// Render a shape in 3D using this configuration
+
+    /// Render a shape in 3D using this configuration and default [`EvalConfig`]
     ///
     /// In the resulting image, saturated pixels (i.e. pixels in the image which
     /// are fully occupied up to the camera) are represented with `depth =
@@ -100,8 +98,9 @@ impl RenderConfig<'_> {
     pub fn run<F: Function + RenderHints>(
         &self,
         shape: BoundShape<F, f32>,
-    ) -> Option<Image> {
-        render(shape, self)
+    ) -> Image {
+        render(shape, self, &Default::default())
+            .expect("no cancellation is possible")
     }
 
     /// Returns the combined screen-to-model transform matrix
@@ -211,7 +210,7 @@ struct Worker<'a, F: Function> {
 }
 
 impl<'a, F: Function> RenderWorker<'a, F> for Worker<'a, F> {
-    type Config = RenderConfig<'a>;
+    type Config = RenderConfig;
     type Output = Image;
 
     fn new(
@@ -487,34 +486,44 @@ impl<F: Function> Worker<'_, F> {
 ////////////////////////////////////////////////////////////////////////////////
 
 /// Renders the given shape into a 3D image with a particular configuration
-/// configuration.
 ///
 /// The shape provides the evaluator backend (`F`) and bound variables; the
-/// configuration supplies resolution, transforms, etc.
+/// render configuration supplies resolution, transforms, etc; the evaluation
+/// configuration supplies thread pool and cancellation.
+///
+/// In the resulting image, saturated pixels (i.e. pixels in the image which are
+/// fully occupied up to the camera) are represented with `depth =
+/// render_config.image_size.depth()` and a normal of `[0, 0, 1]`.
 ///
 /// Returns [`Some(Image)`](Image) of pixel data on success, or `None` if
 /// the render was cancelled.
 pub fn render<F: Function + RenderHints>(
     b: BoundShape<F, f32>,
-    config: &RenderConfig,
+    render_config: &RenderConfig,
+    eval_config: &EvalConfig,
 ) -> Option<Image> {
     let shape = b.shape().clone();
     let vars = b.vars();
-    let max_size = config.width().max(config.height()) as usize;
+    let max_size = render_config.width().max(render_config.height()) as usize;
     let default_tile_sizes;
 
-    let tile_sizes = if let Some(ts) = &config.tile_sizes {
+    let tile_sizes = if let Some(ts) = &eval_config.tile_sizes {
         TileSizesRef::new(ts, max_size)
     } else {
         default_tile_sizes = F::tile_sizes_3d();
         TileSizesRef::new(&default_tile_sizes, max_size)
     };
-    let tiles =
-        super::render_tiles::<F, Worker<F>>(shape, vars, config, tile_sizes)?;
+    let tiles = super::render_tiles::<F, Worker<F>, _>(
+        shape,
+        vars,
+        render_config,
+        eval_config,
+        tile_sizes,
+    )?;
 
-    let width = config.image_size.width() as usize;
-    let height = config.image_size.height() as usize;
-    let mut image = Image::new(config.image_size);
+    let width = render_config.image_size.width() as usize;
+    let height = render_config.image_size.height() as usize;
+    let mut image = Image::new(render_config.image_size);
     for (tile, out) in tiles {
         let mut index = 0;
         for j in 0..tile_sizes[0] {
@@ -525,7 +534,7 @@ pub fn render<F: Function + RenderHints>(
                     let o = y * width + x;
                     if out[index].depth >= image[o].depth {
                         // Clamp voxels to the image depth
-                        let d = config.image_size.depth() - 1;
+                        let d = render_config.image_size.depth() - 1;
                         if out[index].depth >= d {
                             image[o] = GeometryPixel {
                                 depth: d + 1,
@@ -556,7 +565,7 @@ mod test {
         let shape = VmShape::new(&ctx, x).unwrap().try_into().unwrap();
 
         let cfg = RenderConfig::from_size(128.into()); // very small
-        let image = cfg.run(shape).expect("rendering should not be cancelled");
+        let image = cfg.run(shape);
         assert_eq!(image.len(), 128 * 128);
     }
 
@@ -566,10 +575,11 @@ mod test {
         let x = ctx.x();
         let shape = VmShape::new(&ctx, x).unwrap().try_into().unwrap();
 
-        let cfg = RenderConfig::from_size(64.into());
-        let cancel = cfg.cancel.clone();
+        let render_cfg = RenderConfig::from_size(64.into());
+        let eval_cfg = EvalConfig::default();
+        let cancel = eval_cfg.cancel.clone();
         cancel.cancel();
-        assert!(cfg.run::<_>(shape).is_none());
+        assert!(render(shape, &render_cfg, &eval_cfg).is_none());
     }
 
     #[test]
@@ -586,7 +596,6 @@ mod test {
         let mut vars = ShapeVars::new();
         let i = var.index().expect("expected Var::V");
         vars.insert(i, 1.0);
-        cfg.run::<_>(shape.bind(&vars).expect("all vars present"))
-            .expect("not cancelled");
+        cfg.run(shape.bind(&vars).expect("all vars present"));
     }
 }

--- a/fidget-wgpu/Cargo.toml
+++ b/fidget-wgpu/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fidget-wgpu"
 description = "WGPU backend for Fidget"
 readme = "README.md"
-version = "0.5.0"
+version = "0.5.1"
 
 edition.workspace = true
 license.workspace = true

--- a/fidget-wgpu/src/effects/mod.rs
+++ b/fidget-wgpu/src/effects/mod.rs
@@ -932,7 +932,7 @@ mod test {
 
         let size = 128;
         let image_size = RenderSize::from(size);
-        let mut buf = voxel_ctx.buffers(image_size).unwrap();
+        let mut buf = voxel_ctx.buffers();
         let mut merge_buf = effects_ctx.merge_buffers(size.into()).unwrap();
 
         let (x, y, z) = Tree::axes();
@@ -947,6 +947,7 @@ mod test {
                 &mut buf,
                 None,
                 &crate::voxel::RenderConfig {
+                    image_size,
                     world_to_model: nalgebra::Matrix4::identity(),
                 },
             )

--- a/fidget-wgpu/src/lib.rs
+++ b/fidget-wgpu/src/lib.rs
@@ -198,7 +198,7 @@ mod test {
 
         let size = 128;
         let image_size = RenderSize::from(size);
-        let mut buf = voxel_ctx.buffers(image_size).unwrap();
+        let mut buf = voxel_ctx.buffers();
         let mut merge_buf = effects_ctx.merge_buffers(size.into()).unwrap();
         let mut shade_buf = effects_ctx.shade_buffers(size.into()).unwrap();
         let mut shade_out = gpu.read_buffer_for(shade_buf.output());
@@ -219,6 +219,7 @@ mod test {
                 &mut buf,
                 None,
                 &voxel::RenderConfig {
+                    image_size,
                     world_to_model: nalgebra::Matrix4::identity(),
                 },
             )

--- a/fidget-wgpu/src/voxel/mod.rs
+++ b/fidget-wgpu/src/voxel/mod.rs
@@ -118,6 +118,7 @@ use fidget_core::{
     var::Var,
     vm::VmShape,
 };
+pub use fidget_raster::voxel::RenderConfig;
 use fidget_raster::voxel::{GeometryPixel, Image};
 use std::{collections::BTreeMap, num::NonZeroU64};
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
@@ -247,25 +248,15 @@ pub struct BuffersError {
     pub err: BufferSizeError,
 }
 
-////////////////////////////////////////////////////////////////////////////////
-
-/// Settings for 3D rendering
-///
-/// Note that this object only contains the world-to-model transform; the image
-/// size is set by the [`Buffers`] object passed into [`run`](Context::run) or
-/// [`run_async`](Context::run_async).
-#[derive(Copy, Clone)]
-pub struct RenderConfig {
-    /// World-to-model transform
-    pub world_to_model: nalgebra::Matrix4<f32>,
-}
-
-impl Default for RenderConfig {
-    fn default() -> Self {
-        Self {
-            world_to_model: nalgebra::Matrix4::identity(),
-        }
-    }
+/// Error returned when submitting a voxel rasterization job to the GPU
+#[derive(Debug, thiserror::Error)]
+pub enum SubmitError {
+    /// Missing variable when evaluating
+    #[error(transparent)]
+    MissingVar(#[from] MissingVar),
+    /// Error while resizing buffers
+    #[error(transparent)]
+    Buffers(#[from] BuffersError),
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2325,17 +2316,14 @@ impl Context {
         }
     }
 
-    /// Builds a new [`Buffers`] object for the given render size
+    /// Builds a new [`Buffers`] object for use in rendering
     ///
-    /// An image rendered with the resulting buffers will have the given width
-    /// and height; `image_size.depth()` sets the number of voxels to evaluate
-    /// within each pixel of the image (stacked into a column going into the
-    /// screen).
-    pub fn buffers(
-        &self,
-        image_size: VoxelSize,
-    ) -> Result<Buffers, BuffersError> {
-        Buffers::new(&self.gpu.device, image_size, self.has_timestamps)
+    /// The buffers are initialized with a dummy size and resized automatically
+    /// when passed into any of the runner functions (e.g. [`run`](Self::run) or
+    /// [`submit`](Self::submit)).
+    pub fn buffers(&self) -> Buffers {
+        Buffers::new(&self.gpu.device, 64.into(), self.has_timestamps)
+            .expect("64 is always a valid buffers size")
     }
 
     /// Returns an [`ImageReadBuffer`], sized to read from a [`Buffers`] object
@@ -2370,10 +2358,10 @@ impl Context {
     pub fn run(
         &self,
         shape: &RenderShape,
-        buffers: &Buffers,
+        buffers: &mut Buffers,
         out: &mut ImageReadBuffer,
         settings: RenderConfig,
-    ) -> Result<Image, MissingVar> {
+    ) -> Result<Image, SubmitError> {
         self.run_with_vars(shape, &Default::default(), buffers, out, settings)
     }
 
@@ -2385,10 +2373,10 @@ impl Context {
         &self,
         shape: &RenderShape,
         vars: &ShapeVars<f32>,
-        buffers: &Buffers,
+        buffers: &mut Buffers,
         out: &mut ImageReadBuffer,
         settings: RenderConfig,
-    ) -> Result<Image, MissingVar> {
+    ) -> Result<Image, SubmitError> {
         self.submit_with_vars(shape, vars, buffers, Some(out), &settings)?;
         let image = self.map_image(out);
         Ok(image.image())
@@ -2401,10 +2389,10 @@ impl Context {
     pub async fn run_async(
         &self,
         shape: &RenderShape,
-        buffers: &Buffers,
+        buffers: &mut Buffers,
         out: &mut ImageReadBuffer,
         settings: RenderConfig,
-    ) -> Result<Image, MissingVar> {
+    ) -> Result<Image, SubmitError> {
         self.run_with_vars_async(
             shape,
             &Default::default(),
@@ -2423,10 +2411,10 @@ impl Context {
         &self,
         shape: &RenderShape,
         vars: &ShapeVars<f32>,
-        buffers: &Buffers,
+        buffers: &mut Buffers,
         out: &mut ImageReadBuffer,
         settings: RenderConfig,
-    ) -> Result<Image, MissingVar> {
+    ) -> Result<Image, SubmitError> {
         self.submit_with_vars(shape, vars, buffers, Some(out), &settings)?;
         let image = self.map_image_async(out).await;
         Ok(image.image())
@@ -2448,7 +2436,7 @@ impl Context {
         buffers: &mut Buffers,
         out: Option<&mut ImageReadBuffer>,
         settings: &RenderConfig,
-    ) -> Result<(), MissingVar> {
+    ) -> Result<(), SubmitError> {
         self.submit_with_vars(
             shape,
             &Default::default(),
@@ -2465,10 +2453,11 @@ impl Context {
         &self,
         shape: &RenderShape,
         vars: &ShapeVars<f32>,
-        buffers: &Buffers,
+        buffers: &mut Buffers,
         out: Option<&mut ImageReadBuffer>,
         settings: &RenderConfig,
-    ) -> Result<(), MissingVar> {
+    ) -> Result<(), SubmitError> {
+        buffers.set_image_size(&self.gpu.device, settings.image_size)?;
         let render_size = TileRenderSize::from(buffers.image_size);
 
         let mat =
@@ -2528,7 +2517,7 @@ impl Context {
                     Var::X | Var::Y | Var::Z => (),
                     Var::V(vi) => {
                         let Some(value) = vars.get(vi) else {
-                            return Err(MissingVar { var: vi });
+                            return Err(MissingVar { var: vi }.into());
                         };
                         let offset = i * std::mem::size_of::<f32>();
                         writer

--- a/fidget/benches/pixel.rs
+++ b/fidget/benches/pixel.rs
@@ -98,26 +98,28 @@ pub fn prospero_thread_sweep(c: &mut Criterion) {
             Some(ThreadPool::Custom(i)) => i.current_num_threads().to_string(),
             Some(ThreadPool::Global) => "N".to_string(),
         };
-        let cfg = &fidget::raster::pixel::RenderConfig {
+        let render_cfg =
+            &fidget::raster::pixel::RenderConfig::from_size(1024.into());
+        let eval_cfg = &fidget::raster::pixel::EvalConfig {
             threads,
-            ..fidget::raster::pixel::RenderConfig::from_size(1024.into())
+            ..Default::default()
         };
         group.bench_function(BenchmarkId::new("vm", &name), move |b| {
             b.iter(|| {
                 let tape = shape_vm.clone();
-                black_box(cfg.run(tape))
+                black_box(fidget::raster::pixel::render(
+                    tape, render_cfg, eval_cfg,
+                ))
             })
         });
         #[cfg(feature = "jit")]
         {
-            let cfg = &fidget::raster::pixel::RenderConfig {
-                threads,
-                ..fidget::raster::pixel::RenderConfig::from_size(1024.into())
-            };
             group.bench_function(BenchmarkId::new("jit", &name), move |b| {
                 b.iter(|| {
                     let tape = shape_jit.clone();
-                    black_box(cfg.run(tape))
+                    black_box(fidget::raster::pixel::render(
+                        tape, render_cfg, eval_cfg,
+                    ))
                 })
             });
         }

--- a/fidget/src/lib.rs
+++ b/fidget/src/lib.rs
@@ -218,9 +218,7 @@
 //! let cfg = RenderConfig::from_size(RenderSize::from(32));
 //! let shape = VmShape::from(tree);
 //! let bound_shape = shape.try_into().expect("shape has no vars");
-//! let out = cfg
-//!     .run(bound_shape)
-//!     .expect("render is not cancelled");
+//! let out = cfg.run(bound_shape);
 //! let mut iter = out.iter();
 //! for y in 0..cfg.image_size.height() {
 //!     for x in 0..cfg.image_size.width() {

--- a/fidget/tests/pixel_render.rs
+++ b/fidget/tests/pixel_render.rs
@@ -43,9 +43,12 @@ impl Cfg {
             ..RenderConfig::from_size(RenderSize::new(width, 32))
         };
         let bound_shape = shape.bind(&self.vars).expect("all vars present");
-        let out = cfg
-            .run(bound_shape)
-            .expect("rendering should not be cancelled");
+        let out = fidget::raster::pixel::render(
+            bound_shape,
+            &cfg,
+            &Default::default(),
+        )
+        .expect("rendering should not be cancelled");
         let mut img_str = String::new();
         for (i, b) in out.iter().enumerate() {
             if i % width as usize == 0 {
@@ -375,10 +378,9 @@ fn check_neg_infinity<F: Function + MathFunction + RenderHints>() {
 
     let cfg = RenderConfig {
         pixel_perfect: true,
-        threads: None,
         ..RenderConfig::from_size(256.into())
     };
-    let out = cfg.run(shape).expect("rendering should not be cancelled");
+    let out = cfg.run(shape);
     assert!(out.into_iter().all(|i| i.inside()));
 }
 

--- a/fidget/tests/voxel_render.rs
+++ b/fidget/tests/voxel_render.rs
@@ -30,9 +30,7 @@ fn sphere_var<F: Function + MathFunction + RenderHints>() {
         for r in [0.5, 0.75] {
             let mut vars = ShapeVars::new();
             vars.insert(v.index().unwrap(), r);
-            let image = cfg
-                .run::<_>(shape.bind(&vars).unwrap())
-                .expect("rendering should not be cancelled");
+            let image = cfg.run::<_>(shape.bind(&vars).unwrap());
 
             check_sphere(image, size, scale, r);
         }
@@ -113,7 +111,7 @@ mod wgpu {
 
         let size = 32;
         let image_size = RenderSize::from(size);
-        let buf = ctx.buffers(image_size).unwrap();
+        let mut buf = ctx.buffers();
         let mut out = ctx.image_buffer(&buf);
         for scale in [1.0, 0.5] {
             for r in [0.5, 0.75] {
@@ -124,9 +122,10 @@ mod wgpu {
                 let image = ctx
                     .run(
                         &shape,
-                        &buf,
+                        &mut buf,
                         &mut out,
-                        fidget::wgpu::voxel::RenderConfig {
+                        fidget::raster::voxel::RenderConfig {
+                            image_size,
                             world_to_model: View3::from_center_and_scale(
                                 Vector3::zeros(),
                                 scale,
@@ -162,7 +161,7 @@ mod wgpu {
 
         let size = 32;
         let image_size = RenderSize::from(size);
-        let buf = ctx.buffers(image_size).unwrap();
+        let mut buf = ctx.buffers();
         let mut out = ctx.image_buffer(&buf);
         for scale in [1.0, 0.5] {
             for r in [0.5, 0.75] {
@@ -172,9 +171,10 @@ mod wgpu {
                     .run_with_vars(
                         &render_shape,
                         &vars,
-                        &buf,
+                        &mut buf,
                         &mut out,
-                        fidget::wgpu::voxel::RenderConfig {
+                        fidget::raster::voxel::RenderConfig {
+                            image_size,
                             world_to_model: View3::from_center_and_scale(
                                 Vector3::zeros(),
                                 scale,


### PR DESCRIPTION
I would like to use the `RenderConfig` for both CPU and GPU rendering, which means removing pieces of it that are specific to the CPU evaluator.  These pieces are moved to a new `EvalConfig`.