### PR TITLE
Add `Hash` and restore `Eq` for `Tree` and `TreeOp`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,12 @@
       too large for WGPU buffers.
 - Add `z` to `fidget::raster::pixel::RenderConfig` to set the Z evaluation level
 - Move `PartialEq` implementation from `Tree` to `TreeOp`; switch to
-  `OrderedFloat` semantics so that pointer comparisons are valid.
+  `OrderedFloat` semantics so that pointer comparisons are valid.  Previously,
+  the `Eq` implementation on `Tree` was invalid (due to non-reflexive `NaN`
+  comparisons), but it's now fixed.
+- Add a `Hash` implementation to `Tree` and `TreeOp`, again using `OrderedFloat`
+  semantics.  This allows trees to be stored in hashmaps; thanks to @virtualritz
+  for the suggestion!
 
 # 0.5.0
 This is a large release with a bunch of small features, reorganization, and one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@
       which do resizing have a new possible error variant if the render size is
       too large for WGPU buffers.
 - Add `z` to `fidget::raster::pixel::RenderConfig` to set the Z evaluation level
-- Remove `impl Eq for Tree`, because trees with floating-point values (e.g.
-  `TreeOp::Const(f64::NAN)`) break reflexivity.
+- Move `PartialEq` implementation from `Tree` to `TreeOp`; switch to
+  `OrderedFloat` semantics so that pointer comparisons are valid.
 
 # 0.5.0
 This is a large release with a bunch of small features, reorganization, and one

--- a/fidget-core/src/context/tree.rs
+++ b/fidget-core/src/context/tree.rs
@@ -61,10 +61,10 @@ impl Drop for TreeOp {
 
 /// `TreeOp` equality uses [`OrderedFloat`] semantics for comparisons
 ///
-/// This is subtle, but it ensures consistent behavior while uses pointer
+/// This is subtle, but it ensures consistent behavior while using pointer
 /// equality for short-circuiting recursive checks.  If we instead used standard
-/// floating-point semantics, two `NAN` trees would considered equal if one is a
-/// clone of the other (due to pointer equality) but un-equal if they were
+/// floating-point semantics, two `NAN` trees would be considered equal if one
+/// is a clone of the other (due to pointer equality) but unequal if they were
 /// constructed separately (due to float semantics).
 ///
 /// In addition, this makes equality reflexive, allowing us to implement `Eq`

--- a/fidget-core/src/context/tree.rs
+++ b/fidget-core/src/context/tree.rs
@@ -1,6 +1,7 @@
 //! Context-free math trees
 use super::op::{BinaryOpcode, UnaryOpcode};
 use crate::{context::NotAVar, var::Var};
+use ordered_float::OrderedFloat;
 use std::{cmp::Ordering, sync::Arc};
 
 /// Opcode type for trees
@@ -147,6 +148,15 @@ impl std::ops::Deref for Tree {
     }
 }
 
+/// Tree equality uses [`OrderedFloat`] semantics for comparisons
+///
+/// This is subtle, but it ensures consistent behavior while uses pointer
+/// equality for short-circuiting recursive checks.  If we instead used standard
+/// floating-point semantics, two `NAN` trees would considered equal if one is a
+/// clone of the other (due to pointer equality) but un-equal if they were
+/// constructed separately (due to float semantics).
+///
+/// In addition, this makes equality reflexive, allowing us to implement `Eq`.
 impl PartialEq for Tree {
     fn eq(&self, other: &Self) -> bool {
         if self.ptr_eq(other) {
@@ -167,7 +177,7 @@ impl PartialEq for Tree {
                     }
                 }
                 (TreeOp::Const(a), TreeOp::Const(b)) => {
-                    if *a != *b {
+                    if OrderedFloat(*a) != OrderedFloat(*b) {
                         return false;
                     }
                 }
@@ -216,7 +226,12 @@ impl PartialEq for Tree {
                         mat: mat_b,
                     },
                 ) => {
-                    if *mat_a != *mat_b {
+                    if mat_a
+                        .matrix()
+                        .iter()
+                        .zip(mat_b.matrix().iter())
+                        .any(|(a, b)| OrderedFloat(*a) != OrderedFloat(*b))
+                    {
                         return false;
                     }
                     todo.push((t_a, t_b));
@@ -227,6 +242,8 @@ impl PartialEq for Tree {
         true
     }
 }
+
+impl Eq for Tree {}
 
 impl Tree {
     /// Returns an `(x, y, z)` tuple
@@ -809,5 +826,23 @@ mod test {
         let mut ctx = Context::new();
         let node = ctx.import(&t.tree);
         assert_eq!(ctx.eval_xyz(node, 1.0, 2.0, 3.0).unwrap(), 5.0);
+    }
+
+    #[test]
+    fn tree_eq_nan() {
+        let a = Tree::from(f32::NAN);
+        let a_ = a.clone();
+        let b = Tree::from(f32::NAN);
+
+        assert!(a.ptr_eq(&a_));
+        assert_eq!(a, a_);
+        assert!(!a.ptr_eq(&b));
+        assert_eq!(a, b);
+
+        let affine: nalgebra::Affine3<_> =
+            nalgebra::convert(nalgebra::Translation3::new(1.0, 2.0, f64::NAN));
+        let a = Tree::x().remap_affine(affine);
+        let b = Tree::x().remap_affine(affine);
+        assert_eq!(a, b);
     }
 }

--- a/fidget-core/src/context/tree.rs
+++ b/fidget-core/src/context/tree.rs
@@ -59,6 +59,79 @@ impl Drop for TreeOp {
     }
 }
 
+/// `TreeOp` equality uses [`OrderedFloat`] semantics for comparisons
+///
+/// This is subtle, but it ensures consistent behavior while uses pointer
+/// equality for short-circuiting recursive checks.  If we instead used standard
+/// floating-point semantics, two `NAN` trees would considered equal if one is a
+/// clone of the other (due to pointer equality) but un-equal if they were
+/// constructed separately (due to float semantics).
+///
+/// In addition, this makes equality reflexive, allowing us to implement `Eq`.
+impl PartialEq for TreeOp {
+    fn eq(&self, other: &Self) -> bool {
+        if std::ptr::eq(self, other) {
+            return true;
+        }
+        // Heap recursion using a `Vec`, to avoid blowing up the stack
+        let mut todo = vec![(self, other)];
+        while let Some((a, b)) = todo.pop() {
+            // Pointer equality lets us short-circuit deep checks
+            if std::ptr::eq(a, b) {
+                continue;
+            }
+            // Otherwise, we check opcodes then recurse
+            match (a, b) {
+                (TreeOp::Input(a), TreeOp::Input(b)) => {
+                    if *a != *b {
+                        return false;
+                    }
+                }
+                (TreeOp::Const(a), TreeOp::Const(b)) => {
+                    if OrderedFloat(*a) != OrderedFloat(*b) {
+                        return false;
+                    }
+                }
+                (TreeOp::Unary(op_a, ..), TreeOp::Unary(op_b, ..)) => {
+                    if *op_a != *op_b {
+                        return false;
+                    }
+                }
+                (TreeOp::Binary(op_a, ..), TreeOp::Binary(op_b, ..)) => {
+                    if *op_a != *op_b {
+                        return false;
+                    }
+                }
+                (TreeOp::RemapAxes { .. }, TreeOp::RemapAxes { .. }) => {
+                    // No non-recursive state to compare
+                }
+                (
+                    TreeOp::RemapAffine { mat: mat_a, .. },
+                    TreeOp::RemapAffine { mat: mat_b, .. },
+                ) => {
+                    if mat_a
+                        .matrix()
+                        .iter()
+                        .zip(mat_b.matrix().iter())
+                        .any(|(a, b)| OrderedFloat(*a) != OrderedFloat(*b))
+                    {
+                        return false;
+                    }
+                }
+                _ => return false,
+            }
+            todo.extend(
+                a.iter_children()
+                    .zip(b.iter_children())
+                    .map(|(a, b)| (a.as_ref(), b.as_ref())),
+            )
+        }
+        true
+    }
+}
+
+impl Eq for TreeOp {}
+
 impl TreeOp {
     /// Checks whether the given tree is eligible for fast dropping
     ///
@@ -138,7 +211,15 @@ impl From<TreeOp> for Tree {
 }
 
 /// Owned handle for a standalone math tree
-#[derive(Clone, Debug, facet::Facet)]
+///
+/// Note that trees use [`OrderedFloat`] semantics for comparisons, not
+/// floating-point semantics.  This makes it possible to quickly compare trees
+/// by checking inner [`TreeOp`] pointer equality, and makes equality reflexive
+/// (so that trees can derive `Eq` instead of just `PartialEq`).  It would be
+/// surprising if this mattered to anyone, because it only affects behavior
+/// around `NAN` values, and storing `NAN` values in a tree constant or
+/// transform matrix would be a strange thing to do.
+#[derive(Clone, Debug, PartialEq, Eq, facet::Facet)]
 pub struct Tree(#[facet(opaque)] Arc<TreeOp>);
 
 impl std::ops::Deref for Tree {
@@ -147,103 +228,6 @@ impl std::ops::Deref for Tree {
         &self.0
     }
 }
-
-/// Tree equality uses [`OrderedFloat`] semantics for comparisons
-///
-/// This is subtle, but it ensures consistent behavior while uses pointer
-/// equality for short-circuiting recursive checks.  If we instead used standard
-/// floating-point semantics, two `NAN` trees would considered equal if one is a
-/// clone of the other (due to pointer equality) but un-equal if they were
-/// constructed separately (due to float semantics).
-///
-/// In addition, this makes equality reflexive, allowing us to implement `Eq`.
-impl PartialEq for Tree {
-    fn eq(&self, other: &Self) -> bool {
-        if self.ptr_eq(other) {
-            return true;
-        }
-        // Heap recursion using a `Vec`, to avoid blowing up the stack
-        let mut todo = vec![(&self.0, &other.0)];
-        while let Some((a, b)) = todo.pop() {
-            // Pointer equality lets us short-circuit deep checks
-            if Arc::as_ptr(a) == Arc::as_ptr(b) {
-                continue;
-            }
-            // Otherwise, we check opcodes then recurse
-            match (a.as_ref(), b.as_ref()) {
-                (TreeOp::Input(a), TreeOp::Input(b)) => {
-                    if *a != *b {
-                        return false;
-                    }
-                }
-                (TreeOp::Const(a), TreeOp::Const(b)) => {
-                    if OrderedFloat(*a) != OrderedFloat(*b) {
-                        return false;
-                    }
-                }
-                (TreeOp::Unary(op_a, arg_a), TreeOp::Unary(op_b, arg_b)) => {
-                    if *op_a != *op_b {
-                        return false;
-                    }
-                    todo.push((arg_a, arg_b));
-                }
-                (
-                    TreeOp::Binary(op_a, lhs_a, rhs_a),
-                    TreeOp::Binary(op_b, lhs_b, rhs_b),
-                ) => {
-                    if *op_a != *op_b {
-                        return false;
-                    }
-                    todo.push((lhs_a, lhs_b));
-                    todo.push((rhs_a, rhs_b));
-                }
-                (
-                    TreeOp::RemapAxes {
-                        target: t_a,
-                        x: x_a,
-                        y: y_a,
-                        z: z_a,
-                    },
-                    TreeOp::RemapAxes {
-                        target: t_b,
-                        x: x_b,
-                        y: y_b,
-                        z: z_b,
-                    },
-                ) => {
-                    todo.push((t_a, t_b));
-                    todo.push((x_a, x_b));
-                    todo.push((y_a, y_b));
-                    todo.push((z_a, z_b));
-                }
-                (
-                    TreeOp::RemapAffine {
-                        target: t_a,
-                        mat: mat_a,
-                    },
-                    TreeOp::RemapAffine {
-                        target: t_b,
-                        mat: mat_b,
-                    },
-                ) => {
-                    if mat_a
-                        .matrix()
-                        .iter()
-                        .zip(mat_b.matrix().iter())
-                        .any(|(a, b)| OrderedFloat(*a) != OrderedFloat(*b))
-                    {
-                        return false;
-                    }
-                    todo.push((t_a, t_b));
-                }
-                _ => return false,
-            }
-        }
-        true
-    }
-}
-
-impl Eq for Tree {}
 
 impl Tree {
     /// Returns an `(x, y, z)` tuple
@@ -826,6 +810,19 @@ mod test {
         let mut ctx = Context::new();
         let node = ctx.import(&t.tree);
         assert_eq!(ctx.eval_xyz(node, 1.0, 2.0, 3.0).unwrap(), 5.0);
+    }
+
+    #[test]
+    fn tree_eq_simple() {
+        let a = Tree::from(1.0) + Tree::x();
+        let a_ = a.clone();
+        let b = Tree::from(1.0) + Tree::x();
+        assert_eq!(a_, a);
+        assert_eq!(a, b);
+
+        let c = Tree::from(1.0) + Tree::y();
+        assert_ne!(a, c);
+        assert_ne!(b, c);
     }
 
     #[test]

--- a/fidget-core/src/context/tree.rs
+++ b/fidget-core/src/context/tree.rs
@@ -67,7 +67,8 @@ impl Drop for TreeOp {
 /// clone of the other (due to pointer equality) but un-equal if they were
 /// constructed separately (due to float semantics).
 ///
-/// In addition, this makes equality reflexive, allowing us to implement `Eq`.
+/// In addition, this makes equality reflexive, allowing us to implement `Eq`
+/// (and to store values in hashmaps).
 impl PartialEq for TreeOp {
     fn eq(&self, other: &Self) -> bool {
         if std::ptr::eq(self, other) {
@@ -233,14 +234,14 @@ impl From<TreeOp> for Tree {
 
 /// Owned handle for a standalone math tree
 ///
-/// Note that trees use [`OrderedFloat`] semantics for comparisons, not
-/// floating-point semantics.  This makes it possible to quickly compare trees
-/// by checking inner [`TreeOp`] pointer equality, and makes equality reflexive
-/// (so that trees can derive `Eq` instead of just `PartialEq`).  It would be
-/// surprising if this mattered to anyone, because it only affects behavior
-/// around `NAN` values, and storing `NAN` values in a tree constant or
+/// Note that trees use [`OrderedFloat`] semantics for comparisons and hashing,
+/// not floating-point semantics.  This makes it possible to quickly compare
+/// trees by checking inner [`TreeOp`] pointer equality, and makes equality
+/// reflexive (so that trees can derive `Eq` instead of just `PartialEq`).  It
+/// would be surprising if this mattered to anyone, because it only affects
+/// behavior around `NAN` values, and storing `NAN` values in a tree constant or
 /// transform matrix would be a strange thing to do.
-#[derive(Clone, Debug, PartialEq, Eq, facet::Facet)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, facet::Facet)]
 pub struct Tree(#[facet(opaque)] Arc<TreeOp>);
 
 impl std::ops::Deref for Tree {
@@ -505,6 +506,7 @@ impl std::ops::Neg for Tree {
 mod test {
     use super::*;
     use crate::Context;
+    use std::hash::BuildHasher;
 
     #[test]
     fn tree_x() {
@@ -681,6 +683,20 @@ mod test {
     }
 
     #[test]
+    fn deep_recursion_hash() {
+        let mut x1 = Tree::x();
+        for _ in 0..1_000_000 {
+            x1 += 1.0;
+        }
+        let mut x2 = Tree::x();
+        for _ in 0..1_000_000 {
+            x2 += 1.0;
+        }
+        let state = std::hash::RandomState::new();
+        assert_eq!(state.hash_one(&x1), state.hash_one(&x2));
+    }
+
+    #[test]
     fn deep_recursion_import() {
         let mut x = Tree::x();
         for _ in 0..1_000_000 {
@@ -844,6 +860,35 @@ mod test {
         let c = Tree::from(1.0) + Tree::y();
         assert_ne!(a, c);
         assert_ne!(b, c);
+
+        let a = Tree::x().cos();
+        let a_ = Tree::x().cos();
+        let b = Tree::x().sin();
+        assert_eq!(a, a_);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn tree_hash_simple() {
+        let a = Tree::from(1.0) + Tree::x();
+        let a_ = a.clone();
+        let b = Tree::from(1.0) + Tree::x();
+        let state = std::hash::RandomState::new();
+
+        assert_eq!(state.hash_one(&a), state.hash_one(&b));
+        assert_eq!(state.hash_one(&a), state.hash_one(&a_));
+
+        let c = Tree::from(1.0) + Tree::y();
+        assert_ne!(state.hash_one(&a), state.hash_one(&c));
+
+        let d = Tree::from(1.0) * Tree::x();
+        assert_ne!(state.hash_one(&a), state.hash_one(&d));
+
+        let a = Tree::x().cos();
+        let a_ = Tree::x().cos();
+        let b = Tree::x().sin();
+        assert_eq!(state.hash_one(&a), state.hash_one(&a_));
+        assert_ne!(state.hash_one(&a), state.hash_one(&b));
     }
 
     #[test]
@@ -862,5 +907,29 @@ mod test {
         let a = Tree::x().remap_affine(affine);
         let b = Tree::x().remap_affine(affine);
         assert_eq!(a, b);
+    }
+
+    #[test]
+    fn tree_hash_nan() {
+        let a = Tree::from(f32::NAN);
+        let a_ = a.clone();
+        let b = Tree::from(f32::NAN);
+        let c = Tree::from(1.0);
+        let state = std::hash::RandomState::new();
+
+        assert_eq!(state.hash_one(&a), state.hash_one(a_));
+        assert_eq!(state.hash_one(&a), state.hash_one(&b));
+        assert_ne!(state.hash_one(&a), state.hash_one(&c));
+
+        let affine: nalgebra::Affine3<_> =
+            nalgebra::convert(nalgebra::Translation3::new(1.0, 2.0, f64::NAN));
+        let a = Tree::x().remap_affine(affine);
+        let b = Tree::x().remap_affine(affine);
+        assert_eq!(state.hash_one(&a), state.hash_one(&b));
+
+        let affine: nalgebra::Affine3<_> =
+            nalgebra::convert(nalgebra::Translation3::new(1.0, 2.0, 3.0));
+        let c = Tree::x().remap_affine(affine);
+        assert_ne!(state.hash_one(&a), state.hash_one(&c));
     }
 }

--- a/fidget-core/src/context/tree.rs
+++ b/fidget-core/src/context/tree.rs
@@ -180,6 +180,27 @@ impl TreeOp {
     }
 }
 
+impl std::hash::Hash for TreeOp {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        let mut todo = vec![self];
+        while let Some(t) = todo.pop() {
+            std::mem::discriminant(t).hash(state);
+            match t {
+                TreeOp::Input(i) => i.hash(state),
+                TreeOp::Const(v) => OrderedFloat(*v).hash(state),
+                TreeOp::Binary(op, _lhs, _rhs) => op.hash(state),
+                TreeOp::Unary(op, _arg) => op.hash(state),
+                TreeOp::RemapAxes { .. } => (), // no non-recursive state
+                TreeOp::RemapAffine { target: _, mat } => mat
+                    .matrix()
+                    .iter()
+                    .for_each(|f| OrderedFloat(*f).hash(state)),
+            }
+            todo.extend(t.iter_children().map(|t| t.as_ref()))
+        }
+    }
+}
+
 impl From<f64> for Tree {
     fn from(v: f64) -> Tree {
         Tree::constant(v)


### PR DESCRIPTION
This PR does three related things:

- Moves the `PartialEq` implementation from `Tree` to `TreeOp`, because we can (and it's more powerful when higher upstream)
- Switches the `PartialEq` implementation to using `OrderedFloat` semantics, so `Eq` can be derived again (it was removed in #447)
- Adds a `Hash` implementation to `TreeOp` (and to `Tree` via automatic derive), also using `OrderedFloat` semantics

(supercedes #446)