### PR TITLE
Make voxel buffer merging take a single image at a time

### DIFF
--- a/demos/cli/src/main.rs
+++ b/demos/cli/src/main.rs
@@ -414,7 +414,7 @@ fn run3d_wgpu(
         }
         RenderMode3D::BlurredOcclusion { denoise } => {
             effects.submit_merge(
-                &[buffers.image_storage_buffer()],
+                buffers.image_storage_buffer(),
                 denoise,
                 &mut merge_buf,
             )?;
@@ -424,7 +424,7 @@ fn run3d_wgpu(
         }
         RenderMode3D::RawOcclusion { denoise } => {
             effects.submit_merge(
-                &[buffers.image_storage_buffer()],
+                buffers.image_storage_buffer(),
                 denoise,
                 &mut merge_buf,
             )?;
@@ -434,7 +434,7 @@ fn run3d_wgpu(
         }
         RenderMode3D::Shaded { denoise, ssao } => {
             effects.submit_merge(
-                &[buffers.image_storage_buffer()],
+                buffers.image_storage_buffer(),
                 denoise,
                 &mut merge_buf,
             )?;

--- a/fidget-wgpu/src/voxel/effects/mod.rs
+++ b/fidget-wgpu/src/voxel/effects/mod.rs
@@ -133,12 +133,6 @@ struct MergeConfig {
     ///
     /// When this is 0, we initialize the output image
     index_base: u32,
-
-    /// Number of valid image buffers (0-7)
-    image_count: u32,
-
-    // padding to the nearest multiple of 8
-    _pad: u32,
 }
 
 #[derive(Copy, Clone, FromBytes, Immutable, IntoBytes, KnownLayout)]
@@ -171,6 +165,14 @@ impl MergeBuffers {
     /// Returns a handle to the output buffer
     pub fn output(&self) -> &DepthImageBuffer<MergeVoxelBufferTag> {
         &self.out
+    }
+
+    /// Resets the merge buffer
+    ///
+    /// The next call to [`Context::submit_merge`] will clear the buffer and
+    /// begin accumulating from scratch.
+    pub fn reset(&mut self) {
+        self.image_count = 0;
     }
 }
 
@@ -273,15 +275,9 @@ impl Context {
             &wgpu::BindGroupLayoutDescriptor {
                 label: None,
                 entries: &[
-                    buffer_uniform(0),
-                    buffer_ro(1), // image0
-                    buffer_ro(2), // image1
-                    buffer_ro(3), // image2
-                    buffer_ro(4), // image3
-                    buffer_ro(5), // image4
-                    buffer_ro(6), // image5
-                    buffer_ro(7), // image6
-                    buffer_rw(8), // out
+                    buffer_uniform(0), // config
+                    buffer_ro(1),      // image
+                    buffer_rw(2),      // out
                 ],
             },
         );
@@ -447,34 +443,29 @@ impl Context {
         }
     }
 
-    /// Submits a set of merge operations to combine all of the images
+    /// Accumulates an image into a merged image buffer
     ///
-    /// The output buffer is resized to fit the images
-    ///
-    /// If the incoming slice is empty, then no work is submitted
+    /// If the merged buffer has been reset (with [`MergeBuffers::reset`]), then
+    /// it is resized to fit the incoming image; otherwise, an error is returned
+    /// if the image size does not match.
     pub fn submit_merge(
         &self,
-        images: &[&DepthImageBuffer<GeomBufferTag>],
+        image: &DepthImageBuffer<GeomBufferTag>,
         denoise: bool,
         buf: &mut MergeBuffers,
     ) -> Result<(), MergeError> {
-        buf.image_count = images.len();
-        let Some(size) = images.first().map(|i| i.size()) else {
-            return Ok(());
-        };
-        for i in &images[1..] {
-            let actual = i.size();
-            if actual != size {
-                return Err(ImageSizeMismatch {
-                    expected: size,
-                    actual,
-                }
-                .into());
+        let size = image.size();
+        if buf.image_count == 0 {
+            buf.out
+                .grow_to_fit(&self.gpu.device, size)
+                .map_err(MergeError::OutputSize)?;
+        } else if buf.out.size() != size {
+            return Err(ImageSizeMismatch {
+                expected: size,
+                actual: buf.out.size(),
             }
+            .into());
         }
-        buf.out
-            .grow_to_fit(&self.gpu.device, size)
-            .map_err(MergeError::OutputSize)?;
         let mut encoder = self.gpu.device.create_command_encoder(
             &wgpu::CommandEncoderDescriptor {
                 label: Some("merge compute encoder"),
@@ -488,38 +479,30 @@ impl Context {
                     timestamp_writes: None, // TODO add timestamps?
                 });
             compute_pass.set_pipeline(&self.merge_pipeline);
-            for (i, chunk) in images.chunks(7).enumerate() {
-                let cfg = MergeConfig {
-                    image_size: [size.width(), size.height()],
-                    denoise: denoise as u32,
-                    index_base: i as u32 * 7,
-                    image_count: chunk.len() as u32,
-                    _pad: 0,
-                };
-                {
-                    let mut writer = self
-                        .gpu
-                        .queue
-                        .write_buffer_with(
-                            &buf.config,
-                            0,
-                            (std::mem::size_of::<MergeConfig>() as u64)
-                                .try_into()
-                                .unwrap(),
-                        )
-                        .unwrap();
-                    writer.copy_from_slice(cfg.as_bytes());
-                }
-                let image_bind = |i| wgpu::BindGroupEntry {
-                    binding: i as u32 + 1,
-                    resource: chunk
-                        .get(i)
-                        .unwrap_or_else(|| chunk.first().unwrap())
-                        .bind_active(),
-                };
+            let cfg = MergeConfig {
+                image_size: [size.width(), size.height()],
+                denoise: denoise as u32,
+                index_base: buf.image_count as u32,
+            };
+            {
+                let mut writer = self
+                    .gpu
+                    .queue
+                    .write_buffer_with(
+                        &buf.config,
+                        0,
+                        (std::mem::size_of::<MergeConfig>() as u64)
+                            .try_into()
+                            .unwrap(),
+                    )
+                    .unwrap();
+                writer.copy_from_slice(cfg.as_bytes());
+            }
 
-                let bg = self.gpu.device.create_bind_group(
-                    &wgpu::BindGroupDescriptor {
+            let bg =
+                self.gpu
+                    .device
+                    .create_bind_group(&wgpu::BindGroupDescriptor {
                         label: Some("merge bind group"),
                         layout: &self.merge_bind_group_layout,
                         entries: &[
@@ -527,27 +510,23 @@ impl Context {
                                 binding: 0,
                                 resource: buf.config.as_entire_binding(),
                             },
-                            image_bind(0),
-                            image_bind(1),
-                            image_bind(2),
-                            image_bind(3),
-                            image_bind(4),
-                            image_bind(5),
-                            image_bind(6),
                             wgpu::BindGroupEntry {
-                                binding: 8,
+                                binding: 1,
+                                resource: image.bind_active(),
+                            },
+                            wgpu::BindGroupEntry {
+                                binding: 2,
                                 resource: buf.out.bind_active(),
                             },
                         ],
-                    },
-                );
-                compute_pass.set_bind_group(0, Some(&bg), &[]);
-                compute_pass.dispatch_workgroups(
-                    size.width().div_ceil(8),
-                    size.height().div_ceil(8),
-                    1,
-                );
-            }
+                    });
+            compute_pass.set_bind_group(0, Some(&bg), &[]);
+            compute_pass.dispatch_workgroups(
+                size.width().div_ceil(8),
+                size.height().div_ceil(8),
+                1,
+            );
+            buf.image_count += 1;
         }
         self.gpu.queue.submit(Some(encoder.finish()));
         Ok(())
@@ -1306,7 +1285,7 @@ mod test {
             )
             .unwrap();
         effects_ctx
-            .submit_merge(&[buf.image_storage_buffer()], true, &mut merge_buf)
+            .submit_merge(buf.image_storage_buffer(), true, &mut merge_buf)
             .unwrap();
         let mut ssao_buf = effects_ctx.ssao_buffers();
         effects_ctx.submit_ssao(&merge_buf, &mut ssao_buf).unwrap();

--- a/fidget-wgpu/src/voxel/effects/shaders/merge.wgsl
+++ b/fidget-wgpu/src/voxel/effects/shaders/merge.wgsl
@@ -7,24 +7,11 @@ struct MergeConfig {
 
     /// Offset applied to indices when merging
     index_base: u32,
-
-    /// Number of valid image buffers (0-7)
-    image_count: u32,
-
-    // Explicit padding to the nearest multiple of 8
-    _pad: u32,
 }
 
 @group(0) @binding(0) var<uniform> config: MergeConfig;
-
-@group(0) @binding(1) var<storage, read> image0: array<GeometryPixel>;
-@group(0) @binding(2) var<storage, read> image1: array<GeometryPixel>;
-@group(0) @binding(3) var<storage, read> image2: array<GeometryPixel>;
-@group(0) @binding(4) var<storage, read> image3: array<GeometryPixel>;
-@group(0) @binding(5) var<storage, read> image4: array<GeometryPixel>;
-@group(0) @binding(6) var<storage, read> image5: array<GeometryPixel>;
-@group(0) @binding(7) var<storage, read> image6: array<GeometryPixel>;
-@group(0) @binding(8) var<storage, read_write> out: array<PackedVoxel>;
+@group(0) @binding(1) var<storage, read> image: array<GeometryPixel>;
+@group(0) @binding(2) var<storage, read_write> out: array<PackedVoxel>;
 
 
 @compute @workgroup_size(8, 8)
@@ -33,8 +20,7 @@ fn merge_main(
 ) {
     // Clamp to image size
     if global_id.x >= config.image_size.x ||
-       global_id.y >= config.image_size.y ||
-       config.image_count == 0
+       global_id.y >= config.image_size.y
     {
         return;
     }
@@ -42,50 +28,31 @@ fn merge_main(
     let pos = global_id.xy;
     let i = config.image_size.x * pos.y + pos.x;
 
-    var p = PackedVoxel(0, 0); // dummy value
-    let b = pack_at(0, pos);
+    // Read and pack the pixel from the input image
+    let b = pack_at(pos);
+
+    // Either write the pixel directly or merge it with the previous value
     if config.index_base == 0 {
-        p = b;
+        out[i] = b;
     } else {
-        p = merge_pixel(out[i], b);
+        out[i] = merge_pixel(out[i], b);
     }
-
-    if config.image_count > 1 {
-        p = merge_pixel(p, pack_at(1, pos));
-    }
-    if config.image_count > 2 {
-        p = merge_pixel(p, pack_at(2, pos));
-    }
-    if config.image_count > 3 {
-        p = merge_pixel(p, pack_at(3, pos));
-    }
-    if config.image_count > 4 {
-        p = merge_pixel(p, pack_at(4, pos));
-    }
-    if config.image_count > 5 {
-        p = merge_pixel(p, pack_at(5, pos));
-    }
-    if config.image_count > 6 {
-        p = merge_pixel(p, pack_at(6, pos));
-    }
-
-    out[i] = p;
 }
 
-fn pack_at(image_index: u32, pos: vec2u) -> PackedVoxel {
+fn pack_at(pos: vec2u) -> PackedVoxel {
     let i = config.image_size.x * pos.y + pos.x;
-    let p = maybe_denoise(image_index, pos);
-    return pack(TaggedGeometryPixel(p, image_index + config.index_base));
+    let p = maybe_denoise(pos);
+    return pack(TaggedGeometryPixel(p, config.index_base));
 }
 
-fn maybe_denoise(image_index: u32, pos: vec2u) -> GeometryPixel {
-    let pixel = read_pixel(image_index, pos.x + pos.y * config.image_size.x);
+fn maybe_denoise(pos: vec2u) -> GeometryPixel {
+    let pixel = image[pos.x + pos.y * config.image_size.x];
     if config.denoise != 0 {
         if pixel.depth > 0 {
             if pixel.normal.z > 0.0 {
                 return pixel;
             } else {
-                let normal = denoise_at(image_index, pos, pixel);
+                let normal = denoise_at(pos, pixel);
                 return GeometryPixel(normal, pixel.depth);
             }
         } else {
@@ -99,7 +66,7 @@ fn maybe_denoise(image_index: u32, pos: vec2u) -> GeometryPixel {
     }
 }
 
-fn denoise_at(image_index: u32, pos: vec2u, pixel: GeometryPixel) -> vec3f {
+fn denoise_at(pos: vec2u, pixel: GeometryPixel) -> vec3f {
     let empty = GeometryPixel(vec3f(0.0), 0);
     var data = array<array<GeometryPixel, 3>, 3>(
         array<GeometryPixel, 3>(empty, empty, empty),
@@ -118,10 +85,9 @@ fn denoise_at(image_index: u32, pos: vec2u, pixel: GeometryPixel) -> vec3f {
             {
                 continue;
             }
-            data[i + 1][j + 1] = read_pixel(
-                image_index,
+            data[i + 1][j + 1] = image[
                 u32(new_pos.x) + u32(new_pos.y) * config.image_size.x
-            );
+            ];
         }
     }
 
@@ -173,19 +139,6 @@ fn denoise_at(image_index: u32, pos: vec2u, pixel: GeometryPixel) -> vec3f {
         return pixel.normal;
     }
     return best.xyz;
-}
-
-fn read_pixel(image_index: u32, pixel_index: u32) -> GeometryPixel {
-    switch image_index {
-        case 0: { return image0[pixel_index]; }
-        case 1: { return image1[pixel_index]; }
-        case 2: { return image2[pixel_index]; }
-        case 3: { return image3[pixel_index]; }
-        case 4: { return image4[pixel_index]; }
-        case 5: { return image5[pixel_index]; }
-        case 6: { return image6[pixel_index]; }
-        default: { return GeometryPixel(vec3f(0.0), 0); }
-    }
 }
 
 fn merge_pixel(a: PackedVoxel, b: PackedVoxel) -> PackedVoxel {

--- a/fidget-wgpu/src/voxel/mod.rs
+++ b/fidget-wgpu/src/voxel/mod.rs
@@ -2834,11 +2834,7 @@ mod test {
                 .submit(&shape, &mut buf, None, &render_config)
                 .unwrap();
             effects_ctx
-                .submit_merge(
-                    &[buf.image_storage_buffer()],
-                    true,
-                    &mut merge_buf,
-                )
+                .submit_merge(buf.image_storage_buffer(), true, &mut merge_buf)
                 .unwrap();
         }
         let merged = gpu.read_vec::<PackedVoxel>(merge_buf.output().data());


### PR DESCRIPTION
In actual usage, we won't want multiple `Buffers` objects (because they're expensive), so alternating between render and merge seems reasonable.