### PR TITLE
Optimize trig functions when intervals are single values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Fix a JIT bug in the gradient evaluator on Windows, where we assumed that
   input `&[Grad]` slices were aligned to 16 bytes.  This caused a Access
   Violation error code when running the JITted function (0xC0000005).
+- Add fast path for interval trigonometry functions when `lower == upper`
 
 # 0.5.0
 This is a large release with a bunch of small features, reorganization, and one

--- a/fidget-core/src/types/interval.rs
+++ b/fidget-core/src/types/interval.rs
@@ -138,6 +138,8 @@ impl Interval {
             f32::NAN.into()
         } else if self.width() >= TAU {
             Interval::new(-1.0, 1.0)
+        } else if self.lower() == self.upper() {
+            self.lower.sin().into()
         } else {
             use Quadrant::*;
             let lower_quadrant = Self::quadrant(self.lower);
@@ -188,6 +190,8 @@ impl Interval {
             f32::NAN.into()
         } else if self.width() >= TAU {
             Interval::new(-1.0, 1.0)
+        } else if self.lower() == self.upper() {
+            self.lower.cos().into()
         } else {
             let lower_quadrant = Self::quadrant(self.lower);
             let upper_quadrant = Self::quadrant(self.upper);
@@ -237,6 +241,8 @@ impl Interval {
         let size = self.upper - self.lower;
         if size >= std::f32::consts::PI {
             f32::NAN.into()
+        } else if self.lower() == self.upper() {
+            self.lower.tan().into()
         } else {
             let lower = self.lower.tan();
             let upper = self.upper.tan();
@@ -254,6 +260,8 @@ impl Interval {
     pub fn asin(self) -> Self {
         if self.lower < -1.0 || self.upper > 1.0 {
             f32::NAN.into()
+        } else if self.lower() == self.upper() {
+            self.lower.asin().into()
         } else {
             Interval::new(self.lower.asin(), self.upper.asin())
         }
@@ -265,6 +273,8 @@ impl Interval {
     pub fn acos(self) -> Self {
         if self.lower < -1.0 || self.upper > 1.0 {
             f32::NAN.into()
+        } else if self.lower() == self.upper() {
+            self.lower.acos().into()
         } else {
             Interval::new(self.upper.acos(), self.lower.acos())
         }

--- a/fidget-wgpu/src/shaders/interval_ops.wgsl
+++ b/fidget-wgpu/src/shaders/interval_ops.wgsl
@@ -78,6 +78,8 @@ fn op_square(lhs: Value) -> Value {
 fn op_sin(lhs: Value) -> Value {
     if has_nan(lhs) {
         return nan_i();
+    } else if lhs.v[0] == lhs.v[1] {
+        return Value(vec2f(sin(lhs.v[0])));
     } else {
         return Value(vec2f(-1.0, 1.0));
     }
@@ -86,6 +88,8 @@ fn op_sin(lhs: Value) -> Value {
 fn op_cos(lhs: Value) -> Value {
     if has_nan(lhs) {
         return nan_i();
+    } else if lhs.v[0] == lhs.v[1] {
+        return Value(vec2f(cos(lhs.v[0])));
     } else {
         return Value(vec2f(-1.0, 1.0));
     }
@@ -95,6 +99,8 @@ fn op_tan(lhs: Value) -> Value {
     let size = lhs.v[1] - lhs.v[0];
     if size >= 3.14159265f {
         return nan_i();
+    } else if lhs.v[0] == lhs.v[1] {
+        return Value(vec2f(tan(lhs.v[0])));
     } else {
         let lower = tan(lhs.v[0]);
         let upper = tan(lhs.v[1]);
@@ -109,6 +115,8 @@ fn op_tan(lhs: Value) -> Value {
 fn op_asin(lhs: Value) -> Value {
     if lhs.v[0] < -1.0 || lhs.v[1] > 1.0 {
         return nan_i();
+    } else if lhs.v[0] == lhs.v[1] {
+        return Value(vec2f(asin(lhs.v[0])));
     } else {
         return Value(asin(lhs.v));
     }
@@ -117,6 +125,8 @@ fn op_asin(lhs: Value) -> Value {
 fn op_acos(lhs: Value) -> Value {
     if lhs.v[0] < -1.0 || lhs.v[1] > 1.0 {
         return nan_i();
+    } else if lhs.v[0] == lhs.v[1] {
+        return Value(vec2f(acos(lhs.v[0])));
     } else {
         return Value(acos(lhs.v).yx);
     }


### PR DESCRIPTION
This helps for fast evaluation of Perlin noise functions (coming in #453)