### PR TITLE
Use `f32` everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,15 @@
 - Add new `rand` and `mix` opcodes, which can be used for deterministic
   pseudo-random number generation.  There are also examples of single-octave and
   multi-octave Perlin noise in the repository showing how these can be used.
+- **Switch to using `f32` everywhere**.  Fidget's evaluators always used `f32`
+  internally, but other components (e.g. constants in a `Context`) were `f64`.
+  Using `f32` everywhere makes this more consistent, and lets us remove a bunch
+  of annoying workarounds (e.g epsilons scattered throughout the evaluator test
+  suite).
+    - As a side effect, the evaluator test suite now confirms that evaluators
+      **agree exactly** with the canonical operator definition.  This required
+      removing the JIT implementation for `modulo`, which was not exactly in
+      agreement with the non-JIT implementation.
 
 # 0.5.0
 This is a large release with a bunch of small features, reorganization, and one

--- a/fidget-core/src/compiler/ssa_tape.rs
+++ b/fidget-core/src/compiler/ssa_tape.rs
@@ -61,9 +61,7 @@ impl SsaTape {
             }
             let op = ctx.get_op(node).ok_or(BadNode)?;
             let prev = match op {
-                Op::Const(c) => {
-                    mapping.insert(node, Slot::Immediate(c.0 as f32))
-                }
+                Op::Const(c) => mapping.insert(node, Slot::Immediate(c.0)),
                 _ => {
                     if let Op::Input(v) = op {
                         vars.insert(*v);

--- a/fidget-core/src/context/mod.rs
+++ b/fidget-core/src/context/mod.rs
@@ -101,7 +101,7 @@ impl Context {
     ///
     /// If the node is invalid for this tree, returns an error; if the node is
     /// not a constant, returns `Ok(None)`.
-    pub fn get_const(&self, n: Node) -> Result<f64, ConstError> {
+    pub fn get_const(&self, n: Node) -> Result<f32, ConstError> {
         match self.get_op(n) {
             Some(Op::Const(c)) => Ok(c.0),
             Some(_) => Err(ConstError::NotAConst),
@@ -177,7 +177,7 @@ impl Context {
     /// let v = ctx.constant(3.0);
     /// assert_eq!(ctx.eval_xyz(v, 0.0, 0.0, 0.0).unwrap(), 3.0);
     /// ```
-    pub fn constant(&mut self, f: f64) -> Node {
+    pub fn constant(&mut self, f: f32) -> Node {
         self.ops.insert(Op::Const(OrderedFloat(f)))
     }
 
@@ -466,7 +466,7 @@ impl Context {
     /// # let mut ctx = fidget_core::context::Context::new();
     /// let x = ctx.x();
     /// let op = ctx.sin(x).unwrap();
-    /// let v = ctx.eval_xyz(op, std::f64::consts::PI / 2.0, 0.0, 0.0).unwrap();
+    /// let v = ctx.eval_xyz(op, std::f32::consts::PI / 2.0, 0.0, 0.0).unwrap();
     /// assert_eq!(v, 1.0);
     /// ```
     pub fn sin<A: IntoNode>(&mut self, a: A) -> Result<Node, BadNode> {
@@ -629,7 +629,7 @@ impl Context {
     /// let y = ctx.y();
     /// let op = ctx.atan2(y, x).unwrap();
     /// let v = ctx.eval_xyz(op, 0.0, 1.0, 0.0).unwrap();
-    /// assert_eq!(v, std::f64::consts::FRAC_PI_2);
+    /// assert_eq!(v, std::f32::consts::FRAC_PI_2);
     /// ```
     pub fn atan2<A: IntoNode, B: IntoNode>(
         &mut self,
@@ -760,8 +760,8 @@ impl Context {
     ///
     /// assert_eq!(ctx.eval_xyz(if_else, 0.0, 2.0, 3.0).unwrap(), 3.0);
     /// assert_eq!(ctx.eval_xyz(if_else, 1.0, 2.0, 3.0).unwrap(), 2.0);
-    /// assert_eq!(ctx.eval_xyz(if_else, 0.0, f64::NAN, 3.0).unwrap(), 3.0);
-    /// assert_eq!(ctx.eval_xyz(if_else, 1.0, 2.0, f64::NAN).unwrap(), 2.0);
+    /// assert_eq!(ctx.eval_xyz(if_else, 0.0, f32::NAN, 3.0).unwrap(), 3.0);
+    /// assert_eq!(ctx.eval_xyz(if_else, 1.0, 2.0, f32::NAN).unwrap(), 2.0);
     /// ```
     pub fn if_nonzero_else<Condition: IntoNode, A: IntoNode, B: IntoNode>(
         &mut self,
@@ -798,10 +798,10 @@ impl Context {
     pub fn eval_xyz(
         &self,
         root: Node,
-        x: f64,
-        y: f64,
-        z: f64,
-    ) -> Result<f64, EvalError> {
+        x: f32,
+        y: f32,
+        z: f32,
+    ) -> Result<f32, EvalError> {
         let vars = [(Var::X, x), (Var::Y, y), (Var::Z, z)]
             .into_iter()
             .collect();
@@ -815,8 +815,8 @@ impl Context {
     pub fn eval(
         &self,
         root: Node,
-        vars: &HashMap<Var, f64>,
-    ) -> Result<f64, EvalError> {
+        vars: &HashMap<Var, f32>,
+    ) -> Result<f32, EvalError> {
         let mut cache = vec![None; self.ops.len()].into();
         self.eval_inner(root, vars, &mut cache)
     }
@@ -824,9 +824,9 @@ impl Context {
     fn eval_inner(
         &self,
         node: Node,
-        vars: &HashMap<Var, f64>,
-        cache: &mut IndexVec<Option<f64>, Node>,
-    ) -> Result<f64, EvalError> {
+        vars: &HashMap<Var, f32>,
+        cache: &mut IndexVec<Option<f32>, Node>,
+    ) -> Result<f32, EvalError> {
         if node.0 >= cache.len() {
             return Err(EvalError::BadNode(BadNode));
         }
@@ -1035,7 +1035,7 @@ impl Context {
         let mut axes = vec![(self.x(), self.y(), self.z())];
         let mut todo = vec![Action::Down(tree.arc())];
         let mut stack = vec![];
-        let mut affine: Vec<Matrix4<f64>> = vec![];
+        let mut affine: Vec<Matrix4<f32>> = vec![];
 
         // Cache of TreeOp -> Node mapping under a particular frame (axes)
         //
@@ -1585,12 +1585,6 @@ impl IntoNode for Node {
 }
 
 impl IntoNode for f32 {
-    fn into_node(self, ctx: &mut Context) -> Result<Node, BadNode> {
-        Ok(ctx.constant(self as f64))
-    }
-}
-
-impl IntoNode for f64 {
     fn into_node(self, ctx: &mut Context) -> Result<Node, BadNode> {
         Ok(ctx.constant(self))
     }

--- a/fidget-core/src/context/op.rs
+++ b/fidget-core/src/context/op.rs
@@ -1,5 +1,6 @@
 use crate::{
     context::{Node, indexed::Index},
+    types::FloatExt,
     var::Var,
 };
 use ordered_float::OrderedFloat;
@@ -48,45 +49,27 @@ pub enum BinaryOpcode {
 
 impl BinaryOpcode {
     /// Evaluates the opcode
-    pub fn eval(&self, a: f64, b: f64) -> f64 {
+    pub fn eval(&self, a: f32, b: f32) -> f32 {
         match self {
             BinaryOpcode::Add => a + b,
             BinaryOpcode::Sub => a - b,
             BinaryOpcode::Mul => a * b,
             BinaryOpcode::Div => a / b,
             BinaryOpcode::Atan => a.atan2(b),
-            BinaryOpcode::Min => a.min(b),
-            BinaryOpcode::Max => a.max(b),
-            BinaryOpcode::Compare => a
-                .partial_cmp(&b)
-                .map(|i| i as i8 as f64)
-                .unwrap_or(f64::NAN),
+            BinaryOpcode::Min => a.min_choice(b).0,
+            BinaryOpcode::Max => a.max_choice(b).0,
+            BinaryOpcode::Compare => a.compare(b),
             BinaryOpcode::Mod => a.rem_euclid(b),
-            BinaryOpcode::And => {
-                if a == 0.0 {
-                    a
-                } else {
-                    b
-                }
-            }
-            BinaryOpcode::Or => {
-                if a != 0.0 {
-                    a
-                } else {
-                    b
-                }
-            }
-            BinaryOpcode::Mix => f32::from_bits(crate::rng::mix(
-                (a as f32).to_bits(),
-                (b as f32).to_bits(),
-            )) as f64,
+            BinaryOpcode::And => a.and_choice(b).0,
+            BinaryOpcode::Or => a.or_choice(b).0,
+            BinaryOpcode::Mix => a.mix(b),
         }
     }
 }
 
 impl UnaryOpcode {
     /// Evaluates the opcode
-    pub fn eval(&self, a: f64) -> f64 {
+    pub fn eval(&self, a: f32) -> f32 {
         match self {
             UnaryOpcode::Neg => -a,
             UnaryOpcode::Abs => a.abs(),
@@ -104,8 +87,8 @@ impl UnaryOpcode {
             UnaryOpcode::Atan => a.atan(),
             UnaryOpcode::Exp => a.exp(),
             UnaryOpcode::Ln => a.ln(),
-            UnaryOpcode::Not => (a == 0.0).into(),
-            UnaryOpcode::Rand => crate::rng::rand((a as f32).to_bits()) as f64,
+            UnaryOpcode::Not => a.not(),
+            UnaryOpcode::Rand => a.rand(),
         }
     }
 }
@@ -123,7 +106,7 @@ impl UnaryOpcode {
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub enum Op {
     Input(Var),
-    Const(OrderedFloat<f64>),
+    Const(OrderedFloat<f32>),
     Binary(BinaryOpcode, Node, Node),
     Unary(UnaryOpcode, Node),
 }

--- a/fidget-core/src/context/tree.rs
+++ b/fidget-core/src/context/tree.rs
@@ -14,7 +14,7 @@ use std::{cmp::Ordering, sync::Arc};
 pub enum TreeOp {
     /// Input (an arbitrary [`Var`])
     Input(Var),
-    Const(f64),
+    Const(f32),
     Binary(BinaryOpcode, Arc<TreeOp>, Arc<TreeOp>),
     Unary(UnaryOpcode, Arc<TreeOp>),
     /// Lazy remapping of trees
@@ -36,7 +36,7 @@ pub enum TreeOp {
     /// be transformed with the provided affine matrix.
     RemapAffine {
         target: Arc<TreeOp>,
-        mat: nalgebra::Affine3<f64>,
+        mat: nalgebra::Affine3<f32>,
     },
 }
 
@@ -202,21 +202,15 @@ impl std::hash::Hash for TreeOp {
     }
 }
 
-impl From<f64> for Tree {
-    fn from(v: f64) -> Tree {
-        Tree::constant(v)
-    }
-}
-
 impl From<f32> for Tree {
     fn from(v: f32) -> Tree {
-        Tree::constant(v as f64)
+        Tree::constant(v)
     }
 }
 
 impl From<i32> for Tree {
     fn from(v: i32) -> Tree {
-        Tree::constant(v as f64)
+        Tree::constant(v as f32)
     }
 }
 
@@ -294,7 +288,7 @@ impl Tree {
     ///
     /// The remapping is lazy; it is not evaluated until the tree is imported
     /// into a `Context`.
-    pub fn remap_affine(&self, mat: nalgebra::Affine3<f64>) -> Tree {
+    pub fn remap_affine(&self, mat: nalgebra::Affine3<f32>) -> Tree {
         // Flatten affine trees
         let out = match &*self.0 {
             TreeOp::RemapAffine { target, mat: next } => TreeOp::RemapAffine {
@@ -376,7 +370,7 @@ impl Tree {
     pub fn z() -> Self {
         Tree(Arc::new(TreeOp::Input(Var::Z)))
     }
-    pub fn constant(f: f64) -> Self {
+    pub fn constant(f: f32) -> Self {
         Tree(Arc::new(TreeOp::Const(f)))
     }
     fn op_unary(a: Tree, op: UnaryOpcode) -> Self {
@@ -487,12 +481,6 @@ macro_rules! impl_binary {
                 Tree::op_binary(self.into(), other, BinaryOpcode::$op)
             }
         }
-        impl std::ops::$op<Tree> for f64 {
-            type Output = Tree;
-            fn $base_fn(self, other: Tree) -> Tree {
-                Tree::op_binary(self.into(), other, BinaryOpcode::$op)
-            }
-        }
     };
 }
 
@@ -595,9 +583,9 @@ mod test {
     fn test_remap_affine() {
         let s = Tree::x();
         // Two rotations by 45° -> 90°
-        let t = nalgebra::convert(nalgebra::Rotation3::<f64>::from_axis_angle(
-            &nalgebra::Vector3::<f64>::z_axis(),
-            -std::f64::consts::FRAC_PI_4,
+        let t = nalgebra::convert(nalgebra::Rotation3::<f32>::from_axis_angle(
+            &nalgebra::Vector3::<f32>::z_axis(),
+            -std::f32::consts::FRAC_PI_4,
         ));
         let s = s.remap_affine(t);
         let s = s.remap_affine(t);
@@ -618,11 +606,11 @@ mod test {
 
     #[test]
     fn test_remap_order() {
-        let translate = nalgebra::convert(nalgebra::Translation3::<f64>::new(
+        let translate = nalgebra::convert(nalgebra::Translation3::<f32>::new(
             3.0, 0.0, 0.0,
         ));
         let scale =
-            nalgebra::convert(nalgebra::Scale3::<f64>::new(0.5, 0.5, 0.5));
+            nalgebra::convert(nalgebra::Scale3::<f32>::new(0.5, 0.5, 0.5));
 
         let s = Tree::x();
         let s = s.remap_affine(translate);
@@ -828,7 +816,7 @@ mod test {
         assert_eq!(ctx.get_const(root).unwrap(), 27.0);
         ctx.clear();
         let root = ctx.import(&c);
-        assert_eq!(ctx.get_const(root).unwrap(), 1.0 / 27.0);
+        assert_eq!(ctx.get_const(root).unwrap(), (1f32 / 3.0).powi(3));
         ctx.clear();
         let root = ctx.import(&d);
         assert_eq!(ctx.get_const(root).unwrap(), 1.0);
@@ -839,14 +827,14 @@ mod test {
         #[derive(facet::Facet)]
         struct Transform {
             tree: Tree,
-            x: f64,
+            x: f32,
         }
 
         let builder = facet::Partial::alloc::<Transform>()
             .unwrap()
             .set_field("tree", Tree::x() + 2.0 * Tree::y())
             .unwrap()
-            .set_field("x", 1.0)
+            .set_field("x", 1.0f32)
             .unwrap();
         let t: Transform = builder.build().unwrap().materialize().unwrap();
         assert_eq!(t.x, 1.0);
@@ -909,7 +897,7 @@ mod test {
         assert_eq!(a, b);
 
         let affine: nalgebra::Affine3<_> =
-            nalgebra::convert(nalgebra::Translation3::new(1.0, 2.0, f64::NAN));
+            nalgebra::convert(nalgebra::Translation3::new(1.0, 2.0, f32::NAN));
         let a = Tree::x().remap_affine(affine);
         let b = Tree::x().remap_affine(affine);
         assert_eq!(a, b);
@@ -928,7 +916,7 @@ mod test {
         assert_ne!(state.hash_one(&a), state.hash_one(&c));
 
         let affine: nalgebra::Affine3<_> =
-            nalgebra::convert(nalgebra::Translation3::new(1.0, 2.0, f64::NAN));
+            nalgebra::convert(nalgebra::Translation3::new(1.0, 2.0, f32::NAN));
         let a = Tree::x().remap_affine(affine);
         let b = Tree::x().remap_affine(affine);
         assert_eq!(state.hash_one(&a), state.hash_one(&b));

--- a/fidget-core/src/eval/test/float_slice.rs
+++ b/fidget-core/src/eval/test/float_slice.rs
@@ -416,17 +416,18 @@ impl<F: Function + MathFunction> TestFloatSlice<F> {
         lhs: &[f32],
         rhs: &[f32],
         out: &[f32],
-        g: impl Fn(f32, f32) -> f32,
+        constant_folded: bool,
         name: &str,
     ) {
         for ((a, b), &o) in lhs.iter().zip(rhs).zip(out.iter()) {
-            let v = g(*a, *b);
+            let v = C::eval(*a, *b);
             let err = (v - o).abs();
             assert!(
                 (o == v)
                     || C::discontinuous_at(*a, *b)
                     || err < 1e-6
-                    || (v.is_nan() && o.is_nan()),
+                    || (v.is_nan() && o.is_nan())
+                    || (v.is_nan() && constant_folded),
                 "mismatch in '{name}' at {a} {b}: {v} != {o} ({err})"
             )
         }
@@ -444,6 +445,7 @@ impl<F: Function + MathFunction> TestFloatSlice<F> {
             let mut rgsa = args.clone();
             rgsa.rotate_left(rot);
             let node = C::build(&mut ctx, va, vb);
+            let constant_folded = ctx.get_const(node).is_ok();
 
             let shape = F::new(&ctx, &[node]).unwrap();
             let mut eval = F::new_float_slice_eval();
@@ -464,7 +466,7 @@ impl<F: Function + MathFunction> TestFloatSlice<F> {
                 &args,
                 &rgsa,
                 &out[0],
-                C::eval_reg_reg_f32,
+                constant_folded,
                 &name,
             );
         }
@@ -482,6 +484,7 @@ impl<F: Function + MathFunction> TestFloatSlice<F> {
             args.rotate_left(rot);
             for rhs in args.iter() {
                 let node = C::build(&mut ctx, va, *rhs);
+                let constant_folded = ctx.get_const(node).is_ok();
 
                 let shape = F::new(&ctx, &[node]).unwrap();
                 let mut eval = F::new_float_slice_eval();
@@ -494,7 +497,7 @@ impl<F: Function + MathFunction> TestFloatSlice<F> {
                     &args,
                     &rhs,
                     &out[0],
-                    C::eval_reg_imm_f32,
+                    constant_folded,
                     &name,
                 );
             }
@@ -513,6 +516,7 @@ impl<F: Function + MathFunction> TestFloatSlice<F> {
             args.rotate_left(rot);
             for lhs in args.iter() {
                 let node = C::build(&mut ctx, *lhs, va);
+                let constant_folded = ctx.get_const(node).is_ok();
 
                 let shape = F::new(&ctx, &[node]).unwrap();
                 let mut eval = F::new_float_slice_eval();
@@ -525,7 +529,7 @@ impl<F: Function + MathFunction> TestFloatSlice<F> {
                     &lhs,
                     &args,
                     &out[0],
-                    C::eval_imm_reg_f32,
+                    constant_folded,
                     &name,
                 );
             }

--- a/fidget-core/src/eval/test/float_slice.rs
+++ b/fidget-core/src/eval/test/float_slice.rs
@@ -424,7 +424,6 @@ impl<F: Function + MathFunction> TestFloatSlice<F> {
             let err = (v - o).abs();
             assert!(
                 (o == v)
-                    || C::discontinuous_at(*a, *b)
                     || err < 1e-6
                     || (v.is_nan() && o.is_nan())
                     || (v.is_nan() && constant_folded),

--- a/fidget-core/src/eval/test/float_slice.rs
+++ b/fidget-core/src/eval/test/float_slice.rs
@@ -303,13 +303,13 @@ impl<F: Function + MathFunction> TestFloatSlice<F> {
 
         let cmp = eval.eval(&tape, &x, &y, &z).unwrap();
         for (i, (a, b)) in out[0].iter().zip(cmp.iter()).enumerate() {
-            let err = (a - b).abs();
             assert!(
-                err < 1e-6,
-                "mismatch at index {i} ({}, {}, {}): {a} != {b} [{err}], {}",
+                a == b,
+                "mismatch at index {i} ({}, {}, {}): {a} != {b} [{}], {}",
                 x[i],
                 y[i],
                 z[i],
+                a - b,
                 depth,
             );
         }
@@ -403,11 +403,11 @@ impl<F: Function + MathFunction> TestFloatSlice<F> {
         let out = eval.eval(&tape, &[args.as_slice()]).unwrap();
         for (a, &o) in args.iter().zip(out[0].iter()) {
             let v = C::eval_f32(*a);
-            let err = (v - o).abs();
             assert!(
-                (o == v) || err < 1e-6 || (v.is_nan() && o.is_nan()),
-                "mismatch in '{}' at {a}: {v} != {o} ({err})",
+                (o == v) || (v.is_nan() && o.is_nan()),
+                "mismatch in '{}' at {a}: {v} != {o} ({})",
                 C::NAME,
+                o - v,
             )
         }
     }
@@ -421,13 +421,12 @@ impl<F: Function + MathFunction> TestFloatSlice<F> {
     ) {
         for ((a, b), &o) in lhs.iter().zip(rhs).zip(out.iter()) {
             let v = C::eval(*a, *b);
-            let err = (v - o).abs();
             assert!(
                 (o == v)
-                    || err < 1e-6
                     || (v.is_nan() && o.is_nan())
                     || (v.is_nan() && constant_folded),
-                "mismatch in '{name}' at {a} {b}: {v} != {o} ({err})"
+                "mismatch in '{name}' at {a} {b}: {v} != {o} ({})",
+                o - v
             )
         }
     }

--- a/fidget-core/src/eval/test/float_slice.rs
+++ b/fidget-core/src/eval/test/float_slice.rs
@@ -163,7 +163,7 @@ impl<F: Function + MathFunction> TestFloatSlice<F> {
         );
 
         // Test mix(reg, imm) and mix(imm, reg) with NAN
-        let n = ctx.constant(f64::NAN);
+        let n = ctx.constant(f32::NAN);
         let mix = ctx.mix(a, n).unwrap();
         let shape = F::new(&ctx, &[mix]).unwrap();
         let mut eval = F::new_float_slice_eval();
@@ -281,10 +281,8 @@ impl<F: Function + MathFunction> TestFloatSlice<F> {
         let out = eval.eval(&tape, &vs(&x, &y, &z)).unwrap();
 
         for (i, v) in out[0].iter().cloned().enumerate() {
-            let q = ctx
-                .eval_xyz(node, x[i] as f64, y[i] as f64, z[i] as f64)
-                .unwrap();
-            let err = (v as f64 - q).abs();
+            let q = ctx.eval_xyz(node, x[i], y[i], z[i]).unwrap();
+            let err = (v - q).abs();
             assert!(
                 err < 1e-2, // generous error bounds, for the 512-op case
                 "mismatch at index {i} ({}, {}, {}): {v} != {q} [{err}], {}",

--- a/fidget-core/src/eval/test/grad_slice.rs
+++ b/fidget-core/src/eval/test/grad_slice.rs
@@ -564,16 +564,13 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         const EPSILON: f32 = 1e-3; // hand-tuned value
         for ((a, b), &o) in lhs.iter().zip(rhs).zip(out.iter()) {
             let v = C::eval(*a, *b);
-            let err = (v - o.v).abs();
-            let err_frac = err / (v.abs()).max(o.v.abs());
             assert!(
                 o.v == v
-                    || err < 1e-6
-                    || err_frac < 1e-6
                     || (v.is_nan() && o.v.is_nan())
                     || (v.is_nan() && constant_folded),
                 "value mismatch in '{name}' at ({a}, {b}) => {o:?}: \
-                 {v} != {o} ({err})"
+                 {v} != {o} ({})",
+                o.v - v
             );
 
             if v.is_nan() {

--- a/fidget-core/src/eval/test/grad_slice.rs
+++ b/fidget-core/src/eval/test/grad_slice.rs
@@ -558,19 +558,20 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         lhs: &[f32],
         rhs: &[f32],
         out: &[Grad],
-        g: impl Fn(f32, f32) -> f32,
+        constant_folded: bool,
         name: &str,
     ) {
         const EPSILON: f32 = 1e-3; // hand-tuned value
         for ((a, b), &o) in lhs.iter().zip(rhs).zip(out.iter()) {
-            let v = g(*a, *b);
+            let v = C::eval(*a, *b);
             let err = (v - o.v).abs();
             let err_frac = err / (v.abs()).max(o.v.abs());
             assert!(
                 o.v == v
                     || err < 1e-6
                     || err_frac < 1e-6
-                    || (v.is_nan() && o.v.is_nan()),
+                    || (v.is_nan() && o.v.is_nan())
+                    || (v.is_nan() && constant_folded),
                 "value mismatch in '{name}' at ({a}, {b}) => {o:?}: \
                  {v} != {o} ({err})"
             );
@@ -588,11 +589,11 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
             if i == j {
                 let grad = o.d(i);
                 if grad < 1e9 && !grad.is_infinite() {
-                    let d = g(a + EPSILON, b + EPSILON);
+                    let d = C::eval(a + EPSILON, b + EPSILON);
                     let est_grad = (d - v) / EPSILON;
                     let mut err = (est_grad - grad).abs();
 
-                    let d = g(a - EPSILON, b);
+                    let d = C::eval(a - EPSILON, b);
                     let est_grad = (v - d) / EPSILON;
                     err = err.min((est_grad - grad).abs());
                     assert!(
@@ -608,11 +609,11 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
                     if grad < 1e9 && !grad.is_infinite() {
                         // Check both +epsilon and -epsilon positions, because
                         // they may be different if there are C1 discontinuities
-                        let d = g(a + EPSILON, b);
+                        let d = C::eval(a + EPSILON, b);
                         let est_grad = (d as f64 - v as f64) / EPSILON as f64;
                         let mut err = (est_grad - grad).abs();
 
-                        let d = g(a - EPSILON, b);
+                        let d = C::eval(a - EPSILON, b);
                         let est_grad = (v as f64 - d as f64) / EPSILON as f64;
                         err = err.min((est_grad - grad).abs());
                         assert!(
@@ -626,11 +627,11 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
                 if j < 3 {
                     let grad = o.d(j) as f64;
                     if grad < 1e9 && !grad.is_infinite() {
-                        let d = g(a, b + EPSILON);
+                        let d = C::eval(a, b + EPSILON);
                         let est_grad = (d - v) / EPSILON;
                         let mut err = (est_grad as f64 - grad).abs();
 
-                        let d = g(a, b - EPSILON);
+                        let d = C::eval(a, b - EPSILON);
                         let est_grad = (v - d) / EPSILON;
                         err = err.min((est_grad as f64 - grad).abs());
                         assert!(
@@ -658,6 +659,7 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
             for (i, &v) in inputs.iter().enumerate() {
                 for (j, &u) in inputs.iter().enumerate() {
                     let node = C::build(&mut ctx, v, u);
+                    let constant_folded = ctx.get_const(node).is_ok();
 
                     let shape = F::new(&ctx, &[node]).unwrap();
                     let tape = shape.grad_slice_tape(Default::default());
@@ -682,7 +684,7 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
                         &args,
                         rhs,
                         &out,
-                        C::eval_reg_reg_f32,
+                        constant_folded,
                         &name,
                     );
                 }
@@ -704,6 +706,7 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
             for (i, &v) in inputs.iter().enumerate() {
                 for rhs in args.iter() {
                     let node = C::build(&mut ctx, v, *rhs);
+                    let constant_folded = ctx.get_const(node).is_ok();
 
                     let shape = F::new(&ctx, &[node]).unwrap();
                     let tape = shape.grad_slice_tape(Default::default());
@@ -722,7 +725,7 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
                         &args,
                         &rhs,
                         &out,
-                        C::eval_reg_imm_f32,
+                        constant_folded,
                         &name,
                     );
                 }
@@ -744,6 +747,7 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
             for (i, &v) in inputs.iter().enumerate() {
                 for lhs in args.iter() {
                     let node = C::build(&mut ctx, *lhs, v);
+                    let constant_folded = ctx.get_const(node).is_ok();
 
                     let shape = F::new(&ctx, &[node]).unwrap();
                     let tape = shape.grad_slice_tape(Default::default());
@@ -762,7 +766,7 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
                         &lhs,
                         &args,
                         &out,
-                        C::eval_imm_reg_f32,
+                        constant_folded,
                         &name,
                     );
                 }

--- a/fidget-core/src/eval/test/grad_slice.rs
+++ b/fidget-core/src/eval/test/grad_slice.rs
@@ -465,10 +465,8 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
 
         // Compare values (the `.v` term) with the context's evaluator
         for (i, v) in out.iter().cloned().enumerate() {
-            let q = ctx
-                .eval_xyz(node, x[i] as f64, y[i] as f64, z[i] as f64)
-                .unwrap();
-            let err = (v.v as f64 - q).abs();
+            let q = ctx.eval_xyz(node, x[i], y[i], z[i]).unwrap();
+            let err = (v.v - q).abs();
             assert!(
                 err < 1e-2, // generous error bounds, for the 512-op case
                 "mismatch at index {i} ({}, {}, {}): {v:?} != {q} [{err}], {}",

--- a/fidget-core/src/eval/test/grad_slice.rs
+++ b/fidget-core/src/eval/test/grad_slice.rs
@@ -12,9 +12,6 @@ use crate::{
     vm::VmFunction,
 };
 
-/// Epsilon for gradient estimates
-const EPSILON: f64 = 1e-8;
-
 /// Helper struct to put constrains on our `Shape` object
 pub struct TestGradSlice<F>(std::marker::PhantomData<*const F>);
 
@@ -496,6 +493,7 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
     }
 
     pub fn test_unary<C: CanonicalUnaryOp>() {
+        const EPSILON: f32 = 1e-4; // hand-tuned value
         let args = test_args();
 
         let mut ctx = Context::new();
@@ -517,11 +515,11 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
                 .collect::<Vec<Grad>>();
             let out = eval.eval(&tape, &[args.as_slice()]).unwrap();
             for (a, &o) in args.iter().zip(out[0].iter()) {
-                let v = C::eval_f64(a.v as f64);
-                let err = (v as f32 - o.v).abs();
-                let err_frac = err / (v.abs() as f32).max(o.v.abs());
+                let v = C::eval_f32(a.v);
+                let err = (v - o.v).abs();
+                let err_frac = err / (v.abs()).max(o.v.abs());
                 assert!(
-                    o.v == v as f32
+                    o.v == v
                         || err < 1e-6
                         || err_frac < 1e-6
                         || (v.is_nan() && o.v.is_nan()),
@@ -533,18 +531,18 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
                     continue;
                 }
 
-                let grad = o.d(i);
+                let grad = o.d(i) as f64;
                 if !v.is_nan() && grad < 1e9 && !grad.is_infinite() {
-                    let a = a.v as f64;
-                    let d = C::eval_f64(a + EPSILON);
-                    let est_grad = (d - v) / EPSILON;
-                    let mut err = (est_grad as f32 - grad).abs();
+                    let a = a.v;
+                    let d = C::eval_f32(a + EPSILON);
+                    let est_grad = (d as f64 - v as f64) / EPSILON as f64;
+                    let mut err = (est_grad - grad).abs();
 
-                    let d = C::eval_f64(a - EPSILON);
-                    let est_grad = (v - d) / EPSILON;
-                    err = err.min((est_grad as f32 - grad).abs());
+                    let d = C::eval_f32(a - EPSILON);
+                    let est_grad = (v as f64 - d as f64) / EPSILON as f64;
+                    err = err.min((est_grad - grad).abs());
                     assert!(
-                        err.min(err / grad.abs()) < 1e-3,
+                        err.min(err / grad.abs()) < 1e-2,
                         "gradient estimate mismatch in '{}' at {a} => {o:?}:
                         {est_grad} != {grad} ({err})",
                         C::NAME,
@@ -560,15 +558,16 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
         lhs: &[f32],
         rhs: &[f32],
         out: &[Grad],
-        g: impl Fn(f64, f64) -> f64,
+        g: impl Fn(f32, f32) -> f32,
         name: &str,
     ) {
+        const EPSILON: f32 = 1e-3; // hand-tuned value
         for ((a, b), &o) in lhs.iter().zip(rhs).zip(out.iter()) {
-            let v = g(*a as f64, *b as f64);
-            let err = (v as f32 - o.v).abs();
-            let err_frac = err / (v.abs() as f32).max(o.v.abs());
+            let v = g(*a, *b);
+            let err = (v - o.v).abs();
+            let err_frac = err / (v.abs()).max(o.v.abs());
             assert!(
-                (o.v == v as f32)
+                o.v == v
                     || err < 1e-6
                     || err_frac < 1e-6
                     || (v.is_nan() && o.v.is_nan()),
@@ -584,20 +583,20 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
                 continue;
             }
 
-            let a = *a as f64;
-            let b = *b as f64;
+            let a = *a;
+            let b = *b;
             if i == j {
                 let grad = o.d(i);
                 if grad < 1e9 && !grad.is_infinite() {
                     let d = g(a + EPSILON, b + EPSILON);
                     let est_grad = (d - v) / EPSILON;
-                    let mut err = (est_grad as f32 - grad).abs();
+                    let mut err = (est_grad - grad).abs();
 
                     let d = g(a - EPSILON, b);
                     let est_grad = (v - d) / EPSILON;
-                    err = err.min((est_grad as f32 - grad).abs());
+                    err = err.min((est_grad - grad).abs());
                     assert!(
-                        err.min(err / grad.abs()) < 1e-3,
+                        err.min(err / grad.abs()) < 1e-2,
                         "gradient estimate mismatch in '{name}' at \
                          ({a} + epsilon, {b}) => {o:?}: \
                          {est_grad} != {grad} ({err})"
@@ -605,19 +604,19 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
                 }
             } else {
                 if i < 3 {
-                    let grad = o.d(i);
+                    let grad = o.d(i) as f64;
                     if grad < 1e9 && !grad.is_infinite() {
                         // Check both +epsilon and -epsilon positions, because
                         // they may be different if there are C1 discontinuities
                         let d = g(a + EPSILON, b);
-                        let est_grad = (d - v) / EPSILON;
-                        let mut err = (est_grad as f32 - grad).abs();
+                        let est_grad = (d as f64 - v as f64) / EPSILON as f64;
+                        let mut err = (est_grad - grad).abs();
 
                         let d = g(a - EPSILON, b);
-                        let est_grad = (v - d) / EPSILON;
-                        err = err.min((est_grad as f32 - grad).abs());
+                        let est_grad = (v as f64 - d as f64) / EPSILON as f64;
+                        err = err.min((est_grad - grad).abs());
                         assert!(
-                            err.min(err / grad.abs()) < 1e-3,
+                            err.min(err / grad.abs()) < 1e-2,
                             "gradient estimate mismatch in '{name}' at \
                              ({a} + epsilon, {b}) => {o:?}: \
                              {est_grad} != {grad} ({err})"
@@ -625,17 +624,17 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
                     }
                 }
                 if j < 3 {
-                    let grad = o.d(j);
+                    let grad = o.d(j) as f64;
                     if grad < 1e9 && !grad.is_infinite() {
                         let d = g(a, b + EPSILON);
                         let est_grad = (d - v) / EPSILON;
-                        let mut err = (est_grad as f32 - grad).abs();
+                        let mut err = (est_grad as f64 - grad).abs();
 
                         let d = g(a, b - EPSILON);
                         let est_grad = (v - d) / EPSILON;
-                        err = err.min((est_grad as f32 - grad).abs());
+                        err = err.min((est_grad as f64 - grad).abs());
                         assert!(
-                            err.min(err / grad.abs()) < 1e-3,
+                            err.min(err / grad.abs()) < 1e-2,
                             "gradient estimate mismatch in '{name}' at \
                              ({a}, {b} + epsilon) => {o:?}: \
                              {est_grad} != {grad} ({err})"
@@ -683,7 +682,7 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
                         &args,
                         rhs,
                         &out,
-                        C::eval_reg_reg_f64,
+                        C::eval_reg_reg_f32,
                         &name,
                     );
                 }
@@ -723,7 +722,7 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
                         &args,
                         &rhs,
                         &out,
-                        C::eval_reg_imm_f64,
+                        C::eval_reg_imm_f32,
                         &name,
                     );
                 }
@@ -763,7 +762,7 @@ impl<F: Function + MathFunction> TestGradSlice<F> {
                         &lhs,
                         &args,
                         &out,
-                        C::eval_imm_reg_f64,
+                        C::eval_imm_reg_f32,
                         &name,
                     );
                 }

--- a/fidget-core/src/eval/test/interval.rs
+++ b/fidget-core/src/eval/test/interval.rs
@@ -1129,11 +1129,11 @@ where
     }
 
     /// Check `out` against a grid of points in the LHS, RHS intervals
-    pub fn compare_interval_results(
+    pub fn compare_interval_results<C: CanonicalBinaryOp>(
         lhs: Interval,
         rhs: Interval,
         out: Interval,
-        g: impl Fn(f32, f32) -> f32,
+        constant_folded: bool,
         name: &str,
     ) {
         let i_max = if lhs.lower() == lhs.upper() { 1 } else { 8 };
@@ -1148,19 +1148,19 @@ where
                 let v_rhs = (rhs.lower() * j + rhs.upper() * (1.0 - j))
                     .min(rhs.upper())
                     .max(rhs.lower());
-                let inside_value = g(v_lhs, v_rhs);
+                let inside_value = C::eval_reg_reg_f32(v_lhs, v_rhs);
 
                 if inside_value.is_nan() || inside_value.is_infinite() {
                     assert!(
-                        out.has_nan(),
+                        out.has_nan() || constant_folded,
                         "interval failure in '{name}': ({v_lhs}, {v_rhs}) in \
                         ({lhs}, {rhs}) => {inside_value} not in {out} \
                         (should be [NaN, NaN])"
                     );
                 } else if !out.has_nan() {
                     assert!(
-                        inside_value >= out.lower()
-                            && inside_value <= out.upper(),
+                        (inside_value >= out.lower()
+                            && inside_value <= out.upper()),
                         "interval failure in '{name}': ({v_lhs}, {v_rhs}) in \
                         ({lhs}, {rhs}) => {inside_value} not in {out}"
                     );
@@ -1191,6 +1191,7 @@ where
                 if matches!(op, crate::context::Op::Unary(..)) {
                     continue;
                 }
+                let constant_folded = ctx.get_const(node).is_ok();
 
                 let shape = F::new(&ctx, &[node]).unwrap();
                 let tape = shape.interval_tape(tape_data.unwrap_or_default());
@@ -1208,11 +1209,11 @@ where
                 let (out, _trace) = eval.eval(&tape, &args).unwrap();
                 tape_data = Some(tape.recycle().unwrap());
 
-                Self::compare_interval_results(
+                Self::compare_interval_results::<C>(
                     lhs,
                     rhs,
                     out[0],
-                    C::eval_reg_reg_f32,
+                    constant_folded,
                     &name,
                 );
             }
@@ -1227,6 +1228,7 @@ where
             if matches!(op, crate::context::Op::Unary(..)) {
                 continue;
             }
+            let constant_folded = ctx.get_const(node).is_ok();
 
             let shape = F::new(&ctx, &[node]).unwrap();
             let tape = shape.interval_tape(tape_data.unwrap_or_default());
@@ -1240,11 +1242,11 @@ where
             let (out, _trace) = eval.eval(&tape, &args).unwrap();
             tape_data = Some(tape.recycle().unwrap());
 
-            Self::compare_interval_results(
+            Self::compare_interval_results::<C>(
                 lhs,
                 lhs,
                 out[0],
-                C::eval_reg_reg_f32,
+                constant_folded,
                 &name,
             );
         }
@@ -1264,6 +1266,7 @@ where
         for &lhs in args.iter() {
             for &rhs in values.iter() {
                 let node = C::build(&mut ctx, a, rhs);
+                let constant_folded = ctx.get_const(node).is_ok();
 
                 let shape = F::new(&ctx, &[node]).unwrap();
                 let tape = shape.interval_tape(tape_data.unwrap_or_default());
@@ -1271,11 +1274,11 @@ where
                 let (out, _trace) = eval.eval(&tape, &[lhs]).unwrap();
                 tape_data = Some(tape.recycle().unwrap());
 
-                Self::compare_interval_results(
+                Self::compare_interval_results::<C>(
                     lhs,
                     rhs.into(),
                     out[0],
-                    C::eval_reg_imm_f32,
+                    constant_folded,
                     &name,
                 );
             }
@@ -1295,6 +1298,7 @@ where
         for &lhs in values.iter() {
             for &rhs in args.iter() {
                 let node = C::build(&mut ctx, lhs, va);
+                let constant_folded = ctx.get_const(node).is_ok();
 
                 let shape = F::new(&ctx, &[node]).unwrap();
                 let tape = shape.interval_tape(tape_data.unwrap_or_default());
@@ -1302,11 +1306,11 @@ where
                 let (out, _trace) = eval.eval(&tape, &[rhs]).unwrap();
                 tape_data = Some(tape.recycle().unwrap());
 
-                Self::compare_interval_results(
+                Self::compare_interval_results::<C>(
                     lhs.into(),
                     rhs,
                     out[0],
-                    C::eval_imm_reg_f32,
+                    constant_folded,
                     &name,
                 );
             }

--- a/fidget-core/src/eval/test/interval.rs
+++ b/fidget-core/src/eval/test/interval.rs
@@ -1148,7 +1148,7 @@ where
                 let v_rhs = (rhs.lower() * j + rhs.upper() * (1.0 - j))
                     .min(rhs.upper())
                     .max(rhs.lower());
-                let inside_value = C::eval_reg_reg_f32(v_lhs, v_rhs);
+                let inside_value = C::eval(v_lhs, v_rhs);
 
                 if inside_value.is_nan() || inside_value.is_infinite() {
                     assert!(

--- a/fidget-core/src/eval/test/interval.rs
+++ b/fidget-core/src/eval/test/interval.rs
@@ -256,7 +256,7 @@ where
             Interval::from(1.0.mix(5.0)),
         );
 
-        let v = ctx.constant(f64::NAN);
+        let v = ctx.constant(f32::NAN);
         let mix = ctx.mix(a, v).unwrap();
         let shape = F::new(&ctx, &[mix]).unwrap();
         let mut eval = F::new_interval_eval();

--- a/fidget-core/src/eval/test/mod.rs
+++ b/fidget-core/src/eval/test/mod.rs
@@ -101,7 +101,6 @@ pub trait CanonicalUnaryOp {
     const NAME: &'static str;
     fn build(ctx: &mut Context, arg: Node) -> Node;
     fn eval_f32(arg: f32) -> f32;
-    fn eval_f64(arg: f64) -> f64;
 
     /// Returns true if there is a bidirectional discontinuity at a position
     ///
@@ -123,9 +122,6 @@ pub trait CanonicalBinaryOp {
     fn eval_reg_reg_f32(lhs: f32, rhs: f32) -> f32;
     fn eval_reg_imm_f32(lhs: f32, rhs: f32) -> f32;
     fn eval_imm_reg_f32(lhs: f32, rhs: f32) -> f32;
-    fn eval_reg_reg_f64(lhs: f64, rhs: f64) -> f64;
-    fn eval_reg_imm_f64(lhs: f64, rhs: f64) -> f64;
-    fn eval_imm_reg_f64(lhs: f64, rhs: f64) -> f64;
 
     /// Returns true if there is a bidirectional discontinuity at a position
     ///
@@ -145,9 +141,6 @@ macro_rules! declare_canonical_unary {
                 Context::$i(ctx, arg).unwrap()
             }
             fn eval_f32($a: f32) -> f32 {
-                $t
-            }
-            fn eval_f64($a: f64) -> f64 {
                 $t
             }
             fn discontinuous_at($b: f32) -> bool {
@@ -181,15 +174,6 @@ macro_rules! declare_canonical_binary {
                 $t
             }
             fn eval_imm_reg_f32($lhs: f32, $rhs: f32) -> f32 {
-                $t
-            }
-            fn eval_reg_reg_f64($lhs: f64, $rhs: f64) -> f64 {
-                $t
-            }
-            fn eval_reg_imm_f64($lhs: f64, $rhs: f64) -> f64 {
-                $t
-            }
-            fn eval_imm_reg_f64($lhs: f64, $rhs: f64) -> f64 {
                 $t
             }
             fn discontinuous_at($lhs2: f32, $rhs2: f32) -> bool {
@@ -227,15 +211,6 @@ macro_rules! declare_canonical_binary_full {
                 $f_reg_imm
             }
             fn eval_imm_reg_f32($lhs_imm_reg: f32, $rhs_imm_reg: f32) -> f32 {
-                $f_imm_reg
-            }
-            fn eval_reg_reg_f64($lhs_reg_reg: f64, $rhs_reg_reg: f64) -> f64 {
-                $f_reg_reg
-            }
-            fn eval_reg_imm_f64($lhs_reg_imm: f64, $rhs_reg_imm: f64) -> f64 {
-                $f_reg_imm
-            }
-            fn eval_imm_reg_f64($lhs_imm_reg: f64, $rhs_imm_reg: f64) -> f64 {
                 $f_imm_reg
             }
         }

--- a/fidget-core/src/eval/test/mod.rs
+++ b/fidget-core/src/eval/test/mod.rs
@@ -4,6 +4,8 @@ pub mod grad_slice;
 pub mod interval;
 pub mod point;
 
+use crate::types::FloatExt;
+
 // Internal-only tests
 #[cfg(test)] // not enabled for eval-tests
 mod symbolic_deriv;
@@ -119,9 +121,7 @@ pub trait CanonicalBinaryOp {
         lhs: A,
         rhs: B,
     ) -> Node;
-    fn eval_reg_reg_f32(lhs: f32, rhs: f32) -> f32;
-    fn eval_reg_imm_f32(lhs: f32, rhs: f32) -> f32;
-    fn eval_imm_reg_f32(lhs: f32, rhs: f32) -> f32;
+    fn eval(lhs: f32, rhs: f32) -> f32;
 
     /// Returns true if there is a bidirectional discontinuity at a position
     ///
@@ -167,13 +167,7 @@ macro_rules! declare_canonical_binary {
                 let rhs = rhs.into_node(ctx).unwrap();
                 Context::$i(ctx, lhs, rhs).unwrap()
             }
-            fn eval_reg_reg_f32($lhs: f32, $rhs: f32) -> f32 {
-                $t
-            }
-            fn eval_reg_imm_f32($lhs: f32, $rhs: f32) -> f32 {
-                $t
-            }
-            fn eval_imm_reg_f32($lhs: f32, $rhs: f32) -> f32 {
+            fn eval($lhs: f32, $rhs: f32) -> f32 {
                 $t
             }
             fn discontinuous_at($lhs2: f32, $rhs2: f32) -> bool {
@@ -183,37 +177,6 @@ macro_rules! declare_canonical_binary {
     };
     (Context::$i:ident, |$lhs:ident, $rhs:ident| $t:expr) => {
         declare_canonical_binary!(Context::$i, |$lhs, $rhs| $t, |_a, _b| false);
-    };
-}
-
-macro_rules! declare_canonical_binary_full {
-    (Context::$i:ident,
-     |$lhs_reg_reg:ident, $rhs_reg_reg:ident| $f_reg_reg:expr,
-     |$lhs_reg_imm:ident, $rhs_reg_imm:ident| $f_reg_imm:expr,
-     |$lhs_imm_reg:ident, $rhs_imm_reg:ident| $f_imm_reg:expr,
-     ) => {
-        pub struct $i;
-        impl CanonicalBinaryOp for $i {
-            const NAME: &'static str = stringify!($i);
-            fn build<A: IntoNode, B: IntoNode>(
-                ctx: &mut Context,
-                lhs: A,
-                rhs: B,
-            ) -> Node {
-                let lhs = lhs.into_node(ctx).unwrap();
-                let rhs = rhs.into_node(ctx).unwrap();
-                Context::$i(ctx, lhs, rhs).unwrap()
-            }
-            fn eval_reg_reg_f32($lhs_reg_reg: f32, $rhs_reg_reg: f32) -> f32 {
-                $f_reg_reg
-            }
-            fn eval_reg_imm_f32($lhs_reg_imm: f32, $rhs_reg_imm: f32) -> f32 {
-                $f_reg_imm
-            }
-            fn eval_imm_reg_f32($lhs_imm_reg: f32, $rhs_imm_reg: f32) -> f32 {
-                $f_imm_reg
-            }
-        }
     };
 }
 
@@ -244,48 +207,18 @@ pub mod canonical {
     declare_canonical_unary!(Context::not, |a| (a == 0.0).into(), |a| a == 0.0);
     declare_canonical_unary!(
         Context::rand,
-        |a| crate::rng::rand((a as f32).to_bits()).into(),
+        |a| a.rand(),
         |_a| true // always discontinuous, so ignore all gradients
     );
 
     declare_canonical_binary!(Context::add, |a, b| a + b);
     declare_canonical_binary!(Context::sub, |a, b| a - b);
-    declare_canonical_binary_full!(
-        Context::mul,
-        |a, b| a * b,
-        |a, imm| if imm == 0.0 { imm } else { a * imm },
-        |imm, b| if imm == 0.0 { imm } else { imm * b },
-    );
-    declare_canonical_binary_full!(
-        Context::div,
-        |a, b| a / b,
-        |a, imm| a / imm,
-        |imm, b| if imm == 0.0 { imm } else { imm / b },
-    );
-    declare_canonical_binary!(
-        Context::min,
-        |a, b| if a.is_nan() || b.is_nan() {
-            f32::NAN.into()
-        } else {
-            a.min(b)
-        }
-    );
-    declare_canonical_binary!(
-        Context::max,
-        |a, b| if a.is_nan() || b.is_nan() {
-            f32::NAN.into()
-        } else {
-            a.max(b)
-        }
-    );
-    declare_canonical_binary!(
-        Context::compare,
-        |a, b| match a.partial_cmp(&b) {
-            None => f32::NAN.into(),
-            Some(v) => (v as i8).into(),
-        },
-        |a, b| a == b
-    );
+    declare_canonical_binary!(Context::mul, |a, b| a * b);
+    declare_canonical_binary!(Context::div, |a, b| a / b);
+    declare_canonical_binary!(Context::min, |a, b| a.min_choice(b).0);
+    declare_canonical_binary!(Context::max, |a, b| a.max_choice(b).0);
+    declare_canonical_binary!(Context::compare, |a, b| a.compare(b), |a, b| a
+        == b);
     declare_canonical_binary!(
         Context::modulo,
         |a, b| a.rem_euclid(b),
@@ -296,22 +229,18 @@ pub mod canonical {
     );
     declare_canonical_binary!(
         Context::and,
-        |a, b| if a == 0.0 { a } else { b },
+        |a, b| a.and_choice(b).0,
         |a, _b| a == 0.0 // discontinuity, because either side snaps to b
     );
     declare_canonical_binary!(
         Context::or,
-        |a, b| if a != 0.0 { a } else { b },
+        |a, b| a.or_choice(b).0,
         |a, _b| a == 0.0 // discontinuity, because either side snaps to a
     );
     declare_canonical_binary!(Context::atan2, |y, x| y.atan2(x));
     declare_canonical_binary!(
         Context::mix,
-        |a, b| f32::from_bits(crate::rng::mix(
-            (a as f32).to_bits(),
-            (b as f32).to_bits(),
-        ))
-        .into(),
+        |a, b| a.mix(b),
         |_a, _b| true // always discontinuous
     );
 }

--- a/fidget-core/src/eval/test/mod.rs
+++ b/fidget-core/src/eval/test/mod.rs
@@ -204,7 +204,7 @@ pub mod canonical {
     declare_canonical_unary!(Context::floor, |a| a.floor());
     declare_canonical_unary!(Context::ceil, |a| a.ceil());
     declare_canonical_unary!(Context::round, |a| a.round());
-    declare_canonical_unary!(Context::not, |a| (a == 0.0).into(), |a| a == 0.0);
+    declare_canonical_unary!(Context::not, |a| a.not(), |a| a == 0.0);
     declare_canonical_unary!(
         Context::rand,
         |a| a.rand(),

--- a/fidget-core/src/eval/test/point.rs
+++ b/fidget-core/src/eval/test/point.rs
@@ -585,12 +585,10 @@ where
         let err = (value - out).abs();
         assert!(
             (out == value)
-                || C::discontinuous_at(lhs, rhs)
                 || err < 1e-6
                 || value.is_nan() && out.is_nan()
                 || value.is_nan() && constant_folded,
-            "mismatch in '{name}' at ({lhs}, {rhs}): \
-                            {value} != {out} ({err})"
+            "mismatch in '{name}' at ({lhs}, {rhs}): {value} != {out} ({err})"
         )
     }
 

--- a/fidget-core/src/eval/test/point.rs
+++ b/fidget-core/src/eval/test/point.rs
@@ -578,16 +578,17 @@ where
         lhs: f32,
         rhs: f32,
         out: f32,
-        g: impl Fn(f32, f32) -> f32,
+        constant_folded: bool,
         name: &str,
     ) {
-        let value = g(lhs, rhs);
+        let value = C::eval(lhs, rhs);
         let err = (value - out).abs();
         assert!(
             (out == value)
                 || C::discontinuous_at(lhs, rhs)
                 || err < 1e-6
-                || value.is_nan() && out.is_nan(),
+                || value.is_nan() && out.is_nan()
+                || value.is_nan() && constant_folded,
             "mismatch in '{name}' at ({lhs}, {rhs}): \
                             {value} != {out} ({err})"
         )
@@ -604,6 +605,7 @@ where
         for &lhs in args.iter() {
             for &rhs in args.iter() {
                 let node = C::build(&mut ctx, va, vb);
+                let constant_folded = ctx.get_const(node).is_ok();
 
                 let shape = F::new(&ctx, &[node]).unwrap();
                 let mut eval = F::new_point_eval();
@@ -624,7 +626,7 @@ where
                     lhs,
                     rhs,
                     out[0],
-                    C::eval_reg_reg_f32,
+                    constant_folded,
                     &name,
                 );
             }
@@ -632,6 +634,7 @@ where
 
         for &lhs in args.iter() {
             let node = C::build(&mut ctx, va, va);
+            let constant_folded = ctx.get_const(node).is_ok();
 
             let shape = F::new(&ctx, &[node]).unwrap();
             let mut eval = F::new_point_eval();
@@ -648,7 +651,7 @@ where
                 lhs,
                 lhs,
                 out[0],
-                C::eval_reg_reg_f32,
+                constant_folded,
                 &name,
             );
         }
@@ -664,6 +667,7 @@ where
         for &lhs in args.iter() {
             for &rhs in args.iter() {
                 let node = C::build(&mut ctx, va, rhs);
+                let constant_folded = ctx.get_const(node).is_ok();
 
                 let shape = F::new(&ctx, &[node]).unwrap();
                 let mut eval = F::new_point_eval();
@@ -675,7 +679,7 @@ where
                     lhs,
                     rhs,
                     out[0],
-                    C::eval_reg_imm_f32,
+                    constant_folded,
                     &name,
                 );
             }
@@ -692,6 +696,7 @@ where
         for &lhs in args.iter() {
             for &rhs in args.iter() {
                 let node = C::build(&mut ctx, lhs, va);
+                let constant_folded = ctx.get_const(node).is_ok();
 
                 let shape = F::new(&ctx, &[node]).unwrap();
                 let mut eval = F::new_point_eval();
@@ -703,7 +708,7 @@ where
                     lhs,
                     rhs,
                     out[0],
-                    C::eval_imm_reg_f32,
+                    constant_folded,
                     &name,
                 );
             }

--- a/fidget-core/src/eval/test/point.rs
+++ b/fidget-core/src/eval/test/point.rs
@@ -564,11 +564,11 @@ where
                 assert!(trace.is_none());
                 let v = C::eval_f32(a);
                 let o = o[0];
-                let err = (v - o).abs();
                 assert!(
-                    (o == v) || err < 1e-6 || (v.is_nan() && o.is_nan()),
-                    "mismatch in '{}' at {a}: {v} != {o} ({err})",
+                    (o == v) || (v.is_nan() && o.is_nan()),
+                    "mismatch in '{}' at {a}: {v} != {o} ({})",
                     C::NAME,
+                    o - v
                 )
             }
         }
@@ -582,13 +582,12 @@ where
         name: &str,
     ) {
         let value = C::eval(lhs, rhs);
-        let err = (value - out).abs();
         assert!(
             (out == value)
-                || err < 1e-6
                 || value.is_nan() && out.is_nan()
                 || value.is_nan() && constant_folded,
-            "mismatch in '{name}' at ({lhs}, {rhs}): {value} != {out} ({err})"
+            "mismatch in '{name}' at ({lhs}, {rhs}): {value} != {out} ({})",
+            out - value
         )
     }
 

--- a/fidget-core/src/eval/test/point.rs
+++ b/fidget-core/src/eval/test/point.rs
@@ -406,10 +406,8 @@ where
         }
 
         for (i, v) in out.iter().cloned().enumerate() {
-            let q = ctx
-                .eval_xyz(node, x[i] as f64, y[i] as f64, z[i] as f64)
-                .unwrap();
-            let err = (v as f64 - q).abs();
+            let q = ctx.eval_xyz(node, x[i], y[i], z[i]).unwrap();
+            let err = (v - q).abs();
             assert!(
                 err < 1e-2, // generous error bounds, for the 512-op case
                 "mismatch at index {i} ({}, {}, {}): {v} != {q} [{err}], {}",
@@ -517,7 +515,7 @@ where
         );
 
         // Test mix(reg, imm) and mix(imm, reg) with NAN
-        let v = ctx.constant(f64::NAN);
+        let v = ctx.constant(f32::NAN);
         let mix = ctx.mix(a, v).unwrap();
         let shape = F::new(&ctx, &[mix]).unwrap();
         let mut eval = F::new_point_eval();

--- a/fidget-core/src/types/float.rs
+++ b/fidget-core/src/types/float.rs
@@ -58,6 +58,9 @@ pub trait FloatExt: Sized {
 
     /// Pseudo-random number mixing
     fn mix(self, other: f32) -> f32;
+
+    /// Logical not
+    fn not(self) -> f32;
 }
 
 impl FloatExt for f32 {
@@ -130,5 +133,10 @@ impl FloatExt for f32 {
     #[inline]
     fn mix(self, other: Self) -> Self {
         f32::from_bits(crate::rng::mix(self.to_bits(), other.to_bits()))
+    }
+
+    #[inline]
+    fn not(self) -> Self {
+        (self == 0.0).into()
     }
 }

--- a/fidget-jit/src/aarch64/float_slice.rs
+++ b/fidget-jit/src/aarch64/float_slice.rs
@@ -378,13 +378,10 @@ impl Assembler for FloatSliceAssembler {
         )
     }
     fn build_mod(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
-        dynasm!(self.0.ops
-            ; fabs v6.s4, V(reg(rhs_reg)).s4
-            ; fdiv v7.s4, V(reg(lhs_reg)).s4, v6.s4
-            ; frintm v7.s4, v7.s4 // round down
-            ; fmul v7.s4, v7.s4, v6.s4
-            ; fsub V(reg(out_reg)).s4, V(reg(lhs_reg)).s4, v7.s4
-        )
+        extern "C" fn float_mod(x: f32, y: f32) -> f32 {
+            x.rem_euclid(y)
+        }
+        self.call_fn_binary(out_reg, lhs_reg, rhs_reg, float_mod);
     }
     fn build_not(&mut self, out_reg: u8, arg_reg: u8) {
         dynasm!(self.0.ops

--- a/fidget-jit/src/aarch64/point.rs
+++ b/fidget-jit/src/aarch64/point.rs
@@ -326,13 +326,10 @@ impl Assembler for PointAssembler {
     }
 
     fn build_mod(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
-        dynasm!(self.0.ops
-            ; fabs s6, S(reg(rhs_reg))
-            ; fdiv s7, S(reg(lhs_reg)), s6
-            ; frintm s7, s7 // round down
-            ; fmul s7, s7, s6
-            ; fsub S(reg(out_reg)), S(reg(lhs_reg)), s7
-        )
+        extern "C" fn float_mod(x: f32, y: f32) -> f32 {
+            x.rem_euclid(y)
+        }
+        self.call_fn_binary(out_reg, lhs_reg, rhs_reg, float_mod);
     }
 
     fn build_not(&mut self, out_reg: u8, arg_reg: u8) {

--- a/fidget-jit/src/x86_64/float_slice.rs
+++ b/fidget-jit/src/x86_64/float_slice.rs
@@ -400,17 +400,10 @@ impl Assembler for FloatSliceAssembler {
         );
     }
     fn build_mod(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
-        dynasm!(self.0.ops
-            // Take abs(rhs_reg)
-            ; vpcmpeqw ymm2, ymm2, ymm2
-            ; vpsrld ymm2, ymm2, 1 // everything but the sign bit
-            ; vpand ymm1, ymm2, Ry(reg(rhs_reg))
-
-            ; vdivps ymm2, Ry(reg(lhs_reg)), ymm1
-            ; vroundps ymm2, ymm2, 0b1 // floor
-            ; vmulps ymm2, ymm2, ymm1
-            ; vsubps Ry(reg(out_reg)), Ry(reg(lhs_reg)), ymm2
-        );
+        extern "sysv64" fn float_mod(x: f32, y: f32) -> f32 {
+            x.rem_euclid(y)
+        }
+        self.call_fn_binary(out_reg, lhs_reg, rhs_reg, float_mod);
     }
     fn build_not(&mut self, out_reg: u8, arg_reg: u8) {
         dynasm!(self.0.ops

--- a/fidget-jit/src/x86_64/point.rs
+++ b/fidget-jit/src/x86_64/point.rs
@@ -304,7 +304,7 @@ impl Assembler for PointAssembler {
         self.0.ops.commit_local().unwrap()
     }
     fn build_mod(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
-        extern "C" fn float_mod(x: f32, y: f32) -> f32 {
+        extern "sysv64" fn float_mod(x: f32, y: f32) -> f32 {
             x.rem_euclid(y)
         }
         self.call_fn_binary(out_reg, lhs_reg, rhs_reg, float_mod);

--- a/fidget-jit/src/x86_64/point.rs
+++ b/fidget-jit/src/x86_64/point.rs
@@ -304,17 +304,10 @@ impl Assembler for PointAssembler {
         self.0.ops.commit_local().unwrap()
     }
     fn build_mod(&mut self, out_reg: u8, lhs_reg: u8, rhs_reg: u8) {
-        dynasm!(self.0.ops
-            // Take abs(rhs_reg)
-            ; mov eax, 0x7fffffffu32 as i32
-            ; vmovd xmm2, eax
-            ; vandps xmm1, xmm2, Rx(reg(rhs_reg))
-
-            ; vdivss xmm2, Rx(reg(lhs_reg)), xmm1
-            ; vroundss xmm2, xmm2, xmm2, 0b1 // floor
-            ; vmulss xmm2, xmm2, xmm1
-            ; vsubss Rx(reg(out_reg)), Rx(reg(lhs_reg)), xmm2
-        );
+        extern "C" fn float_mod(x: f32, y: f32) -> f32 {
+            x.rem_euclid(y)
+        }
+        self.call_fn_binary(out_reg, lhs_reg, rhs_reg, float_mod);
     }
     fn build_not(&mut self, out_reg: u8, arg_reg: u8) {
         dynasm!(self.0.ops

--- a/fidget-mesh/src/octree.rs
+++ b/fidget-mesh/src/octree.rs
@@ -1115,8 +1115,8 @@ mod test {
         let length = dir.norm();
         let dir = dir.normalize();
 
-        let corner = corner.map(|v| Tree::constant(v as f64));
-        let dir = dir.map(|v| Tree::constant(v as f64));
+        let corner = corner.map(Tree::constant);
+        let dir = dir.map(Tree::constant);
 
         let (x, y, z) = Tree::axes();
         let point = nalgebra::Vector3::new(x, y, z);

--- a/fidget-rhai/src/lib.rs
+++ b/fidget-rhai/src/lib.rs
@@ -381,8 +381,8 @@ mod test {
         let engine = engine();
 
         // Test that PI constant is available
-        let pi: f32 = engine.eval("PI").unwrap();
-        assert!((pi - std::f32::consts::PI).abs() < f32::EPSILON);
+        let pi: f64 = engine.eval("PI").unwrap();
+        assert!((pi - std::f64::consts::PI).abs() < f64::EPSILON);
 
         // Test using constants in angular calculations
         let t = engine

--- a/fidget-rhai/src/lib.rs
+++ b/fidget-rhai/src/lib.rs
@@ -86,7 +86,7 @@
 //! Shapes are built from a set of Rust primitives, with generous conversions
 //! from Rhai's native types:
 //!
-//! - Scalar values (`f64`)
+//! - Scalar values (`f32`)
 //!     - Both floating-point and integer Rhai values will be accepted
 //! - Vectors (`vec2` and `vec3`)
 //!     - These may be explicitly constructed with `vec2(x, y)` and
@@ -307,16 +307,17 @@ where
     ) -> Result<Self, Box<rhai::EvalAltResult>>;
 }
 
-impl FromDynamic for f64 {
+impl FromDynamic for f32 {
     fn from_dynamic(
         ctx: &rhai::NativeCallContext,
         d: rhai::Dynamic,
-        _default: Option<&f64>,
+        _default: Option<&f32>,
     ) -> Result<Self, Box<rhai::EvalAltResult>> {
         let ty = d.type_name();
         d.clone()
             .try_cast::<f64>()
-            .or_else(|| d.try_cast::<i64>().map(|f| f as f64))
+            .map(|f| f as f32)
+            .or_else(|| d.try_cast::<i64>().map(|f| f as f32))
             .ok_or_else(|| {
                 rhai::EvalAltResult::ErrorMismatchDataType(
                     "float".to_string(),
@@ -380,8 +381,8 @@ mod test {
         let engine = engine();
 
         // Test that PI constant is available
-        let pi: f64 = engine.eval("PI").unwrap();
-        assert!((pi - std::f64::consts::PI).abs() < f64::EPSILON);
+        let pi: f32 = engine.eval("PI").unwrap();
+        assert!((pi - std::f32::consts::PI).abs() < f32::EPSILON);
 
         // Test using constants in angular calculations
         let t = engine
@@ -392,7 +393,7 @@ mod test {
 
         // Evaluate at (1, 1) - should be sqrt(2) since cos(π/4) = sin(π/4) = 1/√2
         let result = ctx.eval_xyz(expr, 1.0, 1.0, 0.0).unwrap();
-        let expected = std::f64::consts::SQRT_2;
+        let expected = std::f32::consts::SQRT_2;
         assert!((result - expected).abs() < 1e-10);
     }
 }

--- a/fidget-rhai/src/shapes.rs
+++ b/fidget-rhai/src/shapes.rs
@@ -237,6 +237,7 @@ fn build_transform<T: Facet<'static> + Into<Tree>>(
             .into());
         };
         let d = f.default.map(|df| unsafe { tag.build_from_default_fn(df) });
+        // TODO this could be made lazy
         let v = build_tagged_value(tag, &ctx, v, d)?;
         builder = v.put(builder, i);
     }

--- a/fidget-rhai/src/tree.rs
+++ b/fidget-rhai/src/tree.rs
@@ -14,7 +14,7 @@ impl FromDynamic for Tree {
     ) -> Result<Self, Box<EvalAltResult>> {
         if let Some(t) = d.clone().try_cast::<Tree>() {
             Ok(t)
-        } else if let Ok(v) = f64::from_dynamic(ctx, d.clone(), None) {
+        } else if let Ok(v) = f32::from_dynamic(ctx, d.clone(), None) {
             Ok(Tree::constant(v))
         } else if let Ok(v) = <Vec<Tree>>::from_dynamic(ctx, d.clone(), None) {
             Ok(fidget_shapes::Union { input: v }.into())

--- a/fidget-rhai/src/types.rs
+++ b/fidget-rhai/src/types.rs
@@ -31,19 +31,19 @@ macro_rules! register_binary {
         });
         $engine.register_fn($rop, |a: $ty, b: f64| -> $ty {
             $( use std::ops::$op; )?
-            a.$base_fn(b)
+            a.$base_fn(b as f32)
         });
         $engine.register_fn($rop, |a: $ty, b: i64| -> $ty {
             $( use std::ops::$op; )?
-            a.$base_fn(b as f64)
+            a.$base_fn(b as f32)
         });
         $engine.register_fn($rop, |a: f64, b: $ty| -> $ty {
             $( use std::ops::$op; )?
-            $ty::from(a).$base_fn(b)
+            $ty::from(a as f32).$base_fn(b)
         });
         $engine.register_fn($rop, |a: i64, b: $ty| -> $ty {
             $( use std::ops::$op; )?
-            $ty::from(a as f64).$base_fn(b)
+            $ty::from(a as f32).$base_fn(b)
         });
     };
     ($engine:ident, $ty:ident, $base_fn:ident) => {
@@ -81,8 +81,8 @@ fn register_vec2(engine: &mut rhai::Engine) {
              x: rhai::Dynamic,
              y: rhai::Dynamic|
              -> Result<Vec2, Box<EvalAltResult>> {
-                let x = f64::from_dynamic(&ctx, x, None)?;
-                let y = f64::from_dynamic(&ctx, y, None)?;
+                let x = f32::from_dynamic(&ctx, x, None)?;
+                let y = f32::from_dynamic(&ctx, y, None)?;
                 Ok(Vec2 { x, y })
             },
         )
@@ -112,9 +112,9 @@ fn register_vec3(engine: &mut rhai::Engine) {
              y: rhai::Dynamic,
              z: rhai::Dynamic|
              -> Result<Vec3, Box<EvalAltResult>> {
-                let x = f64::from_dynamic(&ctx, x, None)?;
-                let y = f64::from_dynamic(&ctx, y, None)?;
-                let z = f64::from_dynamic(&ctx, z, None)?;
+                let x = f32::from_dynamic(&ctx, x, None)?;
+                let y = f32::from_dynamic(&ctx, y, None)?;
+                let z = f32::from_dynamic(&ctx, z, None)?;
                 Ok(Vec3 { x, y, z })
             },
         )
@@ -158,8 +158,8 @@ fn vec2_from_rhai_array(
 ) -> Result<Vec2, Box<EvalAltResult>> {
     match array.len() {
         2 => {
-            let x = f64::from_dynamic(ctx, array[0].clone(), None)?;
-            let y = f64::from_dynamic(ctx, array[1].clone(), None)?;
+            let x = f32::from_dynamic(ctx, array[0].clone(), None)?;
+            let y = f32::from_dynamic(ctx, array[1].clone(), None)?;
             Ok(Vec2 { x, y })
         }
         n => Err(EvalAltResult::ErrorMismatchDataType(
@@ -205,15 +205,15 @@ fn vec3_from_rhai_array(
 ) -> Result<Vec3, Box<EvalAltResult>> {
     match array.len() {
         2 => {
-            let x = f64::from_dynamic(ctx, array[0].clone(), None)?;
-            let y = f64::from_dynamic(ctx, array[1].clone(), None)?;
+            let x = f32::from_dynamic(ctx, array[0].clone(), None)?;
+            let y = f32::from_dynamic(ctx, array[1].clone(), None)?;
             let z = default.map(|d| d.z).unwrap_or(0.0);
             Ok(Vec3 { x, y, z })
         }
         3 => {
-            let x = f64::from_dynamic(ctx, array[0].clone(), None)?;
-            let y = f64::from_dynamic(ctx, array[1].clone(), None)?;
-            let z = f64::from_dynamic(ctx, array[2].clone(), None)?;
+            let x = f32::from_dynamic(ctx, array[0].clone(), None)?;
+            let y = f32::from_dynamic(ctx, array[1].clone(), None)?;
+            let z = f32::from_dynamic(ctx, array[2].clone(), None)?;
             Ok(Vec3 { x, y, z })
         }
         n => Err(EvalAltResult::ErrorMismatchDataType(
@@ -243,10 +243,10 @@ impl FromDynamic for Vec4 {
             })?;
             match array.len() {
                 4 => {
-                    let x = f64::from_dynamic(ctx, array[0].clone(), None)?;
-                    let y = f64::from_dynamic(ctx, array[1].clone(), None)?;
-                    let z = f64::from_dynamic(ctx, array[2].clone(), None)?;
-                    let w = f64::from_dynamic(ctx, array[3].clone(), None)?;
+                    let x = f32::from_dynamic(ctx, array[0].clone(), None)?;
+                    let y = f32::from_dynamic(ctx, array[1].clone(), None)?;
+                    let z = f32::from_dynamic(ctx, array[2].clone(), None)?;
+                    let w = f32::from_dynamic(ctx, array[3].clone(), None)?;
                     Ok(Vec4 { x, y, z, w })
                 }
                 n => Err(EvalAltResult::ErrorMismatchDataType(
@@ -403,7 +403,7 @@ fn register_plane(engine: &mut rhai::Engine) {
             "plane",
             |ctx: rhai::NativeCallContext,
              v: rhai::Dynamic,
-             offset: f64|
+             offset: f32|
              -> Result<Plane, Box<EvalAltResult>> {
                 let plane = Plane::from_dynamic(&ctx, v, None)?;
                 Ok(Plane {

--- a/fidget-rhai/src/types.rs
+++ b/fidget-rhai/src/types.rs
@@ -403,12 +403,12 @@ fn register_plane(engine: &mut rhai::Engine) {
             "plane",
             |ctx: rhai::NativeCallContext,
              v: rhai::Dynamic,
-             offset: f32|
+             offset: f64|
              -> Result<Plane, Box<EvalAltResult>> {
                 let plane = Plane::from_dynamic(&ctx, v, None)?;
                 Ok(Plane {
                     axis: plane.axis,
-                    offset,
+                    offset: offset as f32,
                 })
             },
         );

--- a/fidget-shapes/src/lib.rs
+++ b/fidget-shapes/src/lib.rs
@@ -31,7 +31,7 @@ pub struct Circle {
     #[facet(default = Vec2::new(0.0, 0.0))]
     pub center: Vec2,
     /// Circle radius
-    #[facet(default = 1.0)]
+    #[facet(default = 1.0f32)]
     pub radius: f32,
 }
 
@@ -71,7 +71,7 @@ pub struct Sphere {
     #[facet(default = Vec3::new(0.0, 0.0, 0.0))]
     pub center: Vec3,
     /// Sphere radius
-    #[facet(default = 1.0)]
+    #[facet(default = 1.0f32)]
     pub radius: f32,
 }
 
@@ -267,7 +267,7 @@ pub struct ScaleUniform {
     /// Shape to scale
     pub shape: Tree,
     /// Scale to apply
-    #[facet(default = 1.0)]
+    #[facet(default = 1.0f32)]
     pub scale: f32,
 }
 
@@ -317,7 +317,7 @@ pub struct ReflectX {
     pub shape: Tree,
 
     /// X offset
-    #[facet(default = 0.0)]
+    #[facet(default = 0.0f32)]
     pub offset: f32,
 }
 
@@ -341,7 +341,7 @@ pub struct ReflectXY {
     pub shape: Tree,
 
     /// Plane about which to reflect the shape
-    #[facet(default = 0.0)]
+    #[facet(default = 0.0f32)]
     pub offset: f32,
 }
 
@@ -365,7 +365,7 @@ pub struct ReflectY {
     pub shape: Tree,
 
     /// Y offset
-    #[facet(default = 0.0)]
+    #[facet(default = 0.0f32)]
     pub offset: f32,
 }
 
@@ -389,7 +389,7 @@ pub struct ReflectZ {
     pub shape: Tree,
 
     /// Z offset
-    #[facet(default = 0.0)]
+    #[facet(default = 0.0f32)]
     pub offset: f32,
 }
 
@@ -417,7 +417,7 @@ pub struct Rotate {
     pub axis: Axis,
 
     /// Angle to rotate (in degrees)
-    #[facet(default = 0.0)]
+    #[facet(default = 0.0f32)]
     pub angle: f32,
 
     /// Center of rotation
@@ -451,7 +451,7 @@ pub struct RotateX {
     pub shape: Tree,
 
     /// Angle to rotate (in degrees)
-    #[facet(default = 0.0)]
+    #[facet(default = 0.0f32)]
     pub angle: f32,
 
     /// Center of rotation
@@ -478,7 +478,7 @@ pub struct RotateY {
     pub shape: Tree,
 
     /// Angle to rotate (in degrees)
-    #[facet(default = 0.0)]
+    #[facet(default = 0.0f32)]
     pub angle: f32,
 
     /// Center of rotation
@@ -505,7 +505,7 @@ pub struct RotateZ {
     pub shape: Tree,
 
     /// Angle to rotate (in degrees)
-    #[facet(default = 0.0)]
+    #[facet(default = 0.0f32)]
     pub angle: f32,
 
     /// Center of rotation
@@ -533,7 +533,7 @@ pub struct RevolveY {
     /// Shape to revolve
     pub shape: Tree,
     /// X offset about which to revolve
-    #[facet(default = 0.0)]
+    #[facet(default = 0.0f32)]
     pub offset: f32,
 }
 
@@ -557,10 +557,10 @@ pub struct ExtrudeZ {
     /// Shape to extrude
     pub shape: Tree,
     /// Lower bounds of the extrusion
-    #[facet(default = 0.0)]
+    #[facet(default = 0.0f32)]
     pub lower: f32,
     /// Upper bounds of the extrusion
-    #[facet(default = 1.0)]
+    #[facet(default = 1.0f32)]
     pub upper: f32,
 }
 
@@ -580,10 +580,10 @@ pub struct LoftZ {
     /// Upper shape
     pub b: Tree,
     /// Lower bounds of the loft
-    #[facet(default = 0.0)]
+    #[facet(default = 0.0f32)]
     pub lower: f32,
     /// Upper bounds of the loft
-    #[facet(default = 1.0)]
+    #[facet(default = 1.0f32)]
     pub upper: f32,
 }
 
@@ -607,10 +607,10 @@ pub struct RepeatX {
     /// Shape to repeat
     pub shape: Tree,
     /// Radius of the region to repeat
-    #[facet(default = 1.0)]
+    #[facet(default = 1.0f32)]
     pub radius: f32,
     /// X position about which to repeat
-    #[facet(default = 0.0)]
+    #[facet(default = 0.0f32)]
     pub offset: f32,
 }
 

--- a/fidget-shapes/src/lib.rs
+++ b/fidget-shapes/src/lib.rs
@@ -32,7 +32,7 @@ pub struct Circle {
     pub center: Vec2,
     /// Circle radius
     #[facet(default = 1.0)]
-    pub radius: f64,
+    pub radius: f32,
 }
 
 impl From<Circle> for Tree {
@@ -72,7 +72,7 @@ pub struct Sphere {
     pub center: Vec3,
     /// Sphere radius
     #[facet(default = 1.0)]
-    pub radius: f64,
+    pub radius: f32,
 }
 
 impl From<Sphere> for Tree {
@@ -121,7 +121,7 @@ impl From<Union> for Tree {
     fn from(v: Union) -> Self {
         if v.input.is_empty() {
             // XXX should this be an error instead?
-            Tree::constant(f64::INFINITY)
+            Tree::constant(f32::INFINITY)
         } else {
             fn recurse(s: &[Tree]) -> Tree {
                 match s.len() {
@@ -146,7 +146,7 @@ pub struct Blend {
     /// Second shape input
     pub b: Tree,
     /// Blending radius
-    pub radius: f64,
+    pub radius: f32,
 }
 
 impl From<Blend> for Tree {
@@ -174,7 +174,7 @@ impl From<Intersection> for Tree {
     fn from(v: Intersection) -> Self {
         if v.input.is_empty() {
             // XXX should this be an error instead?
-            Tree::constant(-f64::INFINITY)
+            Tree::constant(-f32::INFINITY)
         } else {
             fn recurse(s: &[Tree]) -> Tree {
                 match s.len() {
@@ -231,7 +231,7 @@ pub struct Move {
 impl From<Move> for Tree {
     fn from(v: Move) -> Self {
         v.shape.remap_affine(nalgebra::convert(
-            nalgebra::Translation3::<f64>::new(
+            nalgebra::Translation3::<f32>::new(
                 -v.offset.x,
                 -v.offset.y,
                 -v.offset.z,
@@ -253,7 +253,7 @@ pub struct Scale {
 impl From<Scale> for Tree {
     fn from(v: Scale) -> Self {
         v.shape
-            .remap_affine(nalgebra::convert(nalgebra::Scale3::<f64>::new(
+            .remap_affine(nalgebra::convert(nalgebra::Scale3::<f32>::new(
                 1.0 / v.scale.x,
                 1.0 / v.scale.y,
                 1.0 / v.scale.z,
@@ -268,14 +268,14 @@ pub struct ScaleUniform {
     pub shape: Tree,
     /// Scale to apply
     #[facet(default = 1.0)]
-    pub scale: f64,
+    pub scale: f32,
 }
 
 impl From<ScaleUniform> for Tree {
     fn from(v: ScaleUniform) -> Self {
         let s = 1.0 / v.scale;
         v.shape
-            .remap_affine(nalgebra::convert(nalgebra::Scale3::<f64>::new(
+            .remap_affine(nalgebra::convert(nalgebra::Scale3::<f32>::new(
                 s, s, s,
             )))
     }
@@ -318,7 +318,7 @@ pub struct ReflectX {
 
     /// X offset
     #[facet(default = 0.0)]
-    pub offset: f64,
+    pub offset: f32,
 }
 
 impl From<ReflectX> for Tree {
@@ -342,7 +342,7 @@ pub struct ReflectXY {
 
     /// Plane about which to reflect the shape
     #[facet(default = 0.0)]
-    pub offset: f64,
+    pub offset: f32,
 }
 
 impl From<ReflectXY> for Tree {
@@ -366,7 +366,7 @@ pub struct ReflectY {
 
     /// Y offset
     #[facet(default = 0.0)]
-    pub offset: f64,
+    pub offset: f32,
 }
 
 impl From<ReflectY> for Tree {
@@ -390,7 +390,7 @@ pub struct ReflectZ {
 
     /// Z offset
     #[facet(default = 0.0)]
-    pub offset: f64,
+    pub offset: f32,
 }
 
 impl From<ReflectZ> for Tree {
@@ -418,7 +418,7 @@ pub struct Rotate {
 
     /// Angle to rotate (in degrees)
     #[facet(default = 0.0)]
-    pub angle: f64,
+    pub angle: f32,
 
     /// Center of rotation
     #[facet(default = Vec3::new(0.0, 0.0, 0.0))]
@@ -434,7 +434,7 @@ impl From<Rotate> for Tree {
         let d = -v.angle.to_radians();
         let axis = v.axis.vec();
         let shape = shape.remap_affine(nalgebra::convert(
-            nalgebra::Rotation3::<f64>::new(nalgebra::Vector3::from(d * *axis)),
+            nalgebra::Rotation3::<f32>::new(nalgebra::Vector3::from(d * *axis)),
         ));
         Move {
             shape,
@@ -452,7 +452,7 @@ pub struct RotateX {
 
     /// Angle to rotate (in degrees)
     #[facet(default = 0.0)]
-    pub angle: f64,
+    pub angle: f32,
 
     /// Center of rotation
     #[facet(default = Vec3::new(0.0, 0.0, 0.0))]
@@ -479,7 +479,7 @@ pub struct RotateY {
 
     /// Angle to rotate (in degrees)
     #[facet(default = 0.0)]
-    pub angle: f64,
+    pub angle: f32,
 
     /// Center of rotation
     #[facet(default = Vec3::new(0.0, 0.0, 0.0))]
@@ -506,7 +506,7 @@ pub struct RotateZ {
 
     /// Angle to rotate (in degrees)
     #[facet(default = 0.0)]
-    pub angle: f64,
+    pub angle: f32,
 
     /// Center of rotation
     #[facet(default = Vec3::new(0.0, 0.0, 0.0))]
@@ -534,7 +534,7 @@ pub struct RevolveY {
     pub shape: Tree,
     /// X offset about which to revolve
     #[facet(default = 0.0)]
-    pub offset: f64,
+    pub offset: f32,
 }
 
 impl From<RevolveY> for Tree {
@@ -558,10 +558,10 @@ pub struct ExtrudeZ {
     pub shape: Tree,
     /// Lower bounds of the extrusion
     #[facet(default = 0.0)]
-    pub lower: f64,
+    pub lower: f32,
     /// Upper bounds of the extrusion
     #[facet(default = 1.0)]
-    pub upper: f64,
+    pub upper: f32,
 }
 
 impl From<ExtrudeZ> for Tree {
@@ -581,10 +581,10 @@ pub struct LoftZ {
     pub b: Tree,
     /// Lower bounds of the loft
     #[facet(default = 0.0)]
-    pub lower: f64,
+    pub lower: f32,
     /// Upper bounds of the loft
     #[facet(default = 1.0)]
-    pub upper: f64,
+    pub upper: f32,
 }
 
 impl From<LoftZ> for Tree {
@@ -608,10 +608,10 @@ pub struct RepeatX {
     pub shape: Tree,
     /// Radius of the region to repeat
     #[facet(default = 1.0)]
-    pub radius: f64,
+    pub radius: f32,
     /// X position about which to repeat
     #[facet(default = 0.0)]
-    pub offset: f64,
+    pub offset: f32,
 }
 
 impl From<RepeatX> for Tree {
@@ -805,7 +805,7 @@ mod test {
         #[derive(Clone, facet::Facet)]
         struct BadShape {
             #[facet(default)]
-            center: f64,
+            center: f32,
         }
         impl From<BadShape> for Tree {
             fn from(_: BadShape) -> Tree {
@@ -850,7 +850,7 @@ mod test {
 
         // Check the three repetitions closest to the center
         for i in 0..=1000 {
-            let x = (i as f64 / 1000.0) - (1000.0 - i as f64) / 1000.0;
+            let x = (i as f32 / 1000.0) - (1000.0 - i as f32) / 1000.0;
             let vc = ctx.eval_xyz(c, x, 0.0, 0.0).unwrap();
             let err = (vc - ctx.eval_xyz(r, x, 0.0, 0.0).unwrap()).abs();
             assert!(err < 1e-6, "bad err {err} at {x}");
@@ -876,7 +876,7 @@ mod test {
 
         // Check the three repetitions closest to the center
         for i in 0..=1000 {
-            let x = 0.75 * ((i as f64 / 1000.0) - (1000.0 - i as f64) / 1000.0)
+            let x = 0.75 * ((i as f32 / 1000.0) - (1000.0 - i as f32) / 1000.0)
                 + 1.0;
             let vc = ctx.eval_xyz(c, x, 0.0, 0.0).unwrap();
             let err = (vc - ctx.eval_xyz(r, x, 0.0, 0.0).unwrap()).abs();

--- a/fidget-shapes/src/types.rs
+++ b/fidget-shapes/src/types.rs
@@ -15,11 +15,11 @@ use fidget_core::context::Tree;
 pub enum AxisError {
     /// Vector is too short to convert to an axis
     #[error("vector is too short to convert to an axis (length: {0})")]
-    TooShort(f64),
+    TooShort(f32),
 
     /// Vector is too long to convert to an axis
     #[error("vector is too long to convert to an axis (length: {0})")]
-    TooLong(f64),
+    TooLong(f32),
 
     /// Could not normalize vector due to an invalid length
     #[error("could not normalize vector due to an invalid length")]
@@ -40,12 +40,12 @@ pub struct WrongType {
 #[derive(Copy, Clone, Debug, PartialEq, Facet)]
 #[allow(missing_docs)]
 pub struct Vec2 {
-    pub x: f64,
-    pub y: f64,
+    pub x: f32,
+    pub y: f32,
 }
 
-impl From<nalgebra::Vector2<f64>> for Vec2 {
-    fn from(value: nalgebra::Vector2<f64>) -> Self {
+impl From<nalgebra::Vector2<f32>> for Vec2 {
+    fn from(value: nalgebra::Vector2<f32>) -> Self {
         Self {
             x: value.x,
             y: value.y,
@@ -53,34 +53,34 @@ impl From<nalgebra::Vector2<f64>> for Vec2 {
     }
 }
 
-impl From<Vec2> for nalgebra::Vector2<f64> {
+impl From<Vec2> for nalgebra::Vector2<f32> {
     fn from(value: Vec2) -> Self {
         Self::new(value.x, value.y)
     }
 }
 
-impl From<f64> for Vec2 {
-    fn from(value: f64) -> Self {
+impl From<f32> for Vec2 {
+    fn from(value: f32) -> Self {
         Self { x: value, y: value }
     }
 }
 
 impl Vec2 {
     /// Builds a new `Vec2` from `x, y` coordinates
-    pub fn new(x: f64, y: f64) -> Self {
+    pub fn new(x: f32, y: f32) -> Self {
         Self { x, y }
     }
     /// Returns the L2-norm
-    pub fn norm(&self) -> f64 {
+    pub fn norm(&self) -> f32 {
         (self.x.powi(2) + self.y.powi(2)).sqrt()
     }
-    fn combine<F: Fn(f64, f64) -> f64>(self, rhs: Self, f: F) -> Self {
+    fn combine<F: Fn(f32, f32) -> f32>(self, rhs: Self, f: F) -> Self {
         Self {
             x: f(self.x, rhs.x),
             y: f(self.y, rhs.y),
         }
     }
-    fn map<F: Fn(f64) -> f64>(self, f: F) -> Self {
+    fn map<F: Fn(f32) -> f32>(self, f: F) -> Self {
         Self {
             x: f(self.x),
             y: f(self.y),
@@ -94,13 +94,13 @@ impl Vec2 {
 #[derive(Copy, Clone, Debug, PartialEq, Facet)]
 #[allow(missing_docs)]
 pub struct Vec3 {
-    pub x: f64,
-    pub y: f64,
-    pub z: f64,
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
 }
 
-impl From<nalgebra::Vector3<f64>> for Vec3 {
-    fn from(value: nalgebra::Vector3<f64>) -> Self {
+impl From<nalgebra::Vector3<f32>> for Vec3 {
+    fn from(value: nalgebra::Vector3<f32>) -> Self {
         Self {
             x: value.x,
             y: value.y,
@@ -109,14 +109,14 @@ impl From<nalgebra::Vector3<f64>> for Vec3 {
     }
 }
 
-impl From<Vec3> for nalgebra::Vector3<f64> {
+impl From<Vec3> for nalgebra::Vector3<f32> {
     fn from(value: Vec3) -> Self {
         Self::new(value.x, value.y, value.z)
     }
 }
 
-impl From<f64> for Vec3 {
-    fn from(value: f64) -> Self {
+impl From<f32> for Vec3 {
+    fn from(value: f32) -> Self {
         Self {
             x: value,
             y: value,
@@ -127,21 +127,21 @@ impl From<f64> for Vec3 {
 
 impl Vec3 {
     /// Builds a new `Vec3` from `x, y, z` coordinates
-    pub fn new(x: f64, y: f64, z: f64) -> Self {
+    pub fn new(x: f32, y: f32, z: f32) -> Self {
         Self { x, y, z }
     }
     /// Returns the L2-norm
-    pub fn norm(&self) -> f64 {
+    pub fn norm(&self) -> f32 {
         (self.x.powi(2) + self.y.powi(2) + self.z.powi(2)).sqrt()
     }
-    fn combine<F: Fn(f64, f64) -> f64>(self, rhs: Self, f: F) -> Self {
+    fn combine<F: Fn(f32, f32) -> f32>(self, rhs: Self, f: F) -> Self {
         Self {
             x: f(self.x, rhs.x),
             y: f(self.y, rhs.y),
             z: f(self.z, rhs.z),
         }
     }
-    fn map<F: Fn(f64) -> f64>(self, f: F) -> Self {
+    fn map<F: Fn(f32) -> f32>(self, f: F) -> Self {
         Self {
             x: f(self.x),
             y: f(self.y),
@@ -156,14 +156,14 @@ impl Vec3 {
 #[derive(Copy, Clone, Debug, PartialEq, Facet)]
 #[allow(missing_docs)]
 pub struct Vec4 {
-    pub x: f64,
-    pub y: f64,
-    pub z: f64,
-    pub w: f64,
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+    pub w: f32,
 }
 
-impl From<nalgebra::Vector4<f64>> for Vec4 {
-    fn from(value: nalgebra::Vector4<f64>) -> Self {
+impl From<nalgebra::Vector4<f32>> for Vec4 {
+    fn from(value: nalgebra::Vector4<f32>) -> Self {
         Self {
             x: value.x,
             y: value.y,
@@ -173,14 +173,14 @@ impl From<nalgebra::Vector4<f64>> for Vec4 {
     }
 }
 
-impl From<Vec4> for nalgebra::Vector4<f64> {
+impl From<Vec4> for nalgebra::Vector4<f32> {
     fn from(value: Vec4) -> Self {
         Self::new(value.x, value.y, value.z, value.w)
     }
 }
 
-impl From<f64> for Vec4 {
-    fn from(value: f64) -> Self {
+impl From<f32> for Vec4 {
+    fn from(value: f32) -> Self {
         Self {
             x: value,
             y: value,
@@ -191,7 +191,7 @@ impl From<f64> for Vec4 {
 }
 
 impl Vec4 {
-    fn combine<F: Fn(f64, f64) -> f64>(self, rhs: Self, f: F) -> Self {
+    fn combine<F: Fn(f32, f32) -> f32>(self, rhs: Self, f: F) -> Self {
         Self {
             x: f(self.x, rhs.x),
             y: f(self.y, rhs.y),
@@ -199,7 +199,7 @@ impl Vec4 {
             w: f(self.w, rhs.w),
         }
     }
-    fn map<F: Fn(f64) -> f64>(self, f: F) -> Self {
+    fn map<F: Fn(f32) -> f32>(self, f: F) -> Self {
         Self {
             x: f(self.x),
             y: f(self.y),
@@ -220,15 +220,15 @@ macro_rules! impl_binary {
                 self.combine(rhs, |a, b| a.$base_fn(b))
             }
         }
-        impl std::ops::$op<$ty> for f64 {
+        impl std::ops::$op<$ty> for f32 {
             type Output = $ty;
             fn $base_fn(self, rhs: $ty) -> $ty {
                 $ty::from(self).$base_fn(rhs)
             }
         }
-        impl std::ops::$op<f64> for $ty {
+        impl std::ops::$op<f32> for $ty {
             type Output = $ty;
-            fn $base_fn(self, rhs: f64) -> $ty {
+            fn $base_fn(self, rhs: f32) -> $ty {
                 self.$base_fn($ty::from(rhs))
             }
         }
@@ -340,7 +340,7 @@ pub struct Plane {
     /// Axis orthogonal to the plane
     pub axis: Axis,
     /// Offset relative to the origin
-    pub offset: f64,
+    pub offset: f32,
 }
 
 impl Plane {
@@ -376,7 +376,7 @@ impl From<Plane> for Tree {
 #[strum_discriminants(name(Type), derive(enum_map::Enum), allow(missing_docs))]
 #[allow(missing_docs)]
 pub enum Value {
-    Float(f64),
+    Float(f32),
     Vec2(Vec2),
     Vec3(Vec3),
     Vec4(Vec4),
@@ -431,7 +431,7 @@ macro_rules! try_from_type {
     };
 }
 
-try_from_type!(f64, Float);
+try_from_type!(f32, Float);
 try_from_type!(Vec2);
 try_from_type!(Vec3);
 try_from_type!(Vec4);
@@ -443,7 +443,7 @@ try_from_type!(Vec<Tree>, VecTree);
 impl std::fmt::Display for Type {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = match self {
-            Type::Float => "f64",
+            Type::Float => "f32",
             Type::Vec2 => "Vec2",
             Type::Vec3 => "Vec3",
             Type::Vec4 => "Vec4",
@@ -460,7 +460,7 @@ impl std::fmt::Display for Type {
 impl TryFrom<facet::ConstTypeId> for Type {
     type Error = facet::ConstTypeId;
     fn try_from(t: facet::ConstTypeId) -> Result<Self, Self::Error> {
-        if t == ConstTypeId::of::<f64>() {
+        if t == ConstTypeId::of::<f32>() {
             Ok(Self::Float)
         } else if t == ConstTypeId::of::<Vec2>() {
             Ok(Self::Vec2)

--- a/fidget/tests/pixel_render.rs
+++ b/fidget/tests/pixel_render.rs
@@ -373,7 +373,7 @@ fn check_circle_var<F: Function + MathFunction + RenderHints>() {
 
 fn check_neg_infinity<F: Function + MathFunction + RenderHints>() {
     let mut ctx = Context::new();
-    let root = ctx.constant(-f64::INFINITY);
+    let root = ctx.constant(-f32::INFINITY);
     let shape = Shape::<F>::new(&ctx, root).unwrap().try_into().unwrap();
 
     let cfg = RenderConfig {

--- a/fidget/tests/voxel_render.rs
+++ b/fidget/tests/voxel_render.rs
@@ -135,7 +135,7 @@ mod wgpu {
                     )
                     .unwrap();
 
-                check_sphere(image, size, scale, r as f32);
+                check_sphere(image, size, scale, r);
             }
         }
     }


### PR DESCRIPTION
Fidget's evaluators have always used `f32` values.  However, many other parts of the pipeline (constants in a `Context`, parameters in a shape, transform matrices, etc) used `f64`s.  This was particularly noticeable in evaluation: the context's tree-walk evaluator used `f64` values, as did the evaluator test suite.  Tiny discrepancies necessitated a bunch of extra logic (epsilons everywhere, etc).

This PR switches to using `f32` everywhere in Fidget (for things that eventually end up being evaluated).  It then deletes and simplifies a bunch of awkward hacks and workarounds.

Notably, the evaluator test suite now requires are in *exact agreement* with the canonical implementation.  Unfortunately, the assembly implementations of `modulo` fell by the wayside; they now call into the baseline implementation, at slightly higher overhead.