### PR TITLE
Fix alignment when reading from `Grad` slice in JIT code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
   parallelism to really kick in – but it's useful for consistency.
 - Move more VM functions onto `Grad` and `Interval` (out of the VM
   implementation); add a `FloatExt` trait which adds them to `f32` as well.
+- Fix a JIT bug in the gradient evaluator on Windows, where we assumed that
+  input `&[Grad]` slices were aligned to 16 bytes.  This caused a Access
+  Violation error code when running the JITted function (0xC0000005).
 
 # 0.5.0
 This is a large release with a bunch of small features, reorganization, and one

--- a/fidget-core/src/eval/test/grad_slice.rs
+++ b/fidget-core/src/eval/test/grad_slice.rs
@@ -291,9 +291,9 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         let mut ctx = Context::new();
         let a = ctx.x();
         let b = ctx.y();
-        let b = ctx.add(a, b).unwrap();
+        let sum = ctx.add(a, b).unwrap();
 
-        let shape = F::new(&ctx, &[b]).unwrap();
+        let shape = F::new(&ctx, &[sum]).unwrap();
         let mut eval = F::new_grad_slice_eval();
         let tape = shape.grad_slice_tape(Default::default());
 

--- a/fidget-core/src/eval/test/grad_slice.rs
+++ b/fidget-core/src/eval/test/grad_slice.rs
@@ -287,6 +287,32 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         );
     }
 
+    pub fn test_g_add() {
+        let mut ctx = Context::new();
+        let a = ctx.x();
+        let b = ctx.y();
+        let b = ctx.add(a, b).unwrap();
+
+        let shape = F::new(&ctx, &[b]).unwrap();
+        let mut eval = F::new_grad_slice_eval();
+        let tape = shape.grad_slice_tape(Default::default());
+
+        // This form happens to produce input arrays that aren't aligned to 16
+        // bytes on Windows, which exercise a vmovups / vmovaps distinction.
+        assert_eq!(
+            &eval
+                .eval(
+                    &tape,
+                    &[
+                        [0.0, 1.0].map(Grad::from).as_slice(),
+                        [2.0, 3.0].map(Grad::from).as_slice()
+                    ]
+                )
+                .unwrap()[0],
+            [2.0.into(), 4.0.into()]
+        );
+    }
+
     pub fn test_g_not() {
         let mut ctx = Context::new();
         let x = ctx.x();
@@ -713,6 +739,7 @@ macro_rules! grad_slice_tests {
         $crate::grad_test!(test_g_mul, $t);
         $crate::grad_test!(test_g_min, $t);
         $crate::grad_test!(test_g_max, $t);
+        $crate::grad_test!(test_g_add, $t);
         $crate::grad_test!(test_g_min_max, $t);
         $crate::grad_test!(test_g_not, $t);
         $crate::grad_test!(test_g_div, $t);

--- a/fidget-jit/src/x86_64/grad_slice.rs
+++ b/fidget-jit/src/x86_64/grad_slice.rs
@@ -85,7 +85,6 @@ impl Assembler for GradSliceAssembler {
             + STACK_SIZE_LOWER as u32)
             .try_into()
             .unwrap();
-        // XXX could we use vmovaps here instead?
         dynasm!(self.0.ops
             ; vmovups [rsp + sp_offset], Rx(reg(src_reg))
         );
@@ -94,7 +93,7 @@ impl Assembler for GradSliceAssembler {
         let pos = 8 * i32::try_from(src_arg).unwrap();
         dynasm!(self.0.ops
             ; mov r8, [rdi + pos]   // read the *const float from the array
-            ; vmovaps Rx(reg(out_reg)), [r8 + rcx] // offset by array
+            ; vmovups Rx(reg(out_reg)), [r8 + rcx] // offset by array
         );
     }
 


### PR DESCRIPTION
The first commit adds a unit test (so that we can see it fail in CI); the second should fix it.