### PR TITLE
Remove `impl Eq for Tree`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
       which do resizing have a new possible error variant if the render size is
       too large for WGPU buffers.
 - Add `z` to `fidget::raster::pixel::RenderConfig` to set the Z evaluation level
+- Remove `impl Eq for Tree`, because trees with floating-point values (e.g.
+  `TreeOp::Const(f64::NAN)`) break reflexivity.
 
 # 0.5.0
 This is a large release with a bunch of small features, reorganization, and one

--- a/fidget-core/src/context/tree.rs
+++ b/fidget-core/src/context/tree.rs
@@ -227,7 +227,6 @@ impl PartialEq for Tree {
         true
     }
 }
-impl Eq for Tree {}
 
 impl Tree {
     /// Returns an `(x, y, z)` tuple


### PR DESCRIPTION
`TreeOp::Const(f64::NAN)` or a `TreeOp::RemapAffine` with `NaN` values will break reflexivity.

We're discussing workarounds in https://github.com/mkeeter/fidget/pull/446 , but this is trivially incorrect at the moment; management apologizes for the inconvenience.