### PR TITLE
Move operations onto types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 - Add `fidget::wgpu::pixel` module for 2D rasterization on the GPU.  This is
   often slower than the CPU evaluator – there just aren't enough pixels for
   parallelism to really kick in – but it's useful for consistency.
+- Move more VM functions onto `Grad` and `Interval` (out of the VM
+  implementation); add a `FloatExt` trait which adds them to `f32` as well.
 
 # 0.5.0
 This is a large release with a bunch of small features, reorganization, and one

--- a/fidget-core/src/types/float.rs
+++ b/fidget-core/src/types/float.rs
@@ -1,0 +1,118 @@
+use crate::vm::Choice;
+
+/// Extension trait for tape operations on floats
+pub trait FloatExt: Sized {
+    /// Computes the maximum of two values and a choice
+    ///
+    /// Unlike `f32::max`, this selects `NAN` when either side is `NAN`
+    ///
+    /// ```
+    /// use fidget_core::{vm::Choice, types::FloatExt};
+    ///
+    /// let (v, c) = 12.0.max_choice(10.0);
+    /// assert_eq!(v, 12.0);
+    /// assert_eq!(c, Choice::Left);
+    ///
+    /// let (v, c) = 1.0.max_choice(2.0);
+    /// assert_eq!(v, 2.0);
+    /// assert_eq!(c, Choice::Right);
+    ///
+    /// let (v, c) = 1.0.max_choice(f32::NAN);
+    /// assert!(v.is_nan());
+    /// assert_eq!(c, Choice::Both);
+    /// ```
+    fn max_choice(self, other: Self) -> (Self, Choice);
+
+    /// Computes the minimum of two values and a choice
+    ///
+    /// Unlike `f32::min`, this selects `NAN` when either side is `NAN`
+    ///
+    /// ```
+    /// use fidget_core::{vm::Choice, types::FloatExt};
+    ///
+    /// let (v, c) = 12.0.min_choice(10.0);
+    /// assert_eq!(v, 10.0);
+    /// assert_eq!(c, Choice::Right);
+    ///
+    /// let (v, c) = 1.0.min_choice(2.0);
+    /// assert_eq!(v, 1.0);
+    /// assert_eq!(c, Choice::Left);
+    ///
+    /// let (v, c) = 1.0.min_choice(f32::NAN);
+    /// assert!(v.is_nan());
+    /// assert_eq!(c, Choice::Both);
+    /// ```
+    fn min_choice(self, other: Self) -> (Self, Choice);
+
+    /// Computes the logical AND between two values
+    fn and_choice(self, other: Self) -> (Self, Choice);
+
+    /// Computes the logical OR between two values
+    fn or_choice(self, other: Self) -> (Self, Choice);
+
+    /// Signed comparison of two values
+    fn compare(self, other: Self) -> Self;
+}
+
+impl FloatExt for f32 {
+    #[inline]
+    fn compare(self, other: Self) -> Self {
+        self.partial_cmp(&other)
+            .map(|c| c as i8 as f32)
+            .unwrap_or(f32::NAN)
+    }
+
+    #[inline]
+    fn max_choice(self, other: Self) -> (Self, Choice) {
+        if self > other {
+            (self, Choice::Left)
+        } else if other > self {
+            (other, Choice::Right)
+        } else {
+            (
+                if self.is_nan() || other.is_nan() {
+                    f32::NAN
+                } else {
+                    other
+                },
+                Choice::Both,
+            )
+        }
+    }
+
+    #[inline]
+    fn min_choice(self, other: Self) -> (Self, Choice) {
+        if self < other {
+            (self, Choice::Left)
+        } else if other < self {
+            (other, Choice::Right)
+        } else {
+            (
+                if self.is_nan() || other.is_nan() {
+                    f32::NAN
+                } else {
+                    other
+                },
+                Choice::Both,
+            )
+        }
+    }
+
+    #[inline]
+    fn and_choice(self, other: Self) -> (Self, Choice) {
+        if self == 0.0 {
+            (self, Choice::Left)
+        } else {
+            (other, Choice::Right)
+        }
+    }
+
+    #[inline]
+    fn or_choice(self, other: Self) -> (Self, Choice) {
+        if self != 0.0 {
+            (self, Choice::Left)
+        } else {
+            (other, Choice::Right)
+        }
+    }
+}

--- a/fidget-core/src/types/grad.rs
+++ b/fidget-core/src/types/grad.rs
@@ -167,15 +167,31 @@ impl Grad {
     }
 
     /// Minimum of two values
+    ///
+    /// If either value is `NAN`, then this returns `NAN` (with empty gradients)
     #[inline]
     pub fn min(self, rhs: Self) -> Self {
-        if self.v < rhs.v { self } else { rhs }
+        if self.v.is_nan() || rhs.v.is_nan() {
+            f32::NAN.into()
+        } else if self.v < rhs.v {
+            self
+        } else {
+            rhs
+        }
     }
 
     /// Maximum of two values
+    ///
+    /// If either value is `NAN`, then this returns `NAN` (with empty gradients)
     #[inline]
     pub fn max(self, rhs: Self) -> Self {
-        if self.v > rhs.v { self } else { rhs }
+        if self.v.is_nan() || rhs.v.is_nan() {
+            f32::NAN.into()
+        } else if self.v > rhs.v {
+            self
+        } else {
+            rhs
+        }
     }
 
     /// Least non-negative remainder
@@ -188,6 +204,22 @@ impl Grad {
             dy: self.dy - rhs.dy * e,
             dz: self.dz - rhs.dz * e,
         }
+    }
+
+    /// Logical AND
+    ///
+    /// Returns `self` if `self.v == 0`; otherwise returns `rhs`
+    #[inline]
+    pub fn and(&self, rhs: Grad) -> Self {
+        if self.v == 0.0 { *self } else { rhs }
+    }
+
+    /// Logical OR
+    ///
+    /// Returns `self` if `self.v != 0`; otherwise returns `rhs`
+    #[inline]
+    pub fn or(&self, rhs: Grad) -> Self {
+        if self.v != 0.0 { *self } else { rhs }
     }
 
     /// Snap to the largest less-than-or-equal value
@@ -235,6 +267,21 @@ impl Grad {
             dy: (x.v * y.dy - y.v * x.dy) / d,
             dz: (x.v * y.dz - y.v * x.dz) / d,
         }
+    }
+
+    /// Signed comparison of two values
+    pub fn compare(&self, other: Self) -> Self {
+        self.v
+            .partial_cmp(&other.v)
+            .map(|c| c as i8 as f32)
+            .unwrap_or(f32::NAN)
+            .into()
+    }
+
+    /// Logical not
+    #[inline]
+    pub fn not(&self) -> Self {
+        f32::from(self.v == 0.0).into()
     }
 
     /// Checks that the two values are roughly equal, panicking otherwise

--- a/fidget-core/src/types/interval.rs
+++ b/fidget-core/src/types/interval.rs
@@ -107,7 +107,8 @@ impl Interval {
     /// Compares two values
     ///
     /// - If `lhs.upper() < rhs.lower()`, then the result is -1
-    /// - If `lhs.lower() < rhs.upper()`, then the result is +1
+    /// - If `lhs.lower() > rhs.upper()`, then the result is +1
+    /// - If `lhs` and `rhs` are both equal unit intervals, then the result is 0
     /// - If either side is `NaN`, then the result is the `NaN` interval
     /// - Otherwise, the result is `[-1, +1]`
     #[inline]
@@ -120,6 +121,11 @@ impl Interval {
             Interval::from(-1.0)
         } else if lhs.lower() > rhs.upper() {
             Interval::from(1.0)
+        } else if lhs.lower() == lhs.upper()
+            && rhs.lower() == rhs.upper()
+            && lhs.lower() == rhs.lower()
+        {
+            Interval::new(0.0, 0.0)
         } else {
             Interval::new(-1.0, 1.0)
         }

--- a/fidget-core/src/types/interval.rs
+++ b/fidget-core/src/types/interval.rs
@@ -104,6 +104,27 @@ impl Interval {
         }
     }
 
+    /// Compares two values
+    ///
+    /// - If `lhs.upper() < rhs.lower()`, then the result is -1
+    /// - If `lhs.lower() < rhs.upper()`, then the result is +1
+    /// - If either side is `NaN`, then the result is the `NaN` interval
+    /// - Otherwise, the result is `[-1, +1]`
+    #[inline]
+    pub fn compare<T: Into<Self>, U: Into<Self>>(lhs: T, rhs: U) -> Self {
+        let lhs = lhs.into();
+        let rhs = rhs.into();
+        if lhs.has_nan() || rhs.has_nan() {
+            f32::NAN.into()
+        } else if lhs.upper() < rhs.lower() {
+            Interval::from(-1.0)
+        } else if lhs.lower() > rhs.upper() {
+            Interval::from(1.0)
+        } else {
+            Interval::new(-1.0, 1.0)
+        }
+    }
+
     /// Computes the sine of the interval
     #[inline]
     pub fn sin(self) -> Self {
@@ -481,6 +502,22 @@ impl Interval {
     #[inline]
     pub fn round(&self) -> Self {
         Interval::new(self.lower.round(), self.upper.round())
+    }
+
+    /// Logical not
+    ///
+    /// - If the interval does not contain 0, then this is always 0
+    /// - If the interval is exactly 0, then this is always 1
+    /// - Otherwise (or if `NaN` values are involved), returns `[0, 1]`
+    #[inline]
+    pub fn not(&self) -> Self {
+        if !self.contains(0.0) && !self.has_nan() {
+            Interval::new(0.0, 0.0)
+        } else if self.lower() == 0.0 && self.upper() == 0.0 {
+            Interval::new(1.0, 1.0)
+        } else {
+            Interval::new(0.0, 1.0)
+        }
     }
 
     /// Four-quadrant arctangent

--- a/fidget-core/src/types/mod.rs
+++ b/fidget-core/src/types/mod.rs
@@ -1,6 +1,8 @@
 //! Custom types used during evaluation
 
+mod float;
 mod grad;
 mod interval;
+pub use float::FloatExt;
 pub use grad::Grad;
 pub use interval::Interval;

--- a/fidget-core/src/vm/mod.rs
+++ b/fidget-core/src/vm/mod.rs
@@ -398,13 +398,7 @@ impl<const N: usize> TracingEvaluator for VmIntervalEval<N> {
                     v[out] = v[arg].ln();
                 }
                 RegOp::NotReg(out, arg) => {
-                    v[out] = if !v[arg].contains(0.0) && !v[arg].has_nan() {
-                        Interval::new(0.0, 0.0)
-                    } else if v[arg].lower() == 0.0 && v[arg].upper() == 0.0 {
-                        Interval::new(1.0, 1.0)
-                    } else {
-                        Interval::new(0.0, 1.0)
-                    };
+                    v[out] = v[arg].not();
                 }
                 RegOp::CopyReg(out, arg) => v[out] = v[arg],
                 RegOp::AddRegImm(out, arg, imm) => {
@@ -486,37 +480,13 @@ impl<const N: usize> TracingEvaluator for VmIntervalEval<N> {
                 RegOp::DivRegReg(out, lhs, rhs) => v[out] = v[lhs] / v[rhs],
                 RegOp::SubRegReg(out, lhs, rhs) => v[out] = v[lhs] - v[rhs],
                 RegOp::CompareRegReg(out, lhs, rhs) => {
-                    v[out] = if v[lhs].has_nan() || v[rhs].has_nan() {
-                        f32::NAN.into()
-                    } else if v[lhs].upper() < v[rhs].lower() {
-                        Interval::from(-1.0)
-                    } else if v[lhs].lower() > v[rhs].upper() {
-                        Interval::from(1.0)
-                    } else {
-                        Interval::new(-1.0, 1.0)
-                    };
+                    v[out] = Interval::compare(v[lhs], v[rhs]);
                 }
                 RegOp::CompareRegImm(out, arg, imm) => {
-                    v[out] = if v[arg].has_nan() || imm.is_nan() {
-                        f32::NAN.into()
-                    } else if v[arg].upper() < imm {
-                        Interval::from(-1.0)
-                    } else if v[arg].lower() > imm {
-                        Interval::from(1.0)
-                    } else {
-                        Interval::new(-1.0, 1.0)
-                    };
+                    v[out] = Interval::compare(v[arg], imm);
                 }
                 RegOp::CompareImmReg(out, arg, imm) => {
-                    v[out] = if v[arg].has_nan() || imm.is_nan() {
-                        f32::NAN.into()
-                    } else if imm < v[arg].lower() {
-                        Interval::from(-1.0)
-                    } else if imm > v[arg].upper() {
-                        Interval::from(1.0)
-                    } else {
-                        Interval::new(-1.0, 1.0)
-                    };
+                    v[out] = Interval::compare(imm, v[arg]);
                 }
                 RegOp::MinRegReg(out, lhs, rhs) => {
                     let (value, choice) = v[lhs].min_choice(v[rhs]);
@@ -1307,7 +1277,7 @@ impl<const N: usize> BulkEvaluator for VmGradSliceEval<N> {
                 }
                 RegOp::NotReg(out, arg) => {
                     for i in 0..size {
-                        v[out][i] = f32::from(v[arg][i].v == 0.0).into();
+                        v[out][i] = v[arg][i].not();
                     }
                 }
                 RegOp::CopyReg(out, arg) => {
@@ -1366,42 +1336,27 @@ impl<const N: usize> BulkEvaluator for VmGradSliceEval<N> {
                     }
                 }
                 RegOp::CompareImmReg(out, arg, imm) => {
+                    let imm: Grad = imm.into();
                     for i in 0..size {
-                        let p = imm
-                            .partial_cmp(&v[arg][i].v)
-                            .map(|c| c as i8 as f32)
-                            .unwrap_or(f32::NAN);
-                        v[out][i] = Grad::new(p, 0.0, 0.0, 0.0);
+                        v[out][i] = imm.compare(v[arg][i]);
                     }
                 }
                 RegOp::CompareRegImm(out, arg, imm) => {
+                    let imm = imm.into();
                     for i in 0..size {
-                        let p = v[arg][i]
-                            .v
-                            .partial_cmp(&imm)
-                            .map(|c| c as i8 as f32)
-                            .unwrap_or(f32::NAN);
-                        v[out][i] = Grad::new(p, 0.0, 0.0, 0.0);
+                        v[out][i] = v[arg][i].compare(imm);
                     }
                 }
                 RegOp::MinRegImm(out, arg, imm) => {
                     let imm: Grad = imm.into();
                     for i in 0..size {
-                        v[out][i] = if v[arg][i].v.is_nan() || imm.v.is_nan() {
-                            f32::NAN.into()
-                        } else {
-                            v[arg][i].min(imm)
-                        };
+                        v[out][i] = v[arg][i].min(imm);
                     }
                 }
                 RegOp::MaxRegImm(out, arg, imm) => {
                     let imm: Grad = imm.into();
                     for i in 0..size {
-                        v[out][i] = if v[arg][i].v.is_nan() || imm.v.is_nan() {
-                            f32::NAN.into()
-                        } else {
-                            v[arg][i].max(imm)
-                        };
+                        v[out][i] = v[arg][i].max(imm)
                     }
                 }
                 RegOp::ModRegReg(out, lhs, rhs) => {
@@ -1431,38 +1386,24 @@ impl<const N: usize> BulkEvaluator for VmGradSliceEval<N> {
                 }
                 RegOp::AndRegReg(out, lhs, rhs) => {
                     for i in 0..size {
-                        v[out][i] = if v[lhs][i].v == 0.0 {
-                            v[lhs][i]
-                        } else {
-                            v[rhs][i]
-                        };
+                        v[out][i] = v[lhs][i].and(v[rhs][i]);
                     }
                 }
                 RegOp::AndRegImm(out, arg, imm) => {
+                    let imm = imm.into();
                     for i in 0..size {
-                        v[out][i] = if v[arg][i].v == 0.0 {
-                            v[arg][i]
-                        } else {
-                            imm.into()
-                        };
+                        v[out][i] = v[arg][i].and(imm);
                     }
                 }
                 RegOp::OrRegReg(out, lhs, rhs) => {
                     for i in 0..size {
-                        v[out][i] = if v[lhs][i].v != 0.0 {
-                            v[lhs][i]
-                        } else {
-                            v[rhs][i]
-                        };
+                        v[out][i] = v[lhs][i].or(v[rhs][i]);
                     }
                 }
                 RegOp::OrRegImm(out, arg, imm) => {
+                    let imm = imm.into();
                     for i in 0..size {
-                        v[out][i] = if v[arg][i].v != 0.0 {
-                            v[arg][i]
-                        } else {
-                            imm.into()
-                        };
+                        v[out][i] = v[arg][i].or(imm);
                     }
                 }
                 RegOp::DivRegReg(out, lhs, rhs) => {
@@ -1477,32 +1418,17 @@ impl<const N: usize> BulkEvaluator for VmGradSliceEval<N> {
                 }
                 RegOp::CompareRegReg(out, lhs, rhs) => {
                     for i in 0..size {
-                        let p = v[lhs][i]
-                            .v
-                            .partial_cmp(&v[rhs][i].v)
-                            .map(|c| c as i8 as f32)
-                            .unwrap_or(f32::NAN);
-                        v[out][i] = Grad::new(p, 0.0, 0.0, 0.0);
+                        v[out][i] = v[lhs][i].compare(v[rhs][i]);
                     }
                 }
                 RegOp::MinRegReg(out, lhs, rhs) => {
                     for i in 0..size {
-                        v[out][i] =
-                            if v[lhs][i].v.is_nan() || v[rhs][i].v.is_nan() {
-                                f32::NAN.into()
-                            } else {
-                                v[lhs][i].min(v[rhs][i])
-                            };
+                        v[out][i] = v[lhs][i].min(v[rhs][i]);
                     }
                 }
                 RegOp::MaxRegReg(out, lhs, rhs) => {
                     for i in 0..size {
-                        v[out][i] =
-                            if v[lhs][i].v.is_nan() || v[rhs][i].v.is_nan() {
-                                f32::NAN.into()
-                            } else {
-                                v[lhs][i].max(v[rhs][i])
-                            };
+                        v[out][i] = v[lhs][i].max(v[rhs][i]);
                     }
                 }
                 RegOp::CopyImm(out, imm) => {

--- a/fidget-core/src/vm/mod.rs
+++ b/fidget-core/src/vm/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     render::{RenderHints, TileSizes},
     shape::Shape,
-    types::{Grad, Interval},
+    types::{FloatExt, Grad, Interval},
     var::VarMap,
 };
 use std::sync::Arc;
@@ -633,63 +633,25 @@ impl<const N: usize> TracingEvaluator for VmPointEval<N> {
                     v[out] = v[arg] - imm;
                 }
                 RegOp::MinRegImm(out, arg, imm) => {
-                    let a = v[arg];
-                    let (choice, value) = if a < imm {
-                        (Choice::Left, a)
-                    } else if imm < a {
-                        (Choice::Right, imm)
-                    } else {
-                        (
-                            Choice::Both,
-                            if a.is_nan() || imm.is_nan() {
-                                f32::NAN
-                            } else {
-                                imm
-                            },
-                        )
-                    };
+                    let (value, choice) = v[arg].min_choice(imm);
                     v[out] = value;
                     *choices.next().unwrap() |= choice;
                     simplify |= choice != Choice::Both;
                 }
                 RegOp::MaxRegImm(out, arg, imm) => {
-                    let a = v[arg];
-                    let (choice, value) = if a > imm {
-                        (Choice::Left, a)
-                    } else if imm > a {
-                        (Choice::Right, imm)
-                    } else {
-                        (
-                            Choice::Both,
-                            if a.is_nan() || imm.is_nan() {
-                                f32::NAN
-                            } else {
-                                imm
-                            },
-                        )
-                    };
+                    let (value, choice) = v[arg].max_choice(imm);
                     v[out] = value;
                     *choices.next().unwrap() |= choice;
                     simplify |= choice != Choice::Both;
                 }
                 RegOp::AndRegImm(out, arg, imm) => {
-                    let a = v[arg];
-                    let (choice, value) = if a == 0.0 {
-                        (Choice::Left, a)
-                    } else {
-                        (Choice::Right, imm)
-                    };
+                    let (value, choice) = v[arg].and_choice(imm);
                     v[out] = value;
                     *choices.next().unwrap() |= choice;
                     simplify |= choice != Choice::Both;
                 }
                 RegOp::OrRegImm(out, arg, imm) => {
-                    let a = v[arg];
-                    let (choice, value) = if a != 0.0 {
-                        (Choice::Left, a)
-                    } else {
-                        (Choice::Right, imm)
-                    };
+                    let (value, choice) = v[arg].or_choice(imm);
                     v[out] = value;
                     *choices.next().unwrap() |= choice;
                     simplify |= choice != Choice::Both;
@@ -713,88 +675,37 @@ impl<const N: usize> TracingEvaluator for VmPointEval<N> {
                     v[out] = v[lhs] / v[rhs];
                 }
                 RegOp::CompareRegReg(out, lhs, rhs) => {
-                    v[out] = v[lhs]
-                        .partial_cmp(&v[rhs])
-                        .map(|c| c as i8 as f32)
-                        .unwrap_or(f32::NAN)
+                    v[out] = v[lhs].compare(v[rhs]);
                 }
                 RegOp::CompareRegImm(out, arg, imm) => {
-                    v[out] = v[arg]
-                        .partial_cmp(&imm)
-                        .map(|c| c as i8 as f32)
-                        .unwrap_or(f32::NAN)
+                    v[out] = v[arg].compare(imm);
                 }
                 RegOp::CompareImmReg(out, arg, imm) => {
-                    v[out] = imm
-                        .partial_cmp(&v[arg])
-                        .map(|c| c as i8 as f32)
-                        .unwrap_or(f32::NAN)
+                    v[out] = imm.compare(v[arg]);
                 }
                 RegOp::SubRegReg(out, lhs, rhs) => {
                     v[out] = v[lhs] - v[rhs];
                 }
                 RegOp::MinRegReg(out, lhs, rhs) => {
-                    let a = v[lhs];
-                    let b = v[rhs];
-                    let (choice, value) = if a < b {
-                        (Choice::Left, a)
-                    } else if b < a {
-                        (Choice::Right, b)
-                    } else {
-                        (
-                            Choice::Both,
-                            if a.is_nan() || b.is_nan() {
-                                f32::NAN
-                            } else {
-                                b
-                            },
-                        )
-                    };
+                    let (value, choice) = v[lhs].min_choice(v[rhs]);
                     v[out] = value;
                     *choices.next().unwrap() |= choice;
                     simplify |= choice != Choice::Both;
                 }
                 RegOp::MaxRegReg(out, lhs, rhs) => {
-                    let a = v[lhs];
-                    let b = v[rhs];
-                    let (choice, value) = if a > b {
-                        (Choice::Left, a)
-                    } else if b > a {
-                        (Choice::Right, b)
-                    } else {
-                        (
-                            Choice::Both,
-                            if a.is_nan() || b.is_nan() {
-                                f32::NAN
-                            } else {
-                                b
-                            },
-                        )
-                    };
+                    let (value, choice) = v[lhs].max_choice(v[rhs]);
                     v[out] = value;
                     *choices.next().unwrap() |= choice;
                     simplify |= choice != Choice::Both;
                 }
                 RegOp::AndRegReg(out, lhs, rhs) => {
-                    let a = v[lhs];
-                    let b = v[rhs];
-                    let (choice, value) = if a == 0.0 {
-                        (Choice::Left, a)
-                    } else {
-                        (Choice::Right, b)
-                    };
+                    let (value, choice) = v[lhs].and_choice(v[rhs]);
                     v[out] = value;
                     *choices.next().unwrap() |= choice;
                     simplify |= choice != Choice::Both;
                 }
                 RegOp::OrRegReg(out, lhs, rhs) => {
-                    let a = v[lhs];
-                    let b = v[rhs];
-                    let (choice, value) = if a != 0.0 {
-                        (Choice::Left, a)
-                    } else {
-                        (Choice::Right, b)
-                    };
+                    let (value, choice) = v[lhs].or_choice(v[rhs]);
                     v[out] = value;
                     *choices.next().unwrap() |= choice;
                     simplify |= choice != Choice::Both;
@@ -1018,48 +929,32 @@ impl<const N: usize> BulkEvaluator for VmFloatSliceEval<N> {
                 }
                 RegOp::CompareImmReg(out, arg, imm) => {
                     for i in 0..size {
-                        v[out][i] = imm
-                            .partial_cmp(&v[arg][i])
-                            .map(|c| c as i8 as f32)
-                            .unwrap_or(f32::NAN)
+                        v[out][i] = imm.compare(v[arg][i]);
                     }
                 }
                 RegOp::CompareRegImm(out, arg, imm) => {
                     for i in 0..size {
-                        v[out][i] = v[arg][i]
-                            .partial_cmp(&imm)
-                            .map(|c| c as i8 as f32)
-                            .unwrap_or(f32::NAN)
+                        v[out][i] = v[arg][i].compare(imm);
                     }
                 }
                 RegOp::MinRegImm(out, arg, imm) => {
                     for i in 0..size {
-                        v[out][i] = if v[arg][i].is_nan() || imm.is_nan() {
-                            f32::NAN
-                        } else {
-                            v[arg][i].min(imm)
-                        };
+                        v[out][i] = v[arg][i].min_choice(imm).0;
                     }
                 }
                 RegOp::MaxRegImm(out, arg, imm) => {
                     for i in 0..size {
-                        v[out][i] = if v[arg][i].is_nan() || imm.is_nan() {
-                            f32::NAN
-                        } else {
-                            v[arg][i].max(imm)
-                        };
+                        v[out][i] = v[arg][i].max_choice(imm).0;
                     }
                 }
                 RegOp::AndRegImm(out, arg, imm) => {
                     for i in 0..size {
-                        v[out][i] =
-                            if v[arg][i] == 0.0 { v[arg][i] } else { imm };
+                        v[out][i] = v[arg][i].and_choice(imm).0;
                     }
                 }
                 RegOp::OrRegImm(out, arg, imm) => {
                     for i in 0..size {
-                        v[out][i] =
-                            if v[arg][i] != 0.0 { v[arg][i] } else { imm };
+                        v[out][i] = v[arg][i].or_choice(imm).0;
                     }
                 }
                 RegOp::ModRegReg(out, lhs, rhs) => {
@@ -1099,48 +994,27 @@ impl<const N: usize> BulkEvaluator for VmFloatSliceEval<N> {
                 }
                 RegOp::CompareRegReg(out, lhs, rhs) => {
                     for i in 0..size {
-                        v[out][i] = v[lhs][i]
-                            .partial_cmp(&v[rhs][i])
-                            .map(|c| c as i8 as f32)
-                            .unwrap_or(f32::NAN)
+                        v[out][i] = v[lhs][i].compare(v[rhs][i]);
                     }
                 }
                 RegOp::MinRegReg(out, lhs, rhs) => {
                     for i in 0..size {
-                        v[out][i] = if v[lhs][i].is_nan() || v[rhs][i].is_nan()
-                        {
-                            f32::NAN
-                        } else {
-                            v[lhs][i].min(v[rhs][i])
-                        };
+                        v[out][i] = v[lhs][i].min_choice(v[rhs][i]).0;
                     }
                 }
                 RegOp::MaxRegReg(out, lhs, rhs) => {
                     for i in 0..size {
-                        v[out][i] = if v[lhs][i].is_nan() || v[rhs][i].is_nan()
-                        {
-                            f32::NAN
-                        } else {
-                            v[lhs][i].max(v[rhs][i])
-                        };
+                        v[out][i] = v[lhs][i].max_choice(v[rhs][i]).0;
                     }
                 }
                 RegOp::AndRegReg(out, lhs, rhs) => {
                     for i in 0..size {
-                        v[out][i] = if v[lhs][i] == 0.0 {
-                            v[lhs][i]
-                        } else {
-                            v[rhs][i]
-                        };
+                        v[out][i] = v[lhs][i].and_choice(v[rhs][i]).0;
                     }
                 }
                 RegOp::OrRegReg(out, lhs, rhs) => {
                     for i in 0..size {
-                        v[out][i] = if v[lhs][i] != 0.0 {
-                            v[lhs][i]
-                        } else {
-                            v[rhs][i]
-                        };
+                        v[out][i] = v[lhs][i].or_choice(v[rhs][i]).0;
                     }
                 }
                 RegOp::CopyImm(out, imm) => {


### PR DESCRIPTION
Some operations were defined canonically in `fidget-core/src/vm/mod.rs` based on the VM implementation.  This PR moves them upstream to methods in `Interval` and `Grad`, then adds a new `FloatExt` trait for `f32` implementations.

This somewhat addresses #451, though not completely.