### PR TITLE
Add on-GPU pixel color evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@
   for the suggestion!
 - Add `fidget::wgpu::pixel` module for 2D rasterization on the GPU.  This is
   sometimes slower than the CPU evaluator for very complex expressions, but is
-  blazingly fast for simpler expressions.  Plus, it allows for all-GPU
-  evaluation architecture when embedded Fidget into other applications.
+  blazingly fast for simpler expressions.  Plus, it allows for an all-GPU
+  evaluation architecture when embedding Fidget into other applications.
     - The `fidget::wgpu::pixel::effects` module is also new; it includes merging
       and color evaluation for 2D images.
 - Move more VM functions onto `Grad` and `Interval` (out of the VM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,11 @@
   semantics.  This allows trees to be stored in hashmaps; thanks to @virtualritz
   for the suggestion!
 - Add `fidget::wgpu::pixel` module for 2D rasterization on the GPU.  This is
-  often slower than the CPU evaluator – there just aren't enough pixels for
-  parallelism to really kick in – but it's useful for consistency.
+  sometimes slower than the CPU evaluator for very complex expressions, but is
+  blazingly fast for simpler expressions.  Plus, it allows for all-GPU
+  evaluation architecture when embedded Fidget into other applications.
+    - The `fidget::wgpu::pixel::effects` module is also new; it includes merging
+      and color evaluation for 2D images.
 - Move more VM functions onto `Grad` and `Interval` (out of the VM
   implementation); add a `FloatExt` trait which adds them to `f32` as well.
 - Fix a JIT bug in the gradient evaluator on Windows, where we assumed that
@@ -51,6 +54,10 @@
   helpful if you're going to combine multiple bytecode tapes and want them to
   share a common input indexing order.
 - `VarMap` now implements `Debug`
+- `VarMap::has_free_vars` checks whether there are non-XYZ vars in the map
+- `RawDistancePixel` now implements `zerocopy::IntoBytes`
+- `submit*` functions in WebGPU voxel rendering no longer take an optional `out`
+  parameter; it's instead passed into `map_image[_async]`.
 
 # 0.5.0
 This is a large release with a bunch of small features, reorganization, and one

--- a/demos/cli/src/main.rs
+++ b/demos/cli/src/main.rs
@@ -389,8 +389,8 @@ fn run3d_wgpu(
     let shape = gpu.shape(&shape)?;
     let mut compute_pass_time = std::time::Duration::ZERO;
     for _ in 0..settings.n {
-        ctx.submit(&shape, &mut buffers, Some(&mut out), &cfg)?;
-        let img = ctx.map_image(&mut out);
+        ctx.submit(&shape, &mut buffers, &cfg)?;
+        let img = ctx.map_image(&buffers, &mut out);
         compute_pass_time += img.time().unwrap();
         image = img.image();
     }
@@ -671,8 +671,8 @@ fn run2d_wgpu(
     let mut compute_pass_time = std::time::Duration::ZERO;
     let mut postprocess_time = std::time::Duration::ZERO;
     for _ in 0..settings.n {
-        ctx.submit(&shape, &mut buffers, Some(&mut out), &cfg)?;
-        let img = ctx.map_image(&mut out);
+        ctx.submit(&shape, &mut buffers, &cfg)?;
+        let img = ctx.map_image(&buffers, &mut out);
         compute_pass_time += img.time().unwrap();
         let pp_start = std::time::Instant::now();
         image = postprocess2d(img.image(), &mode, threads);

--- a/fidget-core/src/var/mod.rs
+++ b/fidget-core/src/var/mod.rs
@@ -134,6 +134,12 @@ impl VarMap {
             Var::V(v) => self.v.get(v).cloned(),
         }
     }
+
+    /// Checks whether there are free (non-XYZ) variables present in the map
+    pub fn has_free_vars(&self) -> bool {
+        !self.v.is_empty()
+    }
+
     /// Inserts a variable if not already present in the map
     ///
     /// The index is automatically assigned.

--- a/fidget-raster/src/pixel.rs
+++ b/fidget-raster/src/pixel.rs
@@ -157,7 +157,13 @@ impl Scratch {
 ///   treated as `NaN` in the `[empty, depth 0]` case (rather than infinity) and
 ///   distinguishes from `NaN` values generated during normal evaluation
 #[derive(
-    Copy, Clone, Debug, Default, zerocopy::FromBytes, zerocopy::Immutable,
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    zerocopy::FromBytes,
+    zerocopy::Immutable,
+    zerocopy::IntoBytes,
 )]
 #[repr(C)]
 pub struct RawDistancePixel(f32);

--- a/fidget-wgpu/src/lib.rs
+++ b/fidget-wgpu/src/lib.rs
@@ -4,6 +4,7 @@
 use fidget_bytecode::{Bytecode, ReservedRegister};
 use fidget_core::{
     eval::Function,
+    shape::{MissingVar, ShapeVars},
     var::{Var, VarMap},
     vm::VmShape,
 };
@@ -366,7 +367,7 @@ pub enum ShapeColor<T> {
     },
 }
 
-impl<C> ShapeColorBuffers<C> {
+impl<C: IntoBytes + Immutable> ShapeColorBuffers<C> {
     fn new(
         colors: &[ShapeColor<VmShape>],
         device: &wgpu::Device,
@@ -468,6 +469,46 @@ impl<C> ShapeColorBuffers<C> {
     fn axes(&self) -> [u32; 3] {
         [Var::X, Var::Y, Var::Z]
             .map(|a| self.var_map.get(&a).map(|v| v as u32).unwrap_or(u32::MAX))
+    }
+
+    fn write_config(&self, c: &C, queue: &wgpu::Queue) {
+        let config_len = std::mem::size_of::<C>();
+        let mut writer = queue
+            .write_buffer_with(
+                &self.config,
+                0,
+                (config_len as u64).try_into().unwrap(),
+            )
+            .unwrap();
+        writer.copy_from_slice(c.as_bytes());
+    }
+
+    fn write_vars(
+        &self,
+        vars: &ShapeVars<f32>,
+        queue: &wgpu::Queue,
+    ) -> Result<(), MissingVar> {
+        if self.var_map.has_free_vars() {
+            let var_size = self.vars.size();
+            let mut writer = queue
+                .write_buffer_with(&self.vars, 0, var_size.try_into().unwrap())
+                .unwrap();
+            for (v, i) in self.var_map.iter() {
+                match v {
+                    Var::X | Var::Y | Var::Z => (),
+                    Var::V(vi) => {
+                        let Some(value) = vars.get(vi) else {
+                            return Err(MissingVar { var: vi });
+                        };
+                        let offset = i * std::mem::size_of::<f32>();
+                        writer
+                            .slice(offset..offset + 4)
+                            .copy_from_slice(value.as_bytes());
+                    }
+                }
+            }
+        }
+        Ok(())
     }
 
     fn config_bind_group(

--- a/fidget-wgpu/src/lib.rs
+++ b/fidget-wgpu/src/lib.rs
@@ -319,7 +319,7 @@ impl RenderShape {
 ////////////////////////////////////////////////////////////////////////////////
 
 /// Color buffers for rendering a shape's diffuse color
-pub struct ShapeColorBuffers {
+pub struct ShapeColorBuffers<C> {
     /// Unified [`VarMap`] object
     var_map: VarMap,
 
@@ -348,6 +348,9 @@ pub struct ShapeColorBuffers {
     /// This doesn't live in a `Buffers` object because it's dynamically sized
     /// based on the shape; everything in `Buffers` is based on image size.
     vars: wgpu::Buffer,
+
+    // Marker for the config type
+    _config: std::marker::PhantomData<C>,
 }
 
 /// Generic shape color generator
@@ -363,11 +366,10 @@ pub enum ShapeColor<T> {
     },
 }
 
-impl ShapeColorBuffers {
+impl<C> ShapeColorBuffers<C> {
     fn new(
         colors: &[ShapeColor<VmShape>],
         device: &wgpu::Device,
-        config_size: usize,
     ) -> Result<Self, ShapeColorError> {
         // Build a single unified variable map, used across all tapes
         let mut var_map = VarMap::new();
@@ -435,6 +437,7 @@ impl ShapeColorBuffers {
             .copy_from_slice(shape_start.as_bytes());
         shape_start_buf.unmap();
 
+        let config_size = std::mem::size_of::<C>();
         let config_buf = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("shape_start"),
             size: u64::try_from(
@@ -457,6 +460,7 @@ impl ShapeColorBuffers {
             vars,
             config_bind_group: Default::default(),
             reg_count,
+            _config: std::marker::PhantomData,
         })
     }
 

--- a/fidget-wgpu/src/pixel/effects/mod.rs
+++ b/fidget-wgpu/src/pixel/effects/mod.rs
@@ -1,4 +1,21 @@
 //! Pixel post-processing pipelines
+//!
+//! There is a notable difference between voxel and pixel post-processing:
+//! instead of producing a fully-populated RGBA image to be drawn to the screen,
+//! we produce two images: one containing [`RawDistancePixel`] values, and one
+//! containing RGBA values (as 4-byte words).
+//!
+//! This is because – when the final shader draws to the screen – we can improve
+//! visual fidelity by interpolating between distance values (typically by the
+//! texture unit).  If we baked the final RGBA image, then drawing it at a
+//! different scale (e.g. the user has zoomed and we're waiting for the next
+//! image to be completed) would simply be blurry; with distance interpolation,
+//! it remains sharper (though not pixel-perfect).
+//!
+//! Output is stored in the [`MergeBuffers`] object, which wraps a single GPU
+//! buffer with back-to-back distance and color images.  Note that if color has
+//! not been computed, then the second image instead stores merged shape index,
+//! (which is not particularly meaningful to users).
 use crate::{
     Gpu,
     RegPipeline,

--- a/fidget-wgpu/src/pixel/effects/mod.rs
+++ b/fidget-wgpu/src/pixel/effects/mod.rs
@@ -1,22 +1,26 @@
 use crate::{
     Gpu,
     RegPipeline,
-    RenderShape,
-    TAPE_DATA_CAPACITY,
-    TapeWord,
+    ShapeColorBuffers,
     buf::{
-        ArrayBuffer, BufferItemCount, BufferSizeError, BufferType, ImageBuffer,
-        buffer_ro, buffer_ro_dyn, buffer_rw, buffer_uniform,
+        ArrayBuffer, BufferSizeError, ImageBuffer, buffer_ro, buffer_rw,
+        buffer_uniform,
     },
     pixel::{PixelBufferTag, RawDistancePixel},
     shaders,
     tag,
     voxel::effects::MergeConfig, // same layout, unit-tested to confirm
 };
-use fidget_core::render::ImageSize;
+use fidget_core::{
+    render::ImageSize,
+    shape::{MissingVar, ShapeVars},
+    var::Var,
+};
+use fidget_raster::RgbaImage;
+use std::num::NonZeroU64;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
-pub use crate::voxel::effects::{ImageSizeMismatch, MergeError};
+pub use crate::voxel::effects::{ColorError, ImageSizeMismatch, MergeError};
 
 const COMMON_SHADER: &str = include_str!("shaders/common.wgsl");
 const MERGE_SHADER: &str = include_str!("shaders/merge.wgsl");
@@ -46,24 +50,23 @@ fn color_shader(reg_count: u8) -> String {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-/// Tagged pixel structure used on the GPU
-#[derive(Copy, Clone, FromBytes, Immutable, IntoBytes, KnownLayout)]
-#[repr(C)]
-pub struct TaggedRawDistancePixel {
-    /// Distance value
-    pub distance: RawDistancePixel,
-    /// Shape index
-    pub index: u32,
-}
-
-tag!(pub MergeVoxelBufferTag, TaggedRawDistancePixel, STORAGE | COPY_SRC,
-    "Buffer tag for on-GPU merged ([`TaggedRawDistancePixel`]) images"
+tag!(
+    MergedPixelBufferTag,
+    [u32; 2], // This is a hack; we store two images side by side
+    STORAGE | COPY_SRC,
+    "Buffer tag for on-GPU merged images"
 );
 
 /// Handle to a set of buffers used when merging images
 pub struct MergeBuffers {
     config: wgpu::Buffer,
-    out: ImageBuffer<MergeVoxelBufferTag>,
+
+    /// Stores two images back-to-back
+    ///
+    /// The first image is [`RawDistancePixel`] data; the second is initially
+    /// the shape index then is rewritten to be color.
+    out: ImageBuffer<MergedPixelBufferTag>,
+
     image_count: usize,
 }
 
@@ -75,6 +78,8 @@ pub struct Context {
 
     merge_bind_group_layout: wgpu::BindGroupLayout,
     merge_pipeline: wgpu::ComputePipeline,
+
+    color_ctx: ColorContext,
 }
 
 impl Context {
@@ -121,10 +126,13 @@ impl Context {
             },
         );
 
+        let color_ctx = ColorContext::new(&gpu.device);
+
         Self {
             gpu: gpu.clone(),
             merge_bind_group_layout,
             merge_pipeline,
+            color_ctx,
         }
     }
 
@@ -256,7 +264,368 @@ impl Context {
             image_count: 0,
         })
     }
+
+    /// Submits a color evaluation pass
+    ///
+    /// Image size is set from the `MergeBuffers`; the transform matrix is
+    /// provided separately (but should be the same one used for image
+    /// evaluation).
+    pub fn submit_color(
+        &self,
+        merge: &mut MergeBuffers,
+        world_to_model: &nalgebra::Matrix3<f32>,
+        z: f32,
+        shape: &ShapeColorBuffers,
+    ) -> Result<(), ColorError> {
+        self.submit_color_with_vars(
+            merge,
+            world_to_model,
+            z,
+            shape,
+            &Default::default(),
+        )
+    }
+
+    /// Submits a color evaluation pass with auxiliary variables
+    ///
+    /// Image size is set from the `MergeBuffers`; the transform matrix is
+    /// provided separately (but should be the same one used for image
+    /// evaluation).
+    pub fn submit_color_with_vars(
+        &self,
+        merge: &mut MergeBuffers,
+        world_to_model: &nalgebra::Matrix3<f32>,
+        z: f32,
+        shape: &ShapeColorBuffers,
+        vars: &ShapeVars<f32>,
+    ) -> Result<(), ColorError> {
+        self.color_ctx
+            .submit(merge, world_to_model, z, shape, vars, &self.gpu)
+    }
+
+    /// Returns an [`ImageReadBuffer`] to read from a [`MergeBuffers`] object
+    pub fn image_buffer(&self) -> ImageReadBuffer {
+        ImageReadBuffer::new(&self.gpu.device, "image".to_owned())
+    }
+
+    /// Copies image data and maps a CPU-readable image buffer
+    pub fn map_image<'a>(
+        &self,
+        image_in: &'a MergeBuffers,
+        has_color: bool,
+        image_out: &'a mut ImageReadBuffer,
+    ) -> MappedImage<'a> {
+        let mut encoder = self.gpu.device.create_command_encoder(
+            &wgpu::CommandEncoderDescriptor { label: None },
+        );
+        image_out
+            .grow_to_fit(&self.gpu.device, image_in.out.size())
+            .expect(
+                "image_in.out.size() should always be \
+                a valid size for ImageReadBuffer::grow_to_fit",
+            );
+        encoder.copy_buffer_to_buffer(
+            image_in.out.data(),
+            0,
+            image_out.buffer.data(),
+            0,
+            image_in.out.size_bytes(),
+        );
+        self.gpu.queue.submit(Some(encoder.finish()));
+        let slice = image_out.buffer.map_async(|_| {});
+        self.gpu
+            .device
+            .poll(wgpu::PollType::wait_indefinitely())
+            .unwrap();
+        MappedImage {
+            image: image_out,
+            has_color,
+            slice,
+        }
+    }
 }
+
+////////////////////////////////////////////////////////////////////////////////
+
+/// Buffer for reading data back from the GPU
+///
+/// This object is constructed by [`Context::image_buffer`] and may only be used
+/// with that particular [`Context`].
+///
+/// Once mapped, this is wrapped by a [`MappedImage`]
+pub struct ImageReadBuffer {
+    /// Image render size
+    image_size: ImageSize,
+
+    /// Result buffer that can be read back from the CPU
+    buffer: ImageReadArrayBuffer,
+}
+
+impl ImageReadBuffer {
+    fn new(device: &wgpu::Device, name: String) -> Self {
+        let image_size = 64.into();
+        Self {
+            image_size,
+            buffer: ImageReadArrayBuffer::new(
+                device,
+                name,
+                image_size.width() as usize * image_size.height() as usize * 2,
+            )
+            .expect("64 should always be a valid size"),
+        }
+    }
+
+    fn grow_to_fit(
+        &mut self,
+        device: &wgpu::Device,
+        image_size: ImageSize,
+    ) -> Result<(), BufferSizeError> {
+        self.image_size = image_size;
+        self.buffer.grow_to_fit(
+            device,
+            image_size.width() as usize * image_size.height() as usize * 2,
+        )
+    }
+}
+
+tag!(ImageReadTag, u32, COPY_DST | MAP_READ);
+type ImageReadArrayBuffer = ArrayBuffer<ImageReadTag>;
+
+/// Handle to a mapped image, which unmaps the image when dropped
+pub struct MappedImage<'a> {
+    image: &'a ImageReadBuffer,
+    slice: wgpu::BufferSlice<'a>,
+
+    /// Set to `true` if the color portion of the buffer is valid
+    has_color: bool,
+}
+
+impl Drop for MappedImage<'_> {
+    fn drop(&mut self) {
+        self.image.buffer.data().unmap();
+    }
+}
+
+impl MappedImage<'_> {
+    /// Returns the image's distance data
+    pub fn distance(&self) -> super::Image {
+        // Get the pixel-populated image
+        let result = <[RawDistancePixel]>::ref_from_bytes(
+            &self.slice.get_mapped_range()[..self.image_bytes()],
+        )
+        .unwrap()
+        .to_owned();
+        super::Image::build(result, self.image.image_size).unwrap()
+    }
+
+    /// Returns the image's color data
+    pub fn color(&self) -> Option<RgbaImage> {
+        if self.has_color {
+            // Get the pixel-populated image
+            let result = <[[u8; 4]]>::ref_from_bytes(
+                &self.slice.get_mapped_range()[self.image_bytes()..],
+            )
+            .unwrap()
+            .to_owned();
+            Some(RgbaImage::build(result, self.image.image_size).unwrap())
+        } else {
+            None
+        }
+    }
+
+    fn image_bytes(&self) -> usize {
+        (self.image.image_size.width() as usize)
+            * (self.image.image_size.height() as usize)
+            * std::mem::size_of::<RawDistancePixel>()
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+/// Configuration for the color evaluation pass
+#[derive(Copy, Clone, FromBytes, Immutable, IntoBytes, KnownLayout)]
+#[cfg_attr(test, derive(facet::Facet))]
+#[repr(C)]
+struct ColorConfig {
+    /// Screen-to-model transform matrix (mat3x3)
+    mat: [f32; 12],
+
+    /// Input index of X, Y, Z axes
+    ///
+    /// `u32::MAX` is used as a marker if an axis is unused
+    axes: [u32; 3],
+
+    /// Z height at which to evaluate the colors
+    z: f32,
+
+    /// Image size (pixels)
+    image_size: [u32; 2],
+    // this is followed by a tape_data flexible array member
+}
+
+struct ColorContext {
+    /// Configuration bind group layout (shape-specific, includes tape data)
+    config_bind_group_layout: wgpu::BindGroupLayout,
+
+    /// Image bind groups (input and output)
+    image_bind_group_layout: wgpu::BindGroupLayout,
+
+    /// Pipeline for computing per-pixel color
+    color_pipeline: RegPipeline,
+}
+
+impl ColorContext {
+    pub fn new(device: &wgpu::Device) -> Self {
+        let config_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("color config and shape"),
+                entries: &[buffer_ro(0), buffer_ro(1), buffer_ro(2)],
+            });
+        let image_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("color images"),
+                entries: &[buffer_rw(0)],
+            });
+
+        let pipeline_layout =
+            device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("color pipeline"),
+                bind_group_layouts: &[
+                    Some(&config_bind_group_layout),
+                    Some(&image_bind_group_layout),
+                ],
+                immediate_size: 0u32,
+            });
+        let color_pipeline = RegPipeline::build(|reg_count| {
+            let shader_code = color_shader(reg_count);
+            let shader_module =
+                device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                    label: None,
+                    source: wgpu::ShaderSource::Wgsl(shader_code.into()),
+                });
+            device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                label: Some(&format!("color ({reg_count})")),
+                layout: Some(&pipeline_layout),
+                module: &shader_module,
+                entry_point: Some("color_main"),
+                compilation_options: Default::default(),
+                cache: None,
+            })
+        });
+
+        Self {
+            config_bind_group_layout,
+            image_bind_group_layout,
+            color_pipeline,
+        }
+    }
+
+    fn submit(
+        &self,
+        image: &mut MergeBuffers,
+        world_to_model: &nalgebra::Matrix3<f32>,
+        z: f32,
+        shape: &ShapeColorBuffers,
+        vars: &ShapeVars<f32>,
+        gpu: &Gpu,
+    ) -> Result<(), ColorError> {
+        if image.image_count != shape.shape_count {
+            return Err(ColorError::BadShapeCount {
+                merge_count: image.image_count,
+                shape_count: shape.shape_count,
+            });
+        }
+        let size = image.out.size();
+        let mat = world_to_model
+            * ImageSize::new(size.width(), size.height()).screen_to_world();
+        let mut mat4 = nalgebra::Matrix4x3::<f32>::identity();
+        mat4.fixed_view_mut::<3, 3>(0, 0).copy_from(&mat);
+
+        let config_bg = shape
+            .config_bind_group(&gpu.device, &self.config_bind_group_layout);
+
+        let config = ColorConfig {
+            mat: mat4.data.as_slice().try_into().unwrap(),
+            axes: shape.axes(),
+            image_size: [size.width(), size.height()],
+            z,
+        };
+
+        {
+            // We load the `ColorConfig`; tape data is already in the buffer
+            let config_len = std::mem::size_of_val(&config);
+            let mut writer = gpu
+                .queue
+                .write_buffer_with(
+                    &shape.config,
+                    0,
+                    (config_len as u64).try_into().unwrap(),
+                )
+                .unwrap();
+            writer.copy_from_slice(config.as_bytes());
+        }
+
+        // Copy vars (if present)
+        if let Some(var_size) = NonZeroU64::new(shape.vars.size()) {
+            let mut writer = gpu
+                .queue
+                .write_buffer_with(&shape.vars, 0, var_size)
+                .unwrap();
+            for (v, i) in shape.var_map.iter() {
+                match v {
+                    Var::X | Var::Y | Var::Z => (),
+                    Var::V(vi) => {
+                        let Some(value) = vars.get(vi) else {
+                            return Err(MissingVar { var: vi }.into());
+                        };
+                        let offset = i * std::mem::size_of::<f32>();
+                        writer
+                            .slice(offset..offset + 4)
+                            .copy_from_slice(value.as_bytes());
+                    }
+                }
+            }
+        }
+
+        // Create a command encoder and dispatch the compute work
+        let mut encoder = gpu.device.create_command_encoder(
+            &wgpu::CommandEncoderDescriptor { label: None },
+        );
+        {
+            let mut compute_pass =
+                encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                    label: None,
+                    timestamp_writes: None, // TODO add timestamps?
+                });
+            compute_pass.set_bind_group(0, config_bg, &[]);
+
+            // TODO this creates a bind group for every evaluation, instead of
+            // caching it somewhere.  However, *where* to cache it is not
+            // obvious, because it combines fields from two different buffer
+            // objects.
+            let image_bg =
+                gpu.device.create_bind_group(&wgpu::BindGroupDescriptor {
+                    label: Some("color image bind group"),
+                    layout: &self.image_bind_group_layout,
+                    entries: &[wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: image.out.bind_active(),
+                    }],
+                });
+            compute_pass.set_bind_group(1, &image_bg, &[]);
+            compute_pass.set_pipeline(self.color_pipeline.get(shape.reg_count));
+            compute_pass.dispatch_workgroups(
+                size.width().div_ceil(8),
+                size.height().div_ceil(8),
+                1,
+            );
+        }
+        gpu.queue.submit(Some(encoder.finish()));
+        Ok(())
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
 
 #[cfg(test)]
 mod test {
@@ -277,6 +646,14 @@ mod test {
         crate::test::compare_struct_layout::<MergeConfig>(
             &merge_shader(),
             "MergeConfig",
+        );
+    }
+
+    #[test]
+    fn color_config_layout() {
+        crate::test::compare_struct_layout::<ColorConfig>(
+            &color_shader(16),
+            "Config",
         );
     }
 }

--- a/fidget-wgpu/src/pixel/effects/mod.rs
+++ b/fidget-wgpu/src/pixel/effects/mod.rs
@@ -1,10 +1,16 @@
 use crate::{
-    Gpu, RegPipeline, RenderShape, TAPE_DATA_CAPACITY, TapeWord,
+    Gpu,
+    RegPipeline,
+    RenderShape,
+    TAPE_DATA_CAPACITY,
+    TapeWord,
     buf::{
         ArrayBuffer, BufferItemCount, BufferSizeError, BufferType, ImageBuffer,
         buffer_ro, buffer_ro_dyn, buffer_rw,
     },
-    shaders, tag,
+    shaders,
+    tag,
+    voxel::effects::MergeConfig, // same layout, unit tested to confirm
 };
 
 const COMMON_SHADER: &str = include_str!("shaders/common.wgsl");
@@ -25,5 +31,13 @@ mod test {
     #[test]
     fn compile_merge_shader() {
         crate::compile_shader(&merge_shader(), "merge");
+    }
+
+    #[test]
+    fn merge_config_layout() {
+        crate::test::compare_struct_layout::<MergeConfig>(
+            &merge_shader(),
+            "MergeConfig",
+        );
     }
 }

--- a/fidget-wgpu/src/pixel/effects/mod.rs
+++ b/fidget-wgpu/src/pixel/effects/mod.rs
@@ -78,6 +78,18 @@ pub struct MergeBuffers {
     image_count: usize,
 }
 
+impl MergeBuffers {
+    /// Resets the merge buffer
+    ///
+    /// The next call to [`Context::submit_merge`] will clear the buffer and
+    /// begin accumulating from scratch.
+    pub fn reset(&mut self) {
+        self.has_color = false;
+        self.image_count = 0;
+    }
+}
+
+/// Mirror of the WGSL `MergeConfig` object
 #[derive(Copy, Clone, FromBytes, Immutable, IntoBytes, KnownLayout)]
 #[cfg_attr(test, derive(facet::Facet))]
 #[repr(C)]
@@ -190,10 +202,17 @@ impl Context {
                 .into());
             }
         }
+        if buf.image_count > 0 && size != buf.out.size() {
+            return Err(ImageSizeMismatch {
+                expected: size,
+                actual: buf.out.size(),
+            }
+            .into());
+        }
+
         buf.out
             .grow_to_fit(&self.gpu.device, size)
             .map_err(MergeError::OutputSize)?;
-        buf.image_count = images.len();
         buf.has_color = false;
         let mut encoder = self.gpu.device.create_command_encoder(
             &wgpu::CommandEncoderDescriptor {
@@ -208,11 +227,11 @@ impl Context {
                     timestamp_writes: None, // TODO add timestamps?
                 });
             compute_pass.set_pipeline(&self.merge_pipeline);
-            for (i, chunk) in images.chunks(7).enumerate() {
+            for chunk in images.chunks(7) {
                 let cfg = MergeConfig {
                     image_size: [size.width(), size.height()],
                     remove_nans: remove_nans as u32,
-                    index_base: i as u32 * 7,
+                    index_base: buf.image_count as u32,
                     image_count: chunk.len() as u32,
                     _pad: 0,
                 };
@@ -267,6 +286,7 @@ impl Context {
                     size.height().div_ceil(8),
                     1,
                 );
+                buf.image_count += chunk.len();
             }
         }
         self.gpu.queue.submit(Some(encoder.finish()));

--- a/fidget-wgpu/src/pixel/effects/mod.rs
+++ b/fidget-wgpu/src/pixel/effects/mod.rs
@@ -305,17 +305,10 @@ impl Context {
     pub fn submit_color(
         &self,
         merge: &mut MergeBuffers,
-        world_to_model: &nalgebra::Matrix3<f32>,
-        z: f32,
+        settings: ColorSettings,
         shape: &ShapeColorBuffers<ColorConfig>,
     ) -> Result<(), ColorError> {
-        self.submit_color_with_vars(
-            merge,
-            world_to_model,
-            z,
-            shape,
-            &Default::default(),
-        )
+        self.submit_color_with_vars(merge, settings, shape, &Default::default())
     }
 
     /// Submits a color evaluation pass with auxiliary variables
@@ -326,13 +319,12 @@ impl Context {
     pub fn submit_color_with_vars(
         &self,
         merge: &mut MergeBuffers,
-        world_to_model: &nalgebra::Matrix3<f32>,
-        z: f32,
+        settings: ColorSettings,
         shape: &ShapeColorBuffers<ColorConfig>,
         vars: &ShapeVars<f32>,
     ) -> Result<(), ColorError> {
         self.color_ctx
-            .submit(merge, world_to_model, z, shape, vars, &self.gpu)
+            .submit(merge, settings, shape, vars, &self.gpu)
     }
 
     /// Returns an [`ImageReadBuffer`] to read from a [`MergeBuffers`] object
@@ -488,6 +480,7 @@ impl MappedImage<'_> {
 #[derive(Copy, Clone, FromBytes, Immutable, IntoBytes, KnownLayout)]
 #[cfg_attr(test, derive(facet::Facet))]
 #[repr(C)]
+#[doc(hidden)]
 pub struct ColorConfig {
     /// Screen-to-model transform matrix (mat3x3)
     mat: [f32; 12],
@@ -502,7 +495,29 @@ pub struct ColorConfig {
 
     /// Image size (pixels)
     image_size: [u32; 2],
+
+    ///When non-zero, only compute color for filled pixels
+    only_filled: u32,
+
+    // alignment
+    _pad: u32,
     // this is followed by a tape_data flexible array member
+}
+
+/// Settings for per-pixel color evaluation
+#[derive(Copy, Clone, Debug)]
+pub struct ColorSettings {
+    /// Z height at which to evaluate the colors
+    pub z: f32,
+
+    /// When non-zero, only compute color for filled pixels
+    pub only_filled: bool,
+
+    /// Transform matrix
+    ///
+    /// This should be the same transform matrix used to evaluate the original
+    /// pixel image (unless you're doing something weird)
+    pub world_to_model: nalgebra::Matrix3<f32>,
 }
 
 struct ColorContext {
@@ -565,8 +580,7 @@ impl ColorContext {
     fn submit(
         &self,
         image: &mut MergeBuffers,
-        world_to_model: &nalgebra::Matrix3<f32>,
-        z: f32,
+        settings: ColorSettings,
         shape: &ShapeColorBuffers<ColorConfig>,
         vars: &ShapeVars<f32>,
         gpu: &Gpu,
@@ -578,7 +592,7 @@ impl ColorContext {
             });
         }
         let size = image.out.size();
-        let mat = world_to_model
+        let mat = settings.world_to_model
             * ImageSize::new(size.width(), size.height()).screen_to_world();
         let mut mat4 = nalgebra::Matrix4x3::<f32>::identity();
         mat4.fixed_view_mut::<3, 3>(0, 0).copy_from(&mat);
@@ -590,7 +604,9 @@ impl ColorContext {
             mat: mat4.data.as_slice().try_into().unwrap(),
             axes: shape.axes(),
             image_size: [size.width(), size.height()],
-            z,
+            only_filled: settings.only_filled.into(),
+            _pad: 0,
+            z: settings.z,
         };
         shape.write_config(&config, &gpu.queue);
         shape.write_vars(vars, &gpu.queue)?;

--- a/fidget-wgpu/src/pixel/effects/mod.rs
+++ b/fidget-wgpu/src/pixel/effects/mod.rs
@@ -1,0 +1,29 @@
+use crate::{
+    Gpu, RegPipeline, RenderShape, TAPE_DATA_CAPACITY, TapeWord,
+    buf::{
+        ArrayBuffer, BufferItemCount, BufferSizeError, BufferType, ImageBuffer,
+        buffer_ro, buffer_ro_dyn, buffer_rw,
+    },
+    shaders, tag,
+};
+
+const COMMON_SHADER: &str = include_str!("shaders/common.wgsl");
+const MERGE_SHADER: &str = include_str!("shaders/merge.wgsl");
+
+/// Returns a shader for merging images
+fn merge_shader() -> String {
+    MERGE_SHADER.to_owned()
+        + COMMON_SHADER
+        + shaders::COMMON
+        + super::DISTANCE_PIXEL_SHADER
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn compile_merge_shader() {
+        crate::compile_shader(&merge_shader(), "merge");
+    }
+}

--- a/fidget-wgpu/src/pixel/effects/mod.rs
+++ b/fidget-wgpu/src/pixel/effects/mod.rs
@@ -19,7 +19,9 @@
 use crate::{
     Gpu,
     RegPipeline,
+    ShapeColor,
     ShapeColorBuffers,
+    ShapeColorError,
     buf::{
         ArrayBuffer, BufferSizeError, ImageBuffer, buffer_ro, buffer_rw,
         buffer_uniform,
@@ -33,6 +35,7 @@ use fidget_core::{
     render::ImageSize,
     shape::{MissingVar, ShapeVars},
     var::Var,
+    vm::VmShape,
 };
 use fidget_raster::RgbaImage;
 use std::num::NonZeroU64;
@@ -293,7 +296,7 @@ impl Context {
         merge: &mut MergeBuffers,
         world_to_model: &nalgebra::Matrix3<f32>,
         z: f32,
-        shape: &ShapeColorBuffers,
+        shape: &ShapeColorBuffers<ColorConfig>,
     ) -> Result<(), ColorError> {
         self.submit_color_with_vars(
             merge,
@@ -314,7 +317,7 @@ impl Context {
         merge: &mut MergeBuffers,
         world_to_model: &nalgebra::Matrix3<f32>,
         z: f32,
-        shape: &ShapeColorBuffers,
+        shape: &ShapeColorBuffers<ColorConfig>,
         vars: &ShapeVars<f32>,
     ) -> Result<(), ColorError> {
         self.color_ctx
@@ -360,6 +363,14 @@ impl Context {
             has_color,
             slice,
         }
+    }
+
+    /// Build a set of buffers for doing shape color evaluation
+    pub fn color_buffers(
+        &self,
+        colors: &[ShapeColor<VmShape>],
+    ) -> Result<ShapeColorBuffers<ColorConfig>, ShapeColorError> {
+        ShapeColorBuffers::new(colors, &self.gpu.device)
     }
 }
 
@@ -461,10 +472,13 @@ impl MappedImage<'_> {
 ////////////////////////////////////////////////////////////////////////////////
 
 /// Configuration for the color evaluation pass
+///
+/// This is public because it's used in a public function signature, but it's
+/// not expected to be used.
 #[derive(Copy, Clone, FromBytes, Immutable, IntoBytes, KnownLayout)]
 #[cfg_attr(test, derive(facet::Facet))]
 #[repr(C)]
-struct ColorConfig {
+pub struct ColorConfig {
     /// Screen-to-model transform matrix (mat3x3)
     mat: [f32; 12],
 
@@ -543,7 +557,7 @@ impl ColorContext {
         image: &mut MergeBuffers,
         world_to_model: &nalgebra::Matrix3<f32>,
         z: f32,
-        shape: &ShapeColorBuffers,
+        shape: &ShapeColorBuffers<ColorConfig>,
         vars: &ShapeVars<f32>,
         gpu: &Gpu,
     ) -> Result<(), ColorError> {

--- a/fidget-wgpu/src/pixel/effects/mod.rs
+++ b/fidget-wgpu/src/pixel/effects/mod.rs
@@ -37,16 +37,12 @@ use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 pub use crate::voxel::effects::{ColorError, ImageSizeMismatch, MergeError};
 
-const COMMON_SHADER: &str = include_str!("shaders/common.wgsl");
 const MERGE_SHADER: &str = include_str!("shaders/merge.wgsl");
 const COLOR_SHADER: &str = include_str!("shaders/color.wgsl");
 
 /// Returns a shader for merging images
 fn merge_shader() -> String {
-    MERGE_SHADER.to_owned()
-        + COMMON_SHADER
-        + shaders::COMMON
-        + super::DISTANCE_PIXEL_SHADER
+    MERGE_SHADER.to_owned() + shaders::COMMON + super::DISTANCE_PIXEL_SHADER
 }
 
 fn color_shader(reg_count: u8) -> String {
@@ -54,7 +50,6 @@ fn color_shader(reg_count: u8) -> String {
     shader_code += &format!("const REG_COUNT: u32 = {reg_count};");
     shader_code
         + COLOR_SHADER
-        + COMMON_SHADER
         + super::TRANSFORM_INPUT
         + super::DISTANCE_PIXEL_SHADER
         + shaders::COMMON
@@ -82,6 +77,10 @@ pub struct MergeBuffers {
     /// the shape index then is rewritten to be color.
     out: ImageBuffer<MergedPixelBufferTag>,
 
+    /// Set to `true` if the second half of the output buffer represents color
+    has_color: bool,
+
+    /// Number of images merged together
     image_count: usize,
 }
 
@@ -179,6 +178,7 @@ impl Context {
             .grow_to_fit(&self.gpu.device, size)
             .map_err(MergeError::OutputSize)?;
         buf.image_count = images.len();
+        buf.has_color = false;
         let mut encoder = self.gpu.device.create_command_encoder(
             &wgpu::CommandEncoderDescriptor {
                 label: Some("merge compute encoder"),
@@ -277,6 +277,7 @@ impl Context {
             config,
             out,
             image_count: 0,
+            has_color: false,
         })
     }
 
@@ -327,7 +328,6 @@ impl Context {
     pub fn map_image<'a>(
         &self,
         image_in: &'a MergeBuffers,
-        has_color: bool,
         image_out: &'a mut ImageReadBuffer,
     ) -> MappedImage<'a> {
         let mut encoder = self.gpu.device.create_command_encoder(
@@ -354,7 +354,7 @@ impl Context {
             .unwrap();
         MappedImage {
             image: image_out,
-            has_color,
+            has_color: image_in.has_color,
             slice,
         }
     }
@@ -595,13 +595,17 @@ impl ColorContext {
             // caching it somewhere.  However, *where* to cache it is not
             // obvious, because it combines fields from two different buffer
             // objects.
+            let b = image.out.size_bytes();
             let image_bg =
                 gpu.device.create_bind_group(&wgpu::BindGroupDescriptor {
                     label: Some("color image bind group"),
                     layout: &self.image_bind_group_layout,
                     entries: &[wgpu::BindGroupEntry {
                         binding: 0,
-                        resource: image.out.bind_active(),
+                        // We're being tricky here, because the output data
+                        // buffer is actually two images packed back-to-back,
+                        // but we only care about the second one
+                        resource: image.out.data().slice((b / 2)..b).into(),
                     }],
                 });
             compute_pass.set_bind_group(1, &image_bg, &[]);
@@ -613,6 +617,7 @@ impl ColorContext {
             );
         }
         gpu.queue.submit(Some(encoder.finish()));
+        image.has_color = true;
         Ok(())
     }
 }

--- a/fidget-wgpu/src/pixel/effects/mod.rs
+++ b/fidget-wgpu/src/pixel/effects/mod.rs
@@ -17,19 +17,13 @@
 //! not been computed, then the second image instead stores merged shape index,
 //! (which is not particularly meaningful to users).
 use crate::{
-    Gpu,
-    RegPipeline,
-    ShapeColor,
-    ShapeColorBuffers,
-    ShapeColorError,
+    Gpu, RegPipeline, ShapeColor, ShapeColorBuffers, ShapeColorError,
     buf::{
         ArrayBuffer, BufferSizeError, ImageBuffer, buffer_ro, buffer_rw,
         buffer_uniform,
     },
     pixel::{PixelBufferTag, RawDistancePixel},
-    shaders,
-    tag,
-    voxel::effects::MergeConfig, // same layout, unit-tested to confirm
+    shaders, tag,
 };
 use fidget_core::{render::ImageSize, shape::ShapeVars, vm::VmShape};
 use fidget_raster::RgbaImage;
@@ -82,6 +76,28 @@ pub struct MergeBuffers {
 
     /// Number of images merged together
     image_count: usize,
+}
+
+#[derive(Copy, Clone, FromBytes, Immutable, IntoBytes, KnownLayout)]
+#[cfg_attr(test, derive(facet::Facet))]
+#[repr(C)]
+pub(crate) struct MergeConfig {
+    /// Image size, in pixels
+    pub image_size: [u32; 2],
+
+    /// Whether or not convert NaN values to distance values
+    pub remove_nans: u32,
+
+    /// Offset applied to indices when merging
+    ///
+    /// When this is 0, we initialize the output image
+    pub index_base: u32,
+
+    /// Number of valid image buffers (0-7)
+    pub image_count: u32,
+
+    // padding to the nearest multiple of 8
+    pub _pad: u32,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -158,7 +174,7 @@ impl Context {
     pub fn submit_merge(
         &self,
         images: &[&ImageBuffer<PixelBufferTag>],
-        denoise: bool,
+        remove_nans: bool,
         buf: &mut MergeBuffers,
     ) -> Result<(), MergeError> {
         let Some(size) = images.first().map(|i| i.size()) else {
@@ -195,7 +211,7 @@ impl Context {
             for (i, chunk) in images.chunks(7).enumerate() {
                 let cfg = MergeConfig {
                     image_size: [size.width(), size.height()],
-                    denoise: denoise as u32,
+                    remove_nans: remove_nans as u32,
                     index_base: i as u32 * 7,
                     image_count: chunk.len() as u32,
                     _pad: 0,
@@ -595,17 +611,13 @@ impl ColorContext {
             // caching it somewhere.  However, *where* to cache it is not
             // obvious, because it combines fields from two different buffer
             // objects.
-            let b = image.out.size_bytes();
             let image_bg =
                 gpu.device.create_bind_group(&wgpu::BindGroupDescriptor {
                     label: Some("color image bind group"),
                     layout: &self.image_bind_group_layout,
                     entries: &[wgpu::BindGroupEntry {
                         binding: 0,
-                        // We're being tricky here, because the output data
-                        // buffer is actually two images packed back-to-back,
-                        // but we only care about the second one
-                        resource: image.out.data().slice((b / 2)..b).into(),
+                        resource: image.out.bind_active(),
                     }],
                 });
             compute_pass.set_bind_group(1, &image_bg, &[]);

--- a/fidget-wgpu/src/pixel/effects/mod.rs
+++ b/fidget-wgpu/src/pixel/effects/mod.rs
@@ -29,7 +29,7 @@ use fidget_core::{render::ImageSize, shape::ShapeVars, vm::VmShape};
 use fidget_raster::RgbaImage;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
-pub use crate::voxel::effects::{ColorError, ImageSizeMismatch, MergeError};
+pub use crate::voxel::effects::ColorError;
 
 const MERGE_SHADER: &str = include_str!("shaders/merge.wgsl");
 const COLOR_SHADER: &str = include_str!("shaders/color.wgsl");
@@ -50,6 +50,32 @@ fn color_shader(reg_count: u8) -> String {
         + shaders::TAPE_INTERPRETER
         + shaders::DUMMY_STACK
         + shaders::FLOAT_OPS
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+/// Type indicating an image size mismatch
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "image size mismatch: expected {} × {}, got {} × {}",
+    expected.width(), expected.height(),
+    actual.width(), actual.height(),
+)]
+pub struct ImageSizeMismatch {
+    expected: ImageSize,
+    actual: ImageSize,
+}
+
+/// Error returned when submitting a merge operation
+#[derive(Debug, thiserror::Error)]
+pub enum MergeError {
+    /// Image sizes in the slice are not consistent
+    #[error(transparent)]
+    ImageSizeMismatch(#[from] ImageSizeMismatch),
+
+    /// An error occurred while resizing the output buffer
+    #[error(transparent)]
+    OutputSize(BufferSizeError),
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/fidget-wgpu/src/pixel/effects/mod.rs
+++ b/fidget-wgpu/src/pixel/effects/mod.rs
@@ -6,12 +6,17 @@ use crate::{
     TapeWord,
     buf::{
         ArrayBuffer, BufferItemCount, BufferSizeError, BufferType, ImageBuffer,
-        buffer_ro, buffer_ro_dyn, buffer_rw,
+        buffer_ro, buffer_ro_dyn, buffer_rw, buffer_uniform,
     },
+    pixel::{PixelBufferTag, RawDistancePixel},
     shaders,
     tag,
-    voxel::effects::MergeConfig, // same layout, unit tested to confirm
+    voxel::effects::MergeConfig, // same layout, unit-tested to confirm
 };
+use fidget_core::render::ImageSize;
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
+
+pub use crate::voxel::effects::{ImageSizeMismatch, MergeError};
 
 const COMMON_SHADER: &str = include_str!("shaders/common.wgsl");
 const MERGE_SHADER: &str = include_str!("shaders/merge.wgsl");
@@ -22,6 +27,220 @@ fn merge_shader() -> String {
         + COMMON_SHADER
         + shaders::COMMON
         + super::DISTANCE_PIXEL_SHADER
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+/// Tagged pixel structure used on the GPU
+#[derive(Copy, Clone, FromBytes, Immutable, IntoBytes, KnownLayout)]
+#[repr(C)]
+pub struct TaggedRawDistancePixel {
+    /// Distance value
+    pub distance: RawDistancePixel,
+    /// Shape index
+    pub index: u32,
+}
+
+tag!(pub MergeVoxelBufferTag, TaggedRawDistancePixel, STORAGE | COPY_SRC,
+    "Buffer tag for on-GPU merged ([`TaggedRawDistancePixel`]) images"
+);
+
+/// Handle to a set of buffers used when merging images
+pub struct MergeBuffers {
+    config: wgpu::Buffer,
+    out: ImageBuffer<MergeVoxelBufferTag>,
+    image_count: usize,
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+/// WGPU context for applying various effects
+pub struct Context {
+    gpu: Gpu,
+
+    merge_bind_group_layout: wgpu::BindGroupLayout,
+    merge_pipeline: wgpu::ComputePipeline,
+}
+
+impl Context {
+    /// Builds a new context for applying effects
+    pub fn new(gpu: &Gpu) -> Self {
+        let merge_bind_group_layout = gpu.device.create_bind_group_layout(
+            &wgpu::BindGroupLayoutDescriptor {
+                label: None,
+                entries: &[
+                    buffer_uniform(0),
+                    buffer_ro(1), // image0
+                    buffer_ro(2), // image1
+                    buffer_ro(3), // image2
+                    buffer_ro(4), // image3
+                    buffer_ro(5), // image4
+                    buffer_ro(6), // image5
+                    buffer_ro(7), // image6
+                    buffer_rw(8), // out
+                ],
+            },
+        );
+        let shader_code = merge_shader();
+        let pipeline_layout = gpu.device.create_pipeline_layout(
+            &wgpu::PipelineLayoutDescriptor {
+                label: Some("effects merge pipeline"),
+                bind_group_layouts: &[Some(&merge_bind_group_layout)],
+                immediate_size: 0u32,
+            },
+        );
+        let shader_module =
+            gpu.device
+                .create_shader_module(wgpu::ShaderModuleDescriptor {
+                    label: Some("effects merge shader module"),
+                    source: wgpu::ShaderSource::Wgsl(shader_code.into()),
+                });
+        let merge_pipeline = gpu.device.create_compute_pipeline(
+            &wgpu::ComputePipelineDescriptor {
+                label: Some("effects merge compute pipeline"),
+                layout: Some(&pipeline_layout),
+                module: &shader_module,
+                entry_point: Some("merge_main"),
+                compilation_options: Default::default(),
+                cache: None,
+            },
+        );
+
+        Self {
+            gpu: gpu.clone(),
+            merge_bind_group_layout,
+            merge_pipeline,
+        }
+    }
+
+    /// Submits a set of merge operations to combine all of the images
+    ///
+    /// The output buffer is resized to fit the images
+    ///
+    /// If the incoming slice is empty, then no work is submitted
+    pub fn submit_merge(
+        &self,
+        images: &[&ImageBuffer<PixelBufferTag>],
+        denoise: bool,
+        buf: &mut MergeBuffers,
+    ) -> Result<(), MergeError> {
+        let Some(size) = images.first().map(|i| i.size()) else {
+            return Ok(());
+        };
+        for i in &images[1..] {
+            let actual = i.size();
+            if actual != size {
+                return Err(ImageSizeMismatch {
+                    expected: size,
+                    actual,
+                }
+                .into());
+            }
+        }
+        buf.out
+            .grow_to_fit(&self.gpu.device, size)
+            .map_err(MergeError::OutputSize)?;
+        buf.image_count = images.len();
+        let mut encoder = self.gpu.device.create_command_encoder(
+            &wgpu::CommandEncoderDescriptor {
+                label: Some("merge compute encoder"),
+            },
+        );
+        // Scope to bound the lifetime of compute_pass
+        {
+            let mut compute_pass =
+                encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                    label: Some("merge compute pass"),
+                    timestamp_writes: None, // TODO add timestamps?
+                });
+            compute_pass.set_pipeline(&self.merge_pipeline);
+            for (i, chunk) in images.chunks(7).enumerate() {
+                let cfg = MergeConfig {
+                    image_size: [size.width(), size.height()],
+                    denoise: denoise as u32,
+                    index_base: i as u32 * 7,
+                    image_count: chunk.len() as u32,
+                    _pad: 0,
+                };
+                {
+                    let mut writer = self
+                        .gpu
+                        .queue
+                        .write_buffer_with(
+                            &buf.config,
+                            0,
+                            (std::mem::size_of::<MergeConfig>() as u64)
+                                .try_into()
+                                .unwrap(),
+                        )
+                        .unwrap();
+                    writer.copy_from_slice(cfg.as_bytes());
+                }
+                let image_bind = |i| wgpu::BindGroupEntry {
+                    binding: i as u32 + 1,
+                    resource: chunk
+                        .get(i)
+                        .unwrap_or_else(|| chunk.first().unwrap())
+                        .bind_active(),
+                };
+
+                let bg = self.gpu.device.create_bind_group(
+                    &wgpu::BindGroupDescriptor {
+                        label: Some("merge bind group"),
+                        layout: &self.merge_bind_group_layout,
+                        entries: &[
+                            wgpu::BindGroupEntry {
+                                binding: 0,
+                                resource: buf.config.as_entire_binding(),
+                            },
+                            image_bind(0),
+                            image_bind(1),
+                            image_bind(2),
+                            image_bind(3),
+                            image_bind(4),
+                            image_bind(5),
+                            image_bind(6),
+                            wgpu::BindGroupEntry {
+                                binding: 8,
+                                resource: buf.out.bind_active(),
+                            },
+                        ],
+                    },
+                );
+                compute_pass.set_bind_group(0, Some(&bg), &[]);
+                compute_pass.dispatch_workgroups(
+                    size.width().div_ceil(8),
+                    size.height().div_ceil(8),
+                    1,
+                );
+            }
+        }
+        self.gpu.queue.submit(Some(encoder.finish()));
+        Ok(())
+    }
+
+    /// Builds a new set of [`MergeBuffers`] for the given image size
+    pub fn merge_buffers(
+        &self,
+        image_size: ImageSize,
+    ) -> Result<MergeBuffers, BufferSizeError> {
+        let config = self.gpu.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("config"),
+            size: std::mem::size_of::<MergeConfig>() as u64,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let out = ImageBuffer::new(
+            &self.gpu.device,
+            "merge output".to_owned(),
+            image_size,
+        )?;
+        Ok(MergeBuffers {
+            config,
+            out,
+            image_count: 0,
+        })
+    }
 }
 
 #[cfg(test)]

--- a/fidget-wgpu/src/pixel/effects/mod.rs
+++ b/fidget-wgpu/src/pixel/effects/mod.rs
@@ -468,7 +468,7 @@ impl MappedImage<'_> {
 /// Configuration for the color evaluation pass
 ///
 /// This is public because it's used in a public function signature, but it's
-/// not expected to be used.
+/// unlikely to be used by library end-users.
 #[derive(Copy, Clone, FromBytes, Immutable, IntoBytes, KnownLayout)]
 #[cfg_attr(test, derive(facet::Facet))]
 #[repr(C)]

--- a/fidget-wgpu/src/pixel/effects/mod.rs
+++ b/fidget-wgpu/src/pixel/effects/mod.rs
@@ -31,14 +31,8 @@ use crate::{
     tag,
     voxel::effects::MergeConfig, // same layout, unit-tested to confirm
 };
-use fidget_core::{
-    render::ImageSize,
-    shape::{MissingVar, ShapeVars},
-    var::Var,
-    vm::VmShape,
-};
+use fidget_core::{render::ImageSize, shape::ShapeVars, vm::VmShape};
 use fidget_raster::RgbaImage;
-use std::num::NonZeroU64;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 pub use crate::voxel::effects::{ColorError, ImageSizeMismatch, MergeError};
@@ -582,42 +576,8 @@ impl ColorContext {
             image_size: [size.width(), size.height()],
             z,
         };
-
-        {
-            // We load the `ColorConfig`; tape data is already in the buffer
-            let config_len = std::mem::size_of_val(&config);
-            let mut writer = gpu
-                .queue
-                .write_buffer_with(
-                    &shape.config,
-                    0,
-                    (config_len as u64).try_into().unwrap(),
-                )
-                .unwrap();
-            writer.copy_from_slice(config.as_bytes());
-        }
-
-        // Copy vars (if present)
-        if let Some(var_size) = NonZeroU64::new(shape.vars.size()) {
-            let mut writer = gpu
-                .queue
-                .write_buffer_with(&shape.vars, 0, var_size)
-                .unwrap();
-            for (v, i) in shape.var_map.iter() {
-                match v {
-                    Var::X | Var::Y | Var::Z => (),
-                    Var::V(vi) => {
-                        let Some(value) = vars.get(vi) else {
-                            return Err(MissingVar { var: vi }.into());
-                        };
-                        let offset = i * std::mem::size_of::<f32>();
-                        writer
-                            .slice(offset..offset + 4)
-                            .copy_from_slice(value.as_bytes());
-                    }
-                }
-            }
-        }
+        shape.write_config(&config, &gpu.queue);
+        shape.write_vars(vars, &gpu.queue)?;
 
         // Create a command encoder and dispatch the compute work
         let mut encoder = gpu.device.create_command_encoder(

--- a/fidget-wgpu/src/pixel/effects/mod.rs
+++ b/fidget-wgpu/src/pixel/effects/mod.rs
@@ -1,3 +1,4 @@
+//! Pixel post-processing pipelines
 use crate::{
     Gpu,
     RegPipeline,

--- a/fidget-wgpu/src/pixel/effects/mod.rs
+++ b/fidget-wgpu/src/pixel/effects/mod.rs
@@ -15,7 +15,8 @@
 //! Output is stored in the [`MergeBuffers`] object, which wraps a single GPU
 //! buffer with back-to-back distance and color images.  Note that if color has
 //! not been computed, then the second image instead stores merged shape index,
-//! (which is not particularly meaningful to users).
+//! (which is not particularly meaningful to users); in that case,
+//! [`MappedImage::color`] will return `None`.
 use crate::{
     Gpu, RegPipeline, ShapeColor, ShapeColorBuffers, ShapeColorError,
     buf::{
@@ -81,8 +82,9 @@ pub enum MergeError {
 ////////////////////////////////////////////////////////////////////////////////
 
 tag!(
-    MergedPixelBufferTag,
-    [u32; 2], // This is a hack; we store two images side by side
+    pub MergedPixelBufferTag,
+    // This is a hack; we store two images side by side, not interleaved
+    [u32; 2],
     STORAGE | COPY_SRC,
     "Buffer tag for on-GPU merged images"
 );
@@ -97,11 +99,11 @@ pub struct MergeBuffers {
     /// the shape index then is rewritten to be color.
     out: ImageBuffer<MergedPixelBufferTag>,
 
-    /// Set to `true` if the second half of the output buffer represents color
-    has_color: bool,
-
     /// Number of images merged together
     image_count: usize,
+
+    /// Set to `true` if the second half of the output buffer represents color
+    has_color: bool,
 }
 
 impl MergeBuffers {
@@ -112,6 +114,22 @@ impl MergeBuffers {
     pub fn reset(&mut self) {
         self.has_color = false;
         self.image_count = 0;
+    }
+
+    /// Returns `true` if the second half of the output buffer represents color
+    pub fn has_color(&self) -> bool {
+        self.has_color
+    }
+
+    /// Returns a handle to the output buffer
+    ///
+    /// The output buffer – despite the associated type in
+    /// [`MergedPixelBufferTag`] – stores two images side-by-side, **not**
+    /// interleaved.  The first is distance (as [`RawDistancePixel`] values);
+    /// the second is either shape index or RGBA color depending on
+    /// [`has_color`](Self::has_color).
+    pub fn output(&self) -> &ImageBuffer<MergedPixelBufferTag> {
+        &self.out
     }
 }
 
@@ -601,6 +619,8 @@ impl ColorContext {
                 merge_count: image.image_count,
                 shape_count: shape.shape_count,
             });
+        } else if image.has_color {
+            return Err(ColorError::AlreadyHasColor);
         }
         let size = image.out.size();
         let mat = settings.world_to_model

--- a/fidget-wgpu/src/pixel/effects/mod.rs
+++ b/fidget-wgpu/src/pixel/effects/mod.rs
@@ -20,6 +20,7 @@ pub use crate::voxel::effects::{ImageSizeMismatch, MergeError};
 
 const COMMON_SHADER: &str = include_str!("shaders/common.wgsl");
 const MERGE_SHADER: &str = include_str!("shaders/merge.wgsl");
+const COLOR_SHADER: &str = include_str!("shaders/color.wgsl");
 
 /// Returns a shader for merging images
 fn merge_shader() -> String {
@@ -27,6 +28,20 @@ fn merge_shader() -> String {
         + COMMON_SHADER
         + shaders::COMMON
         + super::DISTANCE_PIXEL_SHADER
+}
+
+fn color_shader(reg_count: u8) -> String {
+    let mut shader_code = shaders::opcode_constants();
+    shader_code += &format!("const REG_COUNT: u32 = {reg_count};");
+    shader_code
+        + COLOR_SHADER
+        + COMMON_SHADER
+        + super::TRANSFORM_INPUT
+        + super::DISTANCE_PIXEL_SHADER
+        + shaders::COMMON
+        + shaders::TAPE_INTERPRETER
+        + shaders::DUMMY_STACK
+        + shaders::FLOAT_OPS
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -250,6 +265,11 @@ mod test {
     #[test]
     fn compile_merge_shader() {
         crate::compile_shader(&merge_shader(), "merge");
+    }
+
+    #[test]
+    fn compile_color_shader() {
+        crate::compile_shader(&color_shader(16), "color");
     }
 
     #[test]

--- a/fidget-wgpu/src/pixel/effects/mod.rs
+++ b/fidget-wgpu/src/pixel/effects/mod.rs
@@ -192,11 +192,11 @@ impl Context {
         }
     }
 
-    /// Submits a set of merge operations to combine all of the images
+    /// Submits a set of merge operations to accumulate a single image
     ///
-    /// The output buffer is resized to fit the images
-    ///
-    /// If the incoming slice is empty, then no work is submitted
+    /// [`MergeBuffers::reset`] should be called before the first call to
+    /// `submit_merge`. For the first merge after a reset, the output buffer is
+    /// resized to fit the images; subsequent merges must be of the same size.
     pub fn submit_merge(
         &self,
         image: &ImageBuffer<PixelBufferTag>,

--- a/fidget-wgpu/src/pixel/effects/mod.rs
+++ b/fidget-wgpu/src/pixel/effects/mod.rs
@@ -130,12 +130,6 @@ pub(crate) struct MergeConfig {
     ///
     /// When this is 0, we initialize the output image
     pub index_base: u32,
-
-    /// Number of valid image buffers (0-7)
-    pub image_count: u32,
-
-    // padding to the nearest multiple of 8
-    pub _pad: u32,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -158,14 +152,8 @@ impl Context {
                 label: None,
                 entries: &[
                     buffer_uniform(0),
-                    buffer_ro(1), // image0
-                    buffer_ro(2), // image1
-                    buffer_ro(3), // image2
-                    buffer_ro(4), // image3
-                    buffer_ro(5), // image4
-                    buffer_ro(6), // image5
-                    buffer_ro(7), // image6
-                    buffer_rw(8), // out
+                    buffer_ro(1), // image
+                    buffer_rw(2), // out
                 ],
             },
         );
@@ -211,34 +199,24 @@ impl Context {
     /// If the incoming slice is empty, then no work is submitted
     pub fn submit_merge(
         &self,
-        images: &[&ImageBuffer<PixelBufferTag>],
+        image: &ImageBuffer<PixelBufferTag>,
         remove_nans: bool,
         buf: &mut MergeBuffers,
     ) -> Result<(), MergeError> {
-        let Some(size) = images.first().map(|i| i.size()) else {
-            return Ok(());
-        };
-        for i in &images[1..] {
-            let actual = i.size();
-            if actual != size {
+        let size = image.size();
+        if buf.image_count > 0 {
+            if size != buf.out.size() {
                 return Err(ImageSizeMismatch {
                     expected: size,
-                    actual,
+                    actual: buf.out.size(),
                 }
                 .into());
             }
+        } else {
+            buf.out
+                .grow_to_fit(&self.gpu.device, size)
+                .map_err(MergeError::OutputSize)?;
         }
-        if buf.image_count > 0 && size != buf.out.size() {
-            return Err(ImageSizeMismatch {
-                expected: size,
-                actual: buf.out.size(),
-            }
-            .into());
-        }
-
-        buf.out
-            .grow_to_fit(&self.gpu.device, size)
-            .map_err(MergeError::OutputSize)?;
         buf.has_color = false;
         let mut encoder = self.gpu.device.create_command_encoder(
             &wgpu::CommandEncoderDescriptor {
@@ -253,38 +231,30 @@ impl Context {
                     timestamp_writes: None, // TODO add timestamps?
                 });
             compute_pass.set_pipeline(&self.merge_pipeline);
-            for chunk in images.chunks(7) {
-                let cfg = MergeConfig {
-                    image_size: [size.width(), size.height()],
-                    remove_nans: remove_nans as u32,
-                    index_base: buf.image_count as u32,
-                    image_count: chunk.len() as u32,
-                    _pad: 0,
-                };
-                {
-                    let mut writer = self
-                        .gpu
-                        .queue
-                        .write_buffer_with(
-                            &buf.config,
-                            0,
-                            (std::mem::size_of::<MergeConfig>() as u64)
-                                .try_into()
-                                .unwrap(),
-                        )
-                        .unwrap();
-                    writer.copy_from_slice(cfg.as_bytes());
-                }
-                let image_bind = |i| wgpu::BindGroupEntry {
-                    binding: i as u32 + 1,
-                    resource: chunk
-                        .get(i)
-                        .unwrap_or_else(|| chunk.first().unwrap())
-                        .bind_active(),
-                };
+            let cfg = MergeConfig {
+                image_size: [size.width(), size.height()],
+                remove_nans: remove_nans as u32,
+                index_base: buf.image_count as u32,
+            };
+            {
+                let mut writer = self
+                    .gpu
+                    .queue
+                    .write_buffer_with(
+                        &buf.config,
+                        0,
+                        (std::mem::size_of::<MergeConfig>() as u64)
+                            .try_into()
+                            .unwrap(),
+                    )
+                    .unwrap();
+                writer.copy_from_slice(cfg.as_bytes());
+            }
 
-                let bg = self.gpu.device.create_bind_group(
-                    &wgpu::BindGroupDescriptor {
+            let bg =
+                self.gpu
+                    .device
+                    .create_bind_group(&wgpu::BindGroupDescriptor {
                         label: Some("merge bind group"),
                         layout: &self.merge_bind_group_layout,
                         entries: &[
@@ -292,28 +262,23 @@ impl Context {
                                 binding: 0,
                                 resource: buf.config.as_entire_binding(),
                             },
-                            image_bind(0),
-                            image_bind(1),
-                            image_bind(2),
-                            image_bind(3),
-                            image_bind(4),
-                            image_bind(5),
-                            image_bind(6),
                             wgpu::BindGroupEntry {
-                                binding: 8,
+                                binding: 1,
+                                resource: image.bind_active(),
+                            },
+                            wgpu::BindGroupEntry {
+                                binding: 2,
                                 resource: buf.out.bind_active(),
                             },
                         ],
-                    },
-                );
-                compute_pass.set_bind_group(0, Some(&bg), &[]);
-                compute_pass.dispatch_workgroups(
-                    size.width().div_ceil(8),
-                    size.height().div_ceil(8),
-                    1,
-                );
-                buf.image_count += chunk.len();
-            }
+                    });
+            compute_pass.set_bind_group(0, Some(&bg), &[]);
+            compute_pass.dispatch_workgroups(
+                size.width().div_ceil(8),
+                size.height().div_ceil(8),
+                1,
+            );
+            buf.image_count += 1;
         }
         self.gpu.queue.submit(Some(encoder.finish()));
         Ok(())

--- a/fidget-wgpu/src/pixel/effects/shaders/color.wgsl
+++ b/fidget-wgpu/src/pixel/effects/shaders/color.wgsl
@@ -1,0 +1,68 @@
+//! Pass to compute per-pixel color based on pixel indices
+
+struct Config {
+    /// Screen-to-model transform matrix, converting pixels to model space
+    mat: mat3x3f,
+
+    /// Mapping from X, Y, Z to input indices
+    axes: vec3u,
+
+    // Z height at which to evaluate
+    z: f32,
+
+    /// Image size, in pixels
+    image_size: vec2u,
+
+    /// Tape data, tightly packed per-tile (flexible array member)
+    tape_data: array<TapeWord>,
+}
+
+@group(0) @binding(0) var<storage, read> config: Config;
+@group(0) @binding(1) var<storage, read> shape_start: array<u32>;
+
+/// Array of values for (non-xyz) variables
+@group(0) @binding(2) var<storage, read> var_values: array<f32>;
+
+/// Image; index is a shape index going in and an RGBA value going out
+@group(1) @binding(0) var<storage, read_write> image: array<TaggedRawDistancePixel>;
+
+@compute @workgroup_size(8, 8)
+fn color_main(
+    @builtin(global_invocation_id) global_id: vec3u
+) {
+    // Clamp to image size
+    if global_id.x >= config.image_size.x ||
+       global_id.y >= config.image_size.y
+    {
+        return;
+    }
+
+    let i = global_id.x + config.image_size.x * global_id.y;
+
+    let p = image[i];
+    if p.index >= arrayLength(&shape_start) {
+        image[i].index = 0xFF0000FF; // corrupt, fill with red
+        return;
+    }
+
+    // Compute input values
+    let m_xy = transformed_inputs(
+        Value(f32(global_id.x)),
+        Value(f32(global_id.y)),
+    );
+    let m = array(m_xy[0], m_xy[1], build_imm(config.z));
+
+    let index = shape_start[p.index];
+    var stack = Stack(); // dummy value
+
+    // RGB tapes are packed together
+    let out_r = run_tape(index, m, &stack);
+    let out_g = run_tape(out_r.pos, m, &stack);
+    let out_b = run_tape(out_g.pos, m, &stack);
+
+    // Convert to a u32
+    let r = u32(clamp(out_r.value.v, 0.0, 1.0) * 255.0);
+    let g = u32(clamp(out_g.value.v, 0.0, 1.0) * 255.0);
+    let b = u32(clamp(out_b.value.v, 0.0, 1.0) * 255.0);
+    image[i].index = 0xFF000000 | (b << 16) | (g << 8) | r;
+}

--- a/fidget-wgpu/src/pixel/effects/shaders/color.wgsl
+++ b/fidget-wgpu/src/pixel/effects/shaders/color.wgsl
@@ -37,7 +37,9 @@ fn color_main(
         return;
     }
 
-    let i = global_id.x + config.image_size.x * global_id.y;
+    // Shape indices are in the second half of the buffer, offset by image size
+    let i = config.image_size.x * config.image_size.y +
+            global_id.x + config.image_size.x * global_id.y;
 
     let tag = image[i];
     if tag >= arrayLength(&shape_start) {
@@ -64,5 +66,7 @@ fn color_main(
     let r = u32(clamp(out_r.value.v, 0.0, 1.0) * 255.0);
     let g = u32(clamp(out_g.value.v, 0.0, 1.0) * 255.0);
     let b = u32(clamp(out_b.value.v, 0.0, 1.0) * 255.0);
+
+    // TODO: consider a flag which only evaluates color if the pixel is filled?
     image[i] = 0xFF000000 | (b << 16) | (g << 8) | r;
 }

--- a/fidget-wgpu/src/pixel/effects/shaders/color.wgsl
+++ b/fidget-wgpu/src/pixel/effects/shaders/color.wgsl
@@ -23,8 +23,8 @@ struct Config {
 /// Array of values for (non-xyz) variables
 @group(0) @binding(2) var<storage, read> var_values: array<f32>;
 
-/// Image; index is a shape index going in and an RGBA value going out
-@group(1) @binding(0) var<storage, read_write> image: array<TaggedRawDistancePixel>;
+/// Image buffer, which is shape index going in and color going out
+@group(1) @binding(0) var<storage, read_write> image: array<u32>;
 
 @compute @workgroup_size(8, 8)
 fn color_main(
@@ -39,9 +39,9 @@ fn color_main(
 
     let i = global_id.x + config.image_size.x * global_id.y;
 
-    let p = image[i];
-    if p.index >= arrayLength(&shape_start) {
-        image[i].index = 0xFF0000FF; // corrupt, fill with red
+    let tag = image[i];
+    if tag >= arrayLength(&shape_start) {
+        image[i] = 0xFF0000FF; // corrupt, fill with red
         return;
     }
 
@@ -52,7 +52,7 @@ fn color_main(
     );
     let m = array(m_xy[0], m_xy[1], build_imm(config.z));
 
-    let index = shape_start[p.index];
+    let index = shape_start[tag];
     var stack = Stack(); // dummy value
 
     // RGB tapes are packed together
@@ -64,5 +64,5 @@ fn color_main(
     let r = u32(clamp(out_r.value.v, 0.0, 1.0) * 255.0);
     let g = u32(clamp(out_g.value.v, 0.0, 1.0) * 255.0);
     let b = u32(clamp(out_b.value.v, 0.0, 1.0) * 255.0);
-    image[i].index = 0xFF000000 | (b << 16) | (g << 8) | r;
+    image[i] = 0xFF000000 | (b << 16) | (g << 8) | r;
 }

--- a/fidget-wgpu/src/pixel/effects/shaders/color.wgsl
+++ b/fidget-wgpu/src/pixel/effects/shaders/color.wgsl
@@ -13,6 +13,12 @@ struct Config {
     /// Image size, in pixels
     image_size: vec2u,
 
+    /// Only compute color for filled pixels when this is non-zero
+    only_filled: u32,
+
+    // manual alignment
+    _pad: u32,
+
     /// Tape data, tightly packed per-tile (flexible array member)
     tape_data: array<TapeWord>,
 }
@@ -38,8 +44,20 @@ fn color_main(
     }
 
     // Shape indices are in the second half of the buffer, offset by image size
-    let i = config.image_size.x * config.image_size.y +
-            global_id.x + config.image_size.x * global_id.y;
+    var i = global_id.x + config.image_size.x * global_id.y;
+    let distance = RawDistancePixel(image[i]);
+
+    // Shift to address shape index / color
+    i += config.image_size.x * config.image_size.y;
+
+    // Store alpha; early exit if we only care about color for filled pixels
+    var alpha = 0u;
+    if distance_pixel_is_inside(distance) {
+        alpha = 0xFF;
+    } else if config.only_filled != 0 {
+        image[i] = 0x00000000;
+        return;
+    }
 
     let tag = image[i];
     if tag >= arrayLength(&shape_start) {
@@ -67,6 +85,5 @@ fn color_main(
     let g = u32(clamp(out_g.value.v, 0.0, 1.0) * 255.0);
     let b = u32(clamp(out_b.value.v, 0.0, 1.0) * 255.0);
 
-    // TODO: consider a flag which only evaluates color if the pixel is filled?
-    image[i] = 0xFF000000 | (b << 16) | (g << 8) | r;
+    image[i] = (alpha << 24) | (b << 16) | (g << 8) | r;
 }

--- a/fidget-wgpu/src/pixel/effects/shaders/common.wgsl
+++ b/fidget-wgpu/src/pixel/effects/shaders/common.wgsl
@@ -1,8 +1,0 @@
-/// Distance pixel with an associated shape tag
-struct TaggedRawDistancePixel {
-    /// Distance associated with this pixel
-    distance: RawDistancePixel,
-
-    /// Shape index
-    index: u32,
-}

--- a/fidget-wgpu/src/pixel/effects/shaders/common.wgsl
+++ b/fidget-wgpu/src/pixel/effects/shaders/common.wgsl
@@ -1,0 +1,8 @@
+/// Distance pixel with an associated shape tag
+struct TaggedRawDistancePixel {
+    /// Distance associated with this pixel
+    distance: RawDistancePixel,
+
+    /// Shape index
+    index: u32,
+}

--- a/fidget-wgpu/src/pixel/effects/shaders/merge.wgsl
+++ b/fidget-wgpu/src/pixel/effects/shaders/merge.wgsl
@@ -80,105 +80,74 @@ fn tag_at(image_index: u32, pos: vec2u) -> TaggedRawDistancePixel {
 
 fn maybe_denoise(image_index: u32, pos: vec2u) -> RawDistancePixel {
     let pixel = read_pixel(image_index, pos.x + pos.y * config.image_size.x);
-    if config.denoise != 0 {
-        /*
-        if pixel.depth > 0 {
-            if pixel.normal.z > 0.0 {
-                return pixel;
-            } else {
-                let normal = denoise_at(image_index, pos, pixel);
-                return RawDistancePixel(normal, pixel.depth);
-            }
-        } else {
-            return RawDistancePixel(
-                vec3f(0.0, 0.0, 0.0),
-                0,
-            );
-        }
-        */
-        return pixel; /// XXX TODO
+    if config.denoise != 0 && distance_pixel_is_fill(pixel) {
+        return denoise_at(image_index, pos, pixel);
     } else {
         return pixel;
     }
 }
 
-/*
-fn denoise_at(image_index: u32, pos: vec2u, pixel: RawDistancePixel) -> vec3f {
-    let empty = RawDistancePixel(vec3f(0.0), 0);
-    var data = array<array<GeometryPixel, 3>, 3>(
-        array<GeometryPixel, 3>(empty, empty, empty),
-        array<GeometryPixel, 3>(empty, pixel, empty),
-        array<GeometryPixel, 3>(empty, empty, empty),
-    );
-    // Populate a 3x3 grid of normals.
-    for (var i = -1; i <= 1; i += 1) {
-        for (var j = -1; j <= 1; j += 1) {
-            let new_pos = vec2i(pos) + vec2i(i, j);
-            if (i == 0 && j == 0) ||
-                new_pos.x < 0 ||
-                new_pos.y < 0 ||
-                u32(new_pos.x) >= config.image_size.x ||
-                u32(new_pos.y) >= config.image_size.y
-            {
+
+// Replace fill pixels with the average of their actual-distance neighbors,
+// falling back to infinity if that fails.  This prevents glitchiness on the
+// edges of models.  If a fill pixel is exactly at the edge of a model, linear
+// interpolation in the texture means that every pixel interpolated with the
+// infinite pixel is also infinite.
+fn denoise_at(
+    image_index: u32,
+    pos: vec2u,
+    pixel: RawDistancePixel) -> RawDistancePixel
+{
+    var inside_count = 0.0;
+    var inside_avg = 0.0;
+    var outside_count = 0.0;
+    var outside_avg = 0.0;
+
+    for (var dy = -1i; dy <= 1; dy += 1) {
+        let y = i32(pos.y) + dy;
+        if y < 0 || u32(y) > config.image_size.y {
+            continue;
+        }
+        for (var dx = -1i; dx <= 1; dx += 1) {
+            let x = i32(pos.x) + dx;
+            if x < 0 || u32(x) > config.image_size.x {
                 continue;
             }
-            data[i + 1][j + 1] = read_pixel(
+
+            let p = read_pixel(
                 image_index,
-                u32(new_pos.x) + u32(new_pos.y) * config.image_size.x
+                u32(x) + u32(y) * config.image_size.x
             );
+
+            if !distance_pixel_is_fill(p) {
+                let d = bitcast<f32>(p.data);
+                if d < 0.0 {
+                    inside_avg += d;
+                    inside_count += 1;
+                } else {
+                    outside_avg += d;
+                    outside_count += 1;
+                }
+            }
         }
     }
 
-    // Iterate over four 2x2 pixel regions, picking the one that's most
-    // consistent (most normals agree with mean)
-    var scores = array<vec4f, 4>(
-        vec4f(0.0),
-        vec4f(0.0),
-        vec4f(0.0),
-        vec4f(0.0),
-    );
-    for (var i = -1; i <= 0; i += 1) {
-        for (var j = -1; j <= 0; j += 1) {
-            var sum = vec3f(0.0);
-            var count = 0;
-            for (var dx = 0; dx <= 1; dx += 1) {
-                for (var dy = 0; dy <= 1; dy += 1) {
-                    let p = data[i + 1 + dx][j + 1 + dy];
-                    if p.depth != 0 && p.normal.z > 0.0 {
-                        sum += data[i + 1 + dx][j + 1 + dy].normal;
-                        count += 1;
-                    }
-                }
-            }
-            if count == 0 {
-                continue; // leave score as 0
-            }
-            var score = 0.0;
-            let mean = sum / f32(count);
-            for (var dx = 0; dx <= 1; dx += 1) {
-                for (var dy = 0; dy <= 1; dy += 1) {
-                    if data[i + 1 + dx][j + 1 + dy].depth != 0 {
-                        score += dot(mean, data[i + 1 + dx][j + 1 + dy].normal);
-                    }
-                }
-            }
-            scores[(i + 1) + (j + 1) * 2] = vec4f(mean, score);
-        }
+    let pixel_is_inside = distance_pixel_is_inside(pixel);
+    if pixel_is_inside && inside_count > 0 {
+        return distance_pixel_value(inside_avg / inside_count);
+    } else if !pixel_is_inside && outside_count > 0 {
+        return distance_pixel_value(outside_avg / outside_count);
+    } else if inside_count + outside_count > 0 {
+        return distance_pixel_value(
+            (inside_avg + outside_avg)
+            / (inside_count + outside_count)
+        );
+    } else if pixel_is_inside {
+        return RawDistancePixel(0xFF800000); // -infinity
+    } else {
+        return RawDistancePixel(0x7F800000); // +infinity
     }
-
-    var best = scores[0];
-    for (var i = 0; i < 3; i += 1) {
-        if scores[i].w > best.w {
-            best = scores[i];
-        }
-    }
-    // Preserve the back-facing normal if we didn't get any valid quadrants
-    if best.w == 0.0 {
-        return pixel.normal;
-    }
-    return best.xyz;
 }
-*/
 
 fn read_pixel(image_index: u32, pixel_index: u32) -> RawDistancePixel {
     switch image_index {

--- a/fidget-wgpu/src/pixel/effects/shaders/merge.wgsl
+++ b/fidget-wgpu/src/pixel/effects/shaders/merge.wgsl
@@ -2,8 +2,8 @@ struct MergeConfig {
     /// Image size, in pixels
     image_size: vec2u,
 
-    /// Whether or not to denoise when merging (bool)
-    denoise: u32,
+    /// Whether or not to remove NaNs when merging images
+    remove_nans: u32,
 
     /// Offset applied to indices when merging
     index_base: u32,
@@ -79,26 +79,26 @@ fn merge_main(
 
 fn tag_at(image_index: u32, pos: vec2u) -> TaggedRawDistancePixel {
     let i = config.image_size.x * pos.y + pos.x;
-    let p = maybe_denoise(image_index, pos);
+    let p = maybe_remove_nans(image_index, pos);
     return TaggedRawDistancePixel(p, image_index + config.index_base);
 }
 
-fn maybe_denoise(image_index: u32, pos: vec2u) -> RawDistancePixel {
+fn maybe_remove_nans(image_index: u32, pos: vec2u) -> RawDistancePixel {
     let pixel = read_pixel(image_index, pos.x + pos.y * config.image_size.x);
-    if config.denoise != 0 && distance_pixel_is_fill(pixel) {
-        return denoise_at(image_index, pos, pixel);
+    if config.remove_nans != 0 && distance_pixel_is_fill(pixel) {
+        return remove_nans_at(image_index, pos, pixel);
     } else {
         return pixel;
     }
 }
 
 
-// Replace fill pixels with the average of their actual-distance neighbors,
-// falling back to infinity if that fails.  This prevents glitchiness on the
-// edges of models.  If a fill pixel is exactly at the edge of a model, linear
-// interpolation in the texture means that every pixel interpolated with the
-// infinite pixel is also infinite.
-fn denoise_at(
+// Replace fill pixels (NaN-boxed) with the average of their actual-distance
+// neighbors, falling back to infinity if that fails.  This prevents glitchiness
+// on the edges of models: If a NaN-boxed fill pixel is exactly at the edge of a
+// model, linear interpolation in the texture means that every pixel
+// interpolated with the infinite pixel is also NaN.
+fn remove_nans_at(
     image_index: u32,
     pos: vec2u,
     pixel: RawDistancePixel) -> RawDistancePixel
@@ -110,12 +110,12 @@ fn denoise_at(
 
     for (var dy = -1i; dy <= 1; dy += 1) {
         let y = i32(pos.y) + dy;
-        if y < 0 || u32(y) > config.image_size.y {
+        if y < 0 || u32(y) >= config.image_size.y {
             continue;
         }
         for (var dx = -1i; dx <= 1; dx += 1) {
             let x = i32(pos.x) + dx;
-            if x < 0 || u32(x) > config.image_size.x {
+            if x < 0 || u32(x) >= config.image_size.x {
                 continue;
             }
 
@@ -129,7 +129,7 @@ fn denoise_at(
                 if d < 0.0 {
                     inside_avg += d;
                     inside_count += 1;
-                } else {
+                } else if d > 0.0 {
                     outside_avg += d;
                     outside_count += 1;
                 }
@@ -143,11 +143,13 @@ fn denoise_at(
     } else if !pixel_is_inside && outside_count > 0 {
         return distance_pixel_value(outside_avg / outside_count);
     } else if inside_count + outside_count > 0 {
-        return distance_pixel_value(
-            (inside_avg + outside_avg)
-            / (inside_count + outside_count)
-        );
-    } else if pixel_is_inside {
+        let avg = (inside_avg + outside_avg) / (inside_count + outside_count);
+        if (avg < 0.0) == pixel_is_inside {
+            return distance_pixel_value(avg);
+        }
+    }
+    // Fallback: set to ±infinity
+    if pixel_is_inside {
         return RawDistancePixel(0xFF800000); // -infinity
     } else {
         return RawDistancePixel(0x7F800000); // +infinity

--- a/fidget-wgpu/src/pixel/effects/shaders/merge.wgsl
+++ b/fidget-wgpu/src/pixel/effects/shaders/merge.wgsl
@@ -74,7 +74,7 @@ fn merge_main(
     }
 
     out[i] = p.distance.data;
-    out[i + offset] = p.index;
+    out[i + offset] = p.tag;
 }
 
 fn tag_at(image_index: u32, pos: vec2u) -> TaggedRawDistancePixel {
@@ -200,4 +200,13 @@ fn merge_pixel(
     } else {
         return b;
     }
+}
+
+/// Distance pixel with an associated shape tag
+struct TaggedRawDistancePixel {
+    /// Distance associated with this pixel
+    distance: RawDistancePixel,
+
+    /// Tag; this is either a shape index or an RGBA color
+    tag: u32,
 }

--- a/fidget-wgpu/src/pixel/effects/shaders/merge.wgsl
+++ b/fidget-wgpu/src/pixel/effects/shaders/merge.wgsl
@@ -42,7 +42,7 @@ fn merge_main(
     }
 
     out[i] = p.distance.data;
-    out[i + offset] = p.tag;
+    out[i + offset] = p.index;
 }
 
 fn tag_at(pos: vec2u) -> TaggedRawDistancePixel {
@@ -166,11 +166,11 @@ fn merge_pixel(
     }
 }
 
-/// Distance pixel with an associated shape tag
+/// Distance pixel with an associated shape index
 struct TaggedRawDistancePixel {
     /// Distance associated with this pixel
     distance: RawDistancePixel,
 
-    /// Tag; this is either a shape index or an RGBA color
-    tag: u32,
+    /// Shape index
+    index: u32,
 }

--- a/fidget-wgpu/src/pixel/effects/shaders/merge.wgsl
+++ b/fidget-wgpu/src/pixel/effects/shaders/merge.wgsl
@@ -7,26 +7,14 @@ struct MergeConfig {
 
     /// Offset applied to indices when merging
     index_base: u32,
-
-    /// Number of valid image buffers (0-7)
-    image_count: u32,
-
-    // Explicit padding to the nearest multiple of 8
-    _pad: u32,
 }
 
 @group(0) @binding(0) var<uniform> config: MergeConfig;
 
-@group(0) @binding(1) var<storage, read> image0: array<RawDistancePixel>;
-@group(0) @binding(2) var<storage, read> image1: array<RawDistancePixel>;
-@group(0) @binding(3) var<storage, read> image2: array<RawDistancePixel>;
-@group(0) @binding(4) var<storage, read> image3: array<RawDistancePixel>;
-@group(0) @binding(5) var<storage, read> image4: array<RawDistancePixel>;
-@group(0) @binding(6) var<storage, read> image5: array<RawDistancePixel>;
-@group(0) @binding(7) var<storage, read> image6: array<RawDistancePixel>;
+@group(0) @binding(1) var<storage, read> image: array<RawDistancePixel>;
 
 // Distance and index values, packed as separate images
-@group(0) @binding(8) var<storage, read_write> out: array<u32>;
+@group(0) @binding(2) var<storage, read_write> out: array<u32>;
 
 
 @compute @workgroup_size(8, 8)
@@ -35,8 +23,7 @@ fn merge_main(
 ) {
     // Clamp to image size
     if global_id.x >= config.image_size.x ||
-       global_id.y >= config.image_size.y ||
-       config.image_count == 0
+       global_id.y >= config.image_size.y
     {
         return;
     }
@@ -46,7 +33,7 @@ fn merge_main(
     let offset = config.image_size.x * config.image_size.y;
 
     var p = TaggedRawDistancePixel(RawDistancePixel(0), 0); // dummy value
-    let b = tag_at(0, pos);
+    let b = tag_at(pos);
     if config.index_base == 0 {
         p = b;
     } else {
@@ -54,39 +41,20 @@ fn merge_main(
         p = merge_pixel(p, b);
     }
 
-    if config.image_count > 1 {
-        p = merge_pixel(p, tag_at(1, pos));
-    }
-    if config.image_count > 2 {
-        p = merge_pixel(p, tag_at(2, pos));
-    }
-    if config.image_count > 3 {
-        p = merge_pixel(p, tag_at(3, pos));
-    }
-    if config.image_count > 4 {
-        p = merge_pixel(p, tag_at(4, pos));
-    }
-    if config.image_count > 5 {
-        p = merge_pixel(p, tag_at(5, pos));
-    }
-    if config.image_count > 6 {
-        p = merge_pixel(p, tag_at(6, pos));
-    }
-
     out[i] = p.distance.data;
     out[i + offset] = p.tag;
 }
 
-fn tag_at(image_index: u32, pos: vec2u) -> TaggedRawDistancePixel {
+fn tag_at(pos: vec2u) -> TaggedRawDistancePixel {
     let i = config.image_size.x * pos.y + pos.x;
-    let p = maybe_remove_nans(image_index, pos);
-    return TaggedRawDistancePixel(p, image_index + config.index_base);
+    let p = maybe_remove_nans(pos);
+    return TaggedRawDistancePixel(p, config.index_base);
 }
 
-fn maybe_remove_nans(image_index: u32, pos: vec2u) -> RawDistancePixel {
-    let pixel = read_pixel(image_index, pos.x + pos.y * config.image_size.x);
+fn maybe_remove_nans( pos: vec2u) -> RawDistancePixel {
+    let pixel = image[pos.x + pos.y * config.image_size.x];
     if config.remove_nans != 0 && distance_pixel_is_fill(pixel) {
-        return remove_nans_at(image_index, pos, pixel);
+        return remove_nans_at( pos, pixel);
     } else {
         return pixel;
     }
@@ -98,7 +66,6 @@ fn maybe_remove_nans(image_index: u32, pos: vec2u) -> RawDistancePixel {
 // model, linear interpolation in the texture means that every pixel
 // interpolated with the infinite pixel is also NaN.
 fn remove_nans_at(
-    image_index: u32,
     pos: vec2u,
     pixel: RawDistancePixel) -> RawDistancePixel
 {
@@ -118,10 +85,7 @@ fn remove_nans_at(
                 continue;
             }
 
-            let p = read_pixel(
-                image_index,
-                u32(x) + u32(y) * config.image_size.x
-            );
+            let p = image[u32(x) + u32(y) * config.image_size.x];
 
             if !distance_pixel_is_fill(p) {
                 let d = bitcast<f32>(p.data);
@@ -152,19 +116,6 @@ fn remove_nans_at(
         return RawDistancePixel(0xFF800000); // -infinity
     } else {
         return RawDistancePixel(0x7F800000); // +infinity
-    }
-}
-
-fn read_pixel(image_index: u32, pixel_index: u32) -> RawDistancePixel {
-    switch image_index {
-        case 0: { return image0[pixel_index]; }
-        case 1: { return image1[pixel_index]; }
-        case 2: { return image2[pixel_index]; }
-        case 3: { return image3[pixel_index]; }
-        case 4: { return image4[pixel_index]; }
-        case 5: { return image5[pixel_index]; }
-        case 6: { return image6[pixel_index]; }
-        default: { return RawDistancePixel(0); }
     }
 }
 

--- a/fidget-wgpu/src/pixel/effects/shaders/merge.wgsl
+++ b/fidget-wgpu/src/pixel/effects/shaders/merge.wgsl
@@ -1,0 +1,229 @@
+struct MergeConfig {
+    /// Image size, in pixels
+    image_size: vec2u,
+
+    /// Whether or not to denoise when merging (bool)
+    denoise: u32,
+
+    /// Offset applied to indices when merging
+    index_base: u32,
+
+    /// Number of valid image buffers (0-7)
+    image_count: u32,
+
+    // Explicit padding to the nearest multiple of 8
+    _pad: u32,
+}
+
+@group(0) @binding(0) var<uniform> config: MergeConfig;
+
+@group(0) @binding(1) var<storage, read> image0: array<RawDistancePixel>;
+@group(0) @binding(2) var<storage, read> image1: array<RawDistancePixel>;
+@group(0) @binding(3) var<storage, read> image2: array<RawDistancePixel>;
+@group(0) @binding(4) var<storage, read> image3: array<RawDistancePixel>;
+@group(0) @binding(5) var<storage, read> image4: array<RawDistancePixel>;
+@group(0) @binding(6) var<storage, read> image5: array<RawDistancePixel>;
+@group(0) @binding(7) var<storage, read> image6: array<RawDistancePixel>;
+@group(0) @binding(8) var<storage, read_write> out: array<TaggedRawDistancePixel>;
+
+
+@compute @workgroup_size(8, 8)
+fn merge_main(
+    @builtin(global_invocation_id) global_id: vec3u
+) {
+    // Clamp to image size
+    if global_id.x >= config.image_size.x ||
+       global_id.y >= config.image_size.y ||
+       config.image_count == 0
+    {
+        return;
+    }
+
+    let pos = global_id.xy;
+    let i = config.image_size.x * pos.y + pos.x;
+
+    var p = TaggedRawDistancePixel(RawDistancePixel(0), 0); // dummy value
+    let b = tag_at(0, pos);
+    if config.index_base == 0 {
+        p = b;
+    } else {
+        p = merge_pixel(out[i], b);
+    }
+
+    if config.image_count > 1 {
+        p = merge_pixel(p, tag_at(1, pos));
+    }
+    if config.image_count > 2 {
+        p = merge_pixel(p, tag_at(2, pos));
+    }
+    if config.image_count > 3 {
+        p = merge_pixel(p, tag_at(3, pos));
+    }
+    if config.image_count > 4 {
+        p = merge_pixel(p, tag_at(4, pos));
+    }
+    if config.image_count > 5 {
+        p = merge_pixel(p, tag_at(5, pos));
+    }
+    if config.image_count > 6 {
+        p = merge_pixel(p, tag_at(6, pos));
+    }
+
+    out[i] = p;
+}
+
+fn tag_at(image_index: u32, pos: vec2u) -> TaggedRawDistancePixel {
+    let i = config.image_size.x * pos.y + pos.x;
+    let p = maybe_denoise(image_index, pos);
+    return TaggedRawDistancePixel(p, image_index + config.index_base);
+}
+
+fn maybe_denoise(image_index: u32, pos: vec2u) -> RawDistancePixel {
+    let pixel = read_pixel(image_index, pos.x + pos.y * config.image_size.x);
+    if config.denoise != 0 {
+        /*
+        if pixel.depth > 0 {
+            if pixel.normal.z > 0.0 {
+                return pixel;
+            } else {
+                let normal = denoise_at(image_index, pos, pixel);
+                return RawDistancePixel(normal, pixel.depth);
+            }
+        } else {
+            return RawDistancePixel(
+                vec3f(0.0, 0.0, 0.0),
+                0,
+            );
+        }
+        */
+        return pixel; /// XXX TODO
+    } else {
+        return pixel;
+    }
+}
+
+/*
+fn denoise_at(image_index: u32, pos: vec2u, pixel: RawDistancePixel) -> vec3f {
+    let empty = RawDistancePixel(vec3f(0.0), 0);
+    var data = array<array<GeometryPixel, 3>, 3>(
+        array<GeometryPixel, 3>(empty, empty, empty),
+        array<GeometryPixel, 3>(empty, pixel, empty),
+        array<GeometryPixel, 3>(empty, empty, empty),
+    );
+    // Populate a 3x3 grid of normals.
+    for (var i = -1; i <= 1; i += 1) {
+        for (var j = -1; j <= 1; j += 1) {
+            let new_pos = vec2i(pos) + vec2i(i, j);
+            if (i == 0 && j == 0) ||
+                new_pos.x < 0 ||
+                new_pos.y < 0 ||
+                u32(new_pos.x) >= config.image_size.x ||
+                u32(new_pos.y) >= config.image_size.y
+            {
+                continue;
+            }
+            data[i + 1][j + 1] = read_pixel(
+                image_index,
+                u32(new_pos.x) + u32(new_pos.y) * config.image_size.x
+            );
+        }
+    }
+
+    // Iterate over four 2x2 pixel regions, picking the one that's most
+    // consistent (most normals agree with mean)
+    var scores = array<vec4f, 4>(
+        vec4f(0.0),
+        vec4f(0.0),
+        vec4f(0.0),
+        vec4f(0.0),
+    );
+    for (var i = -1; i <= 0; i += 1) {
+        for (var j = -1; j <= 0; j += 1) {
+            var sum = vec3f(0.0);
+            var count = 0;
+            for (var dx = 0; dx <= 1; dx += 1) {
+                for (var dy = 0; dy <= 1; dy += 1) {
+                    let p = data[i + 1 + dx][j + 1 + dy];
+                    if p.depth != 0 && p.normal.z > 0.0 {
+                        sum += data[i + 1 + dx][j + 1 + dy].normal;
+                        count += 1;
+                    }
+                }
+            }
+            if count == 0 {
+                continue; // leave score as 0
+            }
+            var score = 0.0;
+            let mean = sum / f32(count);
+            for (var dx = 0; dx <= 1; dx += 1) {
+                for (var dy = 0; dy <= 1; dy += 1) {
+                    if data[i + 1 + dx][j + 1 + dy].depth != 0 {
+                        score += dot(mean, data[i + 1 + dx][j + 1 + dy].normal);
+                    }
+                }
+            }
+            scores[(i + 1) + (j + 1) * 2] = vec4f(mean, score);
+        }
+    }
+
+    var best = scores[0];
+    for (var i = 0; i < 3; i += 1) {
+        if scores[i].w > best.w {
+            best = scores[i];
+        }
+    }
+    // Preserve the back-facing normal if we didn't get any valid quadrants
+    if best.w == 0.0 {
+        return pixel.normal;
+    }
+    return best.xyz;
+}
+*/
+
+fn read_pixel(image_index: u32, pixel_index: u32) -> RawDistancePixel {
+    switch image_index {
+        case 0: { return image0[pixel_index]; }
+        case 1: { return image1[pixel_index]; }
+        case 2: { return image2[pixel_index]; }
+        case 3: { return image3[pixel_index]; }
+        case 4: { return image4[pixel_index]; }
+        case 5: { return image5[pixel_index]; }
+        case 6: { return image6[pixel_index]; }
+        default: { return RawDistancePixel(0); }
+    }
+}
+
+fn merge_pixel(
+    a: TaggedRawDistancePixel,
+    b: TaggedRawDistancePixel
+) -> TaggedRawDistancePixel {
+    // haha booleans go brrrrrrr
+    let a_inside = distance_pixel_is_inside(a.distance);
+    let a_fill = distance_pixel_is_fill(a.distance);
+    let b_inside = distance_pixel_is_inside(b.distance);
+    let b_fill = distance_pixel_is_fill(b.distance);
+
+    // If either side is inside, then prefer it.
+    if a_inside && !b_inside {
+        return a;
+    } else if b_inside && !a_inside {
+        return b;
+    }
+
+    // If both sides are fills, prefer A (arbitrarily); otherwise, prefer the
+    // non-fill side (since it's a truer value).
+    if a_fill && b_fill {
+        return a;
+    } else if a_fill && !b_fill {
+        return b;
+    } else if b_fill && !a_fill {
+        return a;
+    }
+
+    // Otherwise, do a straight distance comparison
+    if bitcast<f32>(a.distance.data) < bitcast<f32>(b.distance.data) {
+        return a;
+    } else {
+        return b;
+    }
+}

--- a/fidget-wgpu/src/pixel/effects/shaders/merge.wgsl
+++ b/fidget-wgpu/src/pixel/effects/shaders/merge.wgsl
@@ -24,7 +24,9 @@ struct MergeConfig {
 @group(0) @binding(5) var<storage, read> image4: array<RawDistancePixel>;
 @group(0) @binding(6) var<storage, read> image5: array<RawDistancePixel>;
 @group(0) @binding(7) var<storage, read> image6: array<RawDistancePixel>;
-@group(0) @binding(8) var<storage, read_write> out: array<TaggedRawDistancePixel>;
+
+// Distance and index values, packed as separate images
+@group(0) @binding(8) var<storage, read_write> out: array<u32>;
 
 
 @compute @workgroup_size(8, 8)
@@ -41,13 +43,15 @@ fn merge_main(
 
     let pos = global_id.xy;
     let i = config.image_size.x * pos.y + pos.x;
+    let offset = config.image_size.x * config.image_size.y;
 
     var p = TaggedRawDistancePixel(RawDistancePixel(0), 0); // dummy value
     let b = tag_at(0, pos);
     if config.index_base == 0 {
         p = b;
     } else {
-        p = merge_pixel(out[i], b);
+        p = TaggedRawDistancePixel(RawDistancePixel(out[i]), out[i + offset]);
+        p = merge_pixel(p, b);
     }
 
     if config.image_count > 1 {
@@ -69,7 +73,8 @@ fn merge_main(
         p = merge_pixel(p, tag_at(6, pos));
     }
 
-    out[i] = p;
+    out[i] = p.distance.data;
+    out[i + offset] = p.index;
 }
 
 fn tag_at(image_index: u32, pos: vec2u) -> TaggedRawDistancePixel {

--- a/fidget-wgpu/src/pixel/effects/shaders/merge.wgsl
+++ b/fidget-wgpu/src/pixel/effects/shaders/merge.wgsl
@@ -174,9 +174,11 @@ fn merge_pixel(
 ) -> TaggedRawDistancePixel {
     // haha booleans go brrrrrrr
     let a_inside = distance_pixel_is_inside(a.distance);
+    let a_inf = (a.distance.data == 0xFF800000) || (a.distance.data == 0x7F800000);
     let a_fill = distance_pixel_is_fill(a.distance);
     let b_inside = distance_pixel_is_inside(b.distance);
     let b_fill = distance_pixel_is_fill(b.distance);
+    let b_inf = (b.distance.data == 0xFF800000) || (b.distance.data == 0x7F800000);
 
     // If either side is inside, then prefer it.
     if a_inside && !b_inside {
@@ -192,6 +194,16 @@ fn merge_pixel(
     } else if a_fill && !b_fill {
         return b;
     } else if b_fill && !a_fill {
+        return a;
+    }
+
+    // If both sides are infinite, then prefer A (arbitrarily); otherwise,
+    // prefer the non-infinite value (same idea as above)
+    if a_inf && b_inf {
+        return a;
+    } else if a_inf && !b_inf {
+        return b;
+    } else if b_inf && !a_inf {
         return a;
     }
 

--- a/fidget-wgpu/src/pixel/effects/shaders/merge.wgsl
+++ b/fidget-wgpu/src/pixel/effects/shaders/merge.wgsl
@@ -92,7 +92,6 @@ fn maybe_remove_nans(image_index: u32, pos: vec2u) -> RawDistancePixel {
     }
 }
 
-
 // Replace fill pixels (NaN-boxed) with the average of their actual-distance
 // neighbors, falling back to infinity if that fails.  This prevents glitchiness
 // on the edges of models: If a NaN-boxed fill pixel is exactly at the edge of a

--- a/fidget-wgpu/src/pixel/mod.rs
+++ b/fidget-wgpu/src/pixel/mod.rs
@@ -1224,8 +1224,8 @@ impl Context {
         out: &mut ImageReadBuffer,
         settings: RenderConfig,
     ) -> Result<Image, SubmitError> {
-        self.submit_with_vars(shape, vars, buffers, Some(out), &settings)?;
-        let image = self.map_image(out);
+        self.submit_with_vars(shape, vars, buffers, &settings)?;
+        let image = self.map_image(buffers, out);
         Ok(image.image())
     }
 
@@ -1272,25 +1272,13 @@ impl Context {
     /// The resulting image (as a buffer of [`RawDistancePixel`] data) is
     /// available on the GPU in
     /// [`buffers.image_storage_buffer()`](Buffers::image_storage_buffer).
-    ///
-    /// If `out` is present, then the rendered image is also copied to that
-    /// [`ImageReadBuffer`] (which may then be mapped for CPU reading by
-    /// [`map_image`](Self::map_image) or
-    /// [`map_image_async`](Self::map_image_async)).
     pub fn submit(
         &self,
         shape: &RenderShape,
         buffers: &mut Buffers,
-        out: Option<&mut ImageReadBuffer>,
         settings: &RenderConfig,
     ) -> Result<(), SubmitError> {
-        self.submit_with_vars(
-            shape,
-            &Default::default(),
-            buffers,
-            out,
-            settings,
-        )
+        self.submit_with_vars(shape, &Default::default(), buffers, settings)
     }
 
     /// Submits a single image to be rendered on the GPU, with extra variables
@@ -1301,7 +1289,6 @@ impl Context {
         shape: &RenderShape,
         vars: &ShapeVars<f32>,
         buffers: &mut Buffers,
-        out: Option<&mut ImageReadBuffer>,
         settings: &RenderConfig,
     ) -> Result<(), SubmitError> {
         buffers.set_image_size(&self.gpu.device, settings.image_size)?;
@@ -1433,45 +1420,49 @@ impl Context {
         );
         drop(compute_pass);
 
-        // Resolve the raw GPU ticks into the resolve buffer, then copy them
-        // into the last 16 bytes of the image buffer
-        if let Some(image) = out {
-            image
-                .grow_to_fit(&self.gpu.device, buffers.image_size)
-                .expect(
-                    "buffers.image_size should always be \
-                 a valid size for ImageReadBuffer::grow_to_fit",
-                );
-            if let Some(timestamps) = &buffers.timestamps {
-                encoder.resolve_query_set(timestamps, 0..2, &buffers.ts_buf, 0);
-                encoder.copy_buffer_to_buffer(
-                    &buffers.ts_buf,
-                    0,
-                    image.buffer.data(),
-                    buffers.pixels.size_bytes(), // offset past the image data
-                    buffers.ts_buf.size(),
-                );
-            }
-
-            // Copy from the STORAGE | COPY_SRC -> COPY_DST | MAP_READ buffer
-            encoder.copy_buffer_to_buffer(
-                buffers.pixels.data(),
-                0,
-                image.buffer.data(),
-                0,
-                buffers.pixels.size_bytes(),
-            );
-        }
-
         // Submit the commands and wait for the GPU to complete
         self.gpu.queue.submit(Some(encoder.finish()));
         Ok(())
     }
 
-    /// Synchronously maps an image read buffer
-    ///
-    /// The image read buffer should be populated by passing it as an argument
-    /// when calling [`submit`](Self::submit).
+    fn copy_image(&self, buffers: &Buffers, image_out: &mut ImageReadBuffer) {
+        let mut encoder = self.gpu.device.create_command_encoder(
+            &wgpu::CommandEncoderDescriptor {
+                label: Some("map_image"),
+            },
+        );
+        image_out
+            .grow_to_fit(&self.gpu.device, buffers.image_size)
+            .expect(
+                "buffers.image_size should always be \
+                 a valid size for ImageReadBuffer::grow_to_fit",
+            );
+        // Resolve the raw GPU ticks into the resolve buffer, then copy them
+        // into the last 16 bytes of the image buffer
+        if let Some(timestamps) = &buffers.timestamps {
+            encoder.resolve_query_set(timestamps, 0..2, &buffers.ts_buf, 0);
+            encoder.copy_buffer_to_buffer(
+                &buffers.ts_buf,
+                0,
+                image_out.buffer.data(),
+                buffers.pixels.size_bytes(), // offset past the image data
+                buffers.ts_buf.size(),
+            );
+        }
+
+        // Copy from the STORAGE | COPY_SRC -> COPY_DST | MAP_READ buffer
+        encoder.copy_buffer_to_buffer(
+            buffers.pixels.data(),
+            0,
+            image_out.buffer.data(),
+            0,
+            buffers.pixels.size_bytes(),
+        );
+
+        self.gpu.queue.submit(Some(encoder.finish()));
+    }
+
+    /// Synchronously populates and maps an CPU-readable image buffer
     ///
     /// The image is borrowed exclusively to avoid double-mapping
     ///
@@ -1479,15 +1470,17 @@ impl Context {
     #[cfg(not(target_arch = "wasm32"))]
     pub fn map_image<'a>(
         &self,
-        image: &'a mut ImageReadBuffer,
+        buffers: &Buffers,
+        image_out: &'a mut ImageReadBuffer,
     ) -> MappedImage<'a> {
-        let slice = image.buffer.map_async(|_| {});
+        self.copy_image(buffers, image_out);
+        let slice = image_out.buffer.map_async(|_| {});
         self.gpu
             .device
             .poll(wgpu::PollType::wait_indefinitely())
             .unwrap();
         MappedImage {
-            image,
+            image: image_out,
             slice,
             ns_per_tick: if self.has_timestamps {
                 Some(self.gpu.queue.get_timestamp_period())
@@ -1497,10 +1490,7 @@ impl Context {
         }
     }
 
-    /// Asynchronously maps an image read buffer
-    ///
-    /// The image read buffer should be populated by passing it as an argument
-    /// when calling [`submit`](Self::submit).
+    /// Asynchronously populates and maps an CPU-readable image buffer
     ///
     /// The image is borrowed exclusively to avoid double-mapping
     ///
@@ -1508,8 +1498,10 @@ impl Context {
     #[cfg(any(target_arch = "wasm32", doc))]
     pub async fn map_image_async<'a>(
         &self,
-        image: &'a mut ImageReadBuffer,
+        buffers: &Buffers,
+        image_out: &'a mut ImageReadBuffer,
     ) -> MappedImage<'a> {
+        self.copy_image(buffers, image_out);
         let (tx, rx) = flume::bounded(0);
         let slice = image.buffer.map_async(move |_| tx.send(()).unwrap());
         rx.recv_async().await.unwrap();
@@ -1678,7 +1670,6 @@ mod test {
                 .submit(
                     &shape,
                     &mut buf,
-                    Some(&mut pixel_out),
                     &RenderConfig {
                         image_size,
                         world_to_model: nalgebra::Matrix3::identity(),
@@ -1687,7 +1678,7 @@ mod test {
                     },
                 )
                 .unwrap();
-            let img_out = pixel_ctx.map_image(&mut pixel_out).image();
+            let img_out = pixel_ctx.map_image(&buf, &mut pixel_out).image();
             assert_eq!(img_out.size(), image_size);
 
             // Basic circle inside/outside check

--- a/fidget-wgpu/src/pixel/mod.rs
+++ b/fidget-wgpu/src/pixel/mod.rs
@@ -1858,29 +1858,29 @@ mod test {
         assert_eq!(
             pixels,
             "\
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggbbbbbbbbbbbbbbbbbbggggggg
-            gggggggggggggggggggggggggggggggggggggggbbbbbbbbbbbbbbbbbbggggggg
-            gggggggggggggggggggggggggggggggggggggggbbbbbbbbbbbbbbbbbbggggggg
-            gggggggggggggggggggggggggggggggggggggggbbbbbbbbbbbbbbbbbbggggggg
-            gggggggggggggggggggggggggggggggggggggggbbbbbbbbbbbbbbbbbbggggggg
-            gggggggggggggggggggggggggggggggggggggggbbbbbbbbbbbbbbbbbbggggggg
-            gggggggggggggggggggggggggggggggggggggggbbbbbbbbbbbbbbbbbbggggggg
-            gggggggggggggggggggggggggggggggggggggggbbbbbbbbbbbbbbbbbbggggggg
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbggggggggggggggggggbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbggggggggggggggggggbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbggggggggggggggggggbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbggggggggggggggggggbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbggggggggggggggggggbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbggggggggggggggggggbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbggggggggggggggggggbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbggggggggggggggggggbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
             gggggggggggggggggggggggggggggggggbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
             gggggggggggggGGGGGGGgggggggggggggbbbbbbbbbbbbBBBBBBBbbbbbbbbbbbb
             gggggggggggGGGGGGGGGGGgggggggggggbbbbbbbbbbBBBBBBBBBBBbbbbbbbbbb
@@ -1891,37 +1891,37 @@ mod test {
             gggggggggGGGGGGGGGGGGGGGgggggggggbbbbbbbbBBBBBBBBBBBBBBBbbbbbbbb
             gggggggggGGGGGGGGGGGGGGGgggggggggbbbbbbbbBBBBBBBBBBBBBBBbbbbbbbb
             gggggggggGGGGGGGGGGGGGGGgggggggggbbbbbbbbBBBBBBBBBBBBBBBbbbbbbbb
-            gggggggggGGGGGGGGGGGGGGGgggggggggggggggbbBBBBBBBBBBBBBBBgggggggg
-            gggggggggGGGGGGGGGGGGGGGgggggggggggggggbbBBBBBBBBBBBBBBBbggggggg
-            ggggggggggGGGGGGGGGGGGGggggggggggggggggbbbBBBBBBBBBBBBBbbggggggg
-            ggggggggggGGGGGGGGGGGGGggggggggggggggggbbbBBBBBBBBBBBBBbbggggggg
-            gggggggggggGGGGGGGGGGGgggggggggggggggggbbbbBBBBBBBBBBBbbbggggggg
-            gggggggggggggGGGGGGGgggggggggggggggggggbbbbbbBBBBBBBbbbbbggggggg
-            gggggggggggggggggggggggggggggggggggggggbbbbbbbbbbbbbbbbbbggggggg
-            gggggggggggggggggggggggggggggggggggggggbbbbbbbbbbbbbbbbbbggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            bbbbbbbggGGGGGGGGGGGGGGGbbbbbbbbbbbbbbbbbBBBBBBBBBBBBBBBbbbbbbbb
+            bbbbbbbggGGGGGGGGGGGGGGGgbbbbbbbbbbbbbbbbBBBBBBBBBBBBBBBbbbbbbbb
+            bbbbbbbgggGGGGGGGGGGGGGggbbbbbbbbbbbbbbbbbBBBBBBBBBBBBBbbbbbbbbb
+            bbbbbbbgggGGGGGGGGGGGGGggbbbbbbbbbbbbbbbbbBBBBBBBBBBBBBbbbbbbbbb
+            bbbbbbbggggGGGGGGGGGGGgggbbbbbbbbbbbbbbbbbbBBBBBBBBBBBbbbbbbbbbb
+            bbbbbbbggggggGGGGGGGgggggbbbbbbbbbbbbbbbbbbbbBBBBBBBbbbbbbbbbbbb
+            bbbbbbbggggggggggggggggggbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbggggggggggggggggggbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
             "
             .replace(" ", "")
         );

--- a/fidget-wgpu/src/pixel/mod.rs
+++ b/fidget-wgpu/src/pixel/mod.rs
@@ -1645,7 +1645,7 @@ mod test {
 
     struct RenderOutput {
         distance: Image,
-        colors: RgbaImage,
+        color: RgbaImage,
     }
 
     fn render(
@@ -1699,7 +1699,7 @@ mod test {
         let img = effects_ctx.map_image(&merge_buf, &mut out);
 
         RenderOutput {
-            colors: img.color().unwrap(),
+            color: img.color().unwrap(),
             distance: img.distance(),
         }
     }
@@ -1725,11 +1725,11 @@ mod test {
         ] {
             let out = render(
                 &[(
-                    circle,
+                    circle.clone(),
                     ShapeColor::Rgb {
-                        r: Tree::constant(1.0),
-                        g: Tree::constant(1.0),
-                        b: Tree::constant(1.0),
+                        r: Tree::x(),
+                        g: Tree::y(),
+                        b: Tree::constant(0.5),
                     },
                 )],
                 RenderConfig {
@@ -1739,24 +1739,8 @@ mod test {
                     z: 0.0,
                 },
             );
-            assert_eq!(out.colors.size(), image_size);
+            assert_eq!(out.color.size(), image_size);
             assert_eq!(out.distance.size(), image_size);
-
-            for j in 0..image_size.height() {
-                for i in 0..image_size.width() {
-                    let p = out.distance[(j as usize, i as usize)];
-                    print!(
-                        "{}",
-                        match (p.inside(), p.is_distance()) {
-                            (true, true) => '#',
-                            (true, false) => 'X',
-                            (false, true) => '.',
-                            (false, false) => '-',
-                        }
-                    );
-                }
-                println!();
-            }
 
             // Basic circle inside/outside check
             let mat = image_size.screen_to_world();
@@ -1783,7 +1767,24 @@ mod test {
                 }
             }
 
-            todo!("read back image and test color");
+            for j in 0..image_size.height() {
+                for i in 0..image_size.width() {
+                    let pos = mat.transform_point(&nalgebra::Point2::new(
+                        i as f32, j as f32,
+                    ));
+                    let p = out.color[(j as usize, i as usize)];
+                    let expected_color = [
+                        (pos.x.clamp(0.0, 1.0) * 255.0) as u8,
+                        (pos.y.clamp(0.0, 1.0) * 255.0) as u8,
+                        127,
+                        255, // alpha is always 1 right now
+                    ];
+                    assert_eq!(
+                        p, expected_color,
+                        "color mismatch at {i}, {j} ({pos})"
+                    );
+                }
+            }
         }
     }
 

--- a/fidget-wgpu/src/pixel/mod.rs
+++ b/fidget-wgpu/src/pixel/mod.rs
@@ -23,6 +23,7 @@ use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 pub use fidget_raster::pixel::{RenderConfig, RenderSize};
 
 const COMMON_SHADER: &str = include_str!("shaders/common.wgsl");
+const DISTANCE_PIXEL_SHADER: &str = include_str!("shaders/distance_pixel.wgsl");
 const INTERVAL_INPUT: &str = include_str!("shaders/interval_input.wgsl");
 const TRANSFORM_INPUT: &str = include_str!("shaders/transform_input.wgsl");
 const INTERVAL_ROOT_SHADER: &str = include_str!("shaders/interval_root.wgsl");
@@ -35,6 +36,7 @@ fn interval_root_shader(reg_count: u8) -> String {
     let mut shader_code = shaders::opcode_constants();
     shader_code += &format!("const REG_COUNT: u32 = {reg_count};");
     shader_code += COMMON_SHADER;
+    shader_code += DISTANCE_PIXEL_SHADER;
     shader_code += INTERVAL_ROOT_SHADER;
     shader_code += INTERVAL_INPUT;
     shader_code += TRANSFORM_INPUT;
@@ -51,6 +53,7 @@ fn interval_tiles_shader(reg_count: u8) -> String {
     let mut shader_code = shaders::opcode_constants();
     shader_code += &format!("const REG_COUNT: u32 = {reg_count};");
     shader_code += COMMON_SHADER;
+    shader_code += DISTANCE_PIXEL_SHADER;
     shader_code += INTERVAL_TILES_SHADER;
     shader_code += INTERVAL_INPUT;
     shader_code += TRANSFORM_INPUT;
@@ -69,6 +72,7 @@ fn pixel_tiles_shader(reg_count: u8) -> String {
     shader_code += PIXEL_TILES_SHADER;
     shader_code += TRANSFORM_INPUT;
     shader_code += COMMON_SHADER;
+    shader_code += DISTANCE_PIXEL_SHADER;
     shader_code += shaders::FLOAT_OPS;
     shader_code += shaders::COMMON;
     shader_code += shaders::TAPE_INTERPRETER;
@@ -78,7 +82,10 @@ fn pixel_tiles_shader(reg_count: u8) -> String {
 
 /// Returns a shader for merging images
 fn merge_shader() -> String {
-    MERGE_SHADER.to_owned() + COMMON_SHADER + shaders::COMMON
+    MERGE_SHADER.to_owned()
+        + COMMON_SHADER
+        + DISTANCE_PIXEL_SHADER
+        + shaders::COMMON
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/fidget-wgpu/src/pixel/mod.rs
+++ b/fidget-wgpu/src/pixel/mod.rs
@@ -1262,8 +1262,8 @@ impl Context {
         out: &mut ImageReadBuffer,
         settings: RenderConfig,
     ) -> Result<Image, SubmitError> {
-        self.submit_with_vars(shape, vars, buffers, Some(out), &settings)?;
-        let image = self.map_image_async(out).await;
+        self.submit_with_vars(shape, vars, buffers, &settings)?;
+        let image = self.map_image_async(buffers, out).await;
         Ok(image.image())
     }
 
@@ -1503,10 +1503,10 @@ impl Context {
     ) -> MappedImage<'a> {
         self.copy_image(buffers, image_out);
         let (tx, rx) = flume::bounded(0);
-        let slice = image.buffer.map_async(move |_| tx.send(()).unwrap());
+        let slice = image_out.buffer.map_async(move |_| tx.send(()).unwrap());
         rx.recv_async().await.unwrap();
         MappedImage {
-            image,
+            image: image_out,
             slice,
             ns_per_tick: if self.has_timestamps {
                 Some(self.gpu.queue.get_timestamp_period())

--- a/fidget-wgpu/src/pixel/mod.rs
+++ b/fidget-wgpu/src/pixel/mod.rs
@@ -1618,6 +1618,9 @@ impl ResetContext {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::ShapeColor;
+    use fidget_raster::RgbaImage;
+
     use fidget_core::{context::Tree, vm::VmShape};
 
     #[test]
@@ -1640,6 +1643,67 @@ mod test {
         crate::compile_shader(&merge_shader(), "merge");
     }
 
+    struct RenderOutput {
+        distance: Image,
+        colors: RgbaImage,
+    }
+
+    fn render(
+        shapes: &[(Tree, ShapeColor<Tree>)],
+        render_config: RenderConfig,
+    ) -> RenderOutput {
+        let gpu = pollster::block_on(Gpu::init_basic()).unwrap();
+        let pixel_ctx = Context::new(&gpu);
+        let effects_ctx = effects::Context::new(&gpu);
+
+        let mut buf = pixel_ctx.buffers();
+        let mut merge_buf =
+            effects_ctx.merge_buffers(render_config.image_size).unwrap();
+
+        // Render and accumulate each shape
+        for (shape, _) in shapes {
+            let shape = gpu.shape(&VmShape::from(shape.clone())).unwrap();
+            pixel_ctx.submit(&shape, &mut buf, &render_config).unwrap();
+            effects_ctx
+                .submit_merge(
+                    &[buf.image_storage_buffer()],
+                    true,
+                    &mut merge_buf,
+                )
+                .unwrap();
+        }
+        let shape_colors = shapes
+            .iter()
+            .map(|(_, c)| {
+                let ShapeColor::Rgb { r, g, b } = c;
+                ShapeColor::Rgb {
+                    r: VmShape::from(r.clone()),
+                    g: VmShape::from(g.clone()),
+                    b: VmShape::from(b.clone()),
+                }
+            })
+            .collect::<Vec<_>>();
+        let shape_colors = effects_ctx.color_buffers(&shape_colors).unwrap();
+
+        // Compute per-pixel colors
+        effects_ctx
+            .submit_color(
+                &mut merge_buf,
+                &render_config.world_to_model,
+                0.0,
+                &shape_colors,
+            )
+            .unwrap();
+
+        let mut out = effects_ctx.image_buffer();
+        let img = effects_ctx.map_image(&merge_buf, &mut out);
+
+        RenderOutput {
+            colors: img.color().unwrap(),
+            distance: img.distance(),
+        }
+    }
+
     #[test]
     fn pixel_pipeline() {
         // We only run in CI if we're on MacOS (because other runners don't have
@@ -1649,14 +1713,8 @@ mod test {
             return;
         }
 
-        let gpu = pollster::block_on(Gpu::init_basic()).unwrap();
-        let pixel_ctx = Context::new(&gpu);
-        let effects_ctx = effects::Context::new(&gpu);
-        let mut buf = pixel_ctx.buffers();
-
         let (x, y, _z) = Tree::axes();
         let circle = (x.square() + y.square()).sqrt() - Tree::constant(0.5);
-        let shape = gpu.shape(&VmShape::from(circle)).unwrap();
 
         // Test a variety of image sizes for correctness
         for image_size in [
@@ -1665,21 +1723,40 @@ mod test {
             RenderSize::new(64, 128),
             RenderSize::new(27, 51),
         ] {
-            let mut pixel_out = pixel_ctx.image_buffer();
-            pixel_ctx
-                .submit(
-                    &shape,
-                    &mut buf,
-                    &RenderConfig {
-                        image_size,
-                        world_to_model: nalgebra::Matrix3::identity(),
-                        pixel_perfect: false,
-                        z: 0.0,
+            let out = render(
+                &[(
+                    circle,
+                    ShapeColor::Rgb {
+                        r: Tree::constant(1.0),
+                        g: Tree::constant(1.0),
+                        b: Tree::constant(1.0),
                     },
-                )
-                .unwrap();
-            let img_out = pixel_ctx.map_image(&buf, &mut pixel_out).image();
-            assert_eq!(img_out.size(), image_size);
+                )],
+                RenderConfig {
+                    image_size,
+                    world_to_model: nalgebra::Matrix3::identity(),
+                    pixel_perfect: false,
+                    z: 0.0,
+                },
+            );
+            assert_eq!(out.colors.size(), image_size);
+            assert_eq!(out.distance.size(), image_size);
+
+            for j in 0..image_size.height() {
+                for i in 0..image_size.width() {
+                    let p = out.distance[(j as usize, i as usize)];
+                    print!(
+                        "{}",
+                        match (p.inside(), p.is_distance()) {
+                            (true, true) => '#',
+                            (true, false) => 'X',
+                            (false, true) => '.',
+                            (false, false) => '-',
+                        }
+                    );
+                }
+                println!();
+            }
 
             // Basic circle inside/outside check
             let mat = image_size.screen_to_world();
@@ -1688,7 +1765,7 @@ mod test {
                     let pos = mat.transform_point(&nalgebra::Point2::new(
                         i as f32, j as f32,
                     ));
-                    let p = img_out[(j as usize, i as usize)];
+                    let p = out.distance[(j as usize, i as usize)];
                     let r = (pos.x.powi(2) + pos.y.powi(2)).sqrt();
                     if r < 0.5 {
                         assert!(
@@ -1705,16 +1782,6 @@ mod test {
                     }
                 }
             }
-
-            // smoke testing for merge pass
-            let mut out_buf = effects_ctx.merge_buffers(image_size).unwrap();
-            effects_ctx
-                .submit_merge(
-                    &[buf.image_storage_buffer()],
-                    false,
-                    &mut out_buf,
-                )
-                .unwrap();
 
             todo!("read back image and test color");
         }

--- a/fidget-wgpu/src/pixel/mod.rs
+++ b/fidget-wgpu/src/pixel/mod.rs
@@ -1706,6 +1706,7 @@ mod test {
                 }
             }
 
+            // smoke testing for merge pass
             let mut out_buf = effects_ctx.merge_buffers(image_size).unwrap();
             effects_ctx
                 .submit_merge(
@@ -1714,6 +1715,8 @@ mod test {
                     &mut out_buf,
                 )
                 .unwrap();
+
+            todo!("read back image and test color");
         }
     }
 

--- a/fidget-wgpu/src/pixel/mod.rs
+++ b/fidget-wgpu/src/pixel/mod.rs
@@ -1617,6 +1617,7 @@ impl ResetContext {
 
 #[cfg(test)]
 mod test {
+    use super::effects::ColorSettings;
     use super::*;
     use crate::ShapeColor;
     use fidget_raster::RgbaImage;
@@ -1689,8 +1690,11 @@ mod test {
         effects_ctx
             .submit_color(
                 &mut merge_buf,
-                &render_config.world_to_model,
-                0.0,
+                ColorSettings {
+                    z: 0.0,
+                    only_filled: false,
+                    world_to_model: render_config.world_to_model,
+                },
                 &shape_colors,
             )
             .unwrap();
@@ -1773,11 +1777,13 @@ mod test {
                         i as f32, j as f32,
                     ));
                     let p = out.color[(j as usize, i as usize)];
+                    let r = (pos.x.powi(2) + pos.y.powi(2)).sqrt();
+                    let alpha = if r < 0.5 { 255 } else { 0 };
                     let expected_color = [
                         (pos.x.clamp(0.0, 1.0) * 255.0) as u8,
                         (pos.y.clamp(0.0, 1.0) * 255.0) as u8,
                         127,
-                        255, // alpha is always 1 right now
+                        alpha,
                     ];
                     assert_eq!(
                         p, expected_color,

--- a/fidget-wgpu/src/pixel/mod.rs
+++ b/fidget-wgpu/src/pixel/mod.rs
@@ -1795,6 +1795,139 @@ mod test {
     }
 
     #[test]
+    fn pixel_multiple_images() {
+        // We only run in CI if we're on MacOS (because other runners don't have
+        // GPUs and will fail to build the context).
+        #[cfg(not(target_os = "macos"))]
+        if std::env::var("CI").is_ok() {
+            return;
+        }
+
+        let circle_a = ((Tree::x() - 0.5).square() + Tree::y().square()).sqrt()
+            - Tree::constant(0.25);
+        let circle_b = ((Tree::x() + 0.5).square() + Tree::y().square()).sqrt()
+            - Tree::constant(0.25);
+
+        // Test a variety of image sizes for correctness
+        let image_size = RenderSize::new(64, 64);
+        let out = render(
+            &[
+                (
+                    circle_a,
+                    ShapeColor::Rgb {
+                        r: Tree::constant(0.0),
+                        g: Tree::constant(0.0),
+                        b: Tree::constant(1.0),
+                    },
+                ),
+                (
+                    circle_b,
+                    ShapeColor::Rgb {
+                        r: Tree::constant(0.0),
+                        g: Tree::constant(1.0),
+                        b: Tree::constant(0.0),
+                    },
+                ),
+            ],
+            RenderConfig {
+                image_size,
+                world_to_model: nalgebra::Matrix3::identity(),
+                pixel_perfect: false,
+                z: 0.0,
+            },
+        );
+        assert_eq!(out.color.size(), image_size);
+        assert_eq!(out.distance.size(), image_size);
+
+        let mut pixels = String::new();
+        for j in 0..image_size.height() {
+            for i in 0..image_size.width() {
+                let p = out.color[(j as usize, i as usize)];
+                let c = match p {
+                    [0, 0, 255, 0] => "b",
+                    [0, 0, 255, 255] => "B",
+                    [0, 255, 0, 0] => "g",
+                    [0, 255, 0, 255] => "G",
+                    _ => panic!("invalid color {p:?}"),
+                };
+                pixels += c;
+            }
+            pixels += "\n";
+        }
+
+        assert_eq!(
+            pixels,
+            "\
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggbbbbbbbbbbbbbbbbbbggggggg
+            gggggggggggggggggggggggggggggggggggggggbbbbbbbbbbbbbbbbbbggggggg
+            gggggggggggggggggggggggggggggggggggggggbbbbbbbbbbbbbbbbbbggggggg
+            gggggggggggggggggggggggggggggggggggggggbbbbbbbbbbbbbbbbbbggggggg
+            gggggggggggggggggggggggggggggggggggggggbbbbbbbbbbbbbbbbbbggggggg
+            gggggggggggggggggggggggggggggggggggggggbbbbbbbbbbbbbbbbbbggggggg
+            gggggggggggggggggggggggggggggggggggggggbbbbbbbbbbbbbbbbbbggggggg
+            gggggggggggggggggggggggggggggggggggggggbbbbbbbbbbbbbbbbbbggggggg
+            gggggggggggggggggggggggggggggggggbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            gggggggggggggGGGGGGGgggggggggggggbbbbbbbbbbbbBBBBBBBbbbbbbbbbbbb
+            gggggggggggGGGGGGGGGGGgggggggggggbbbbbbbbbbBBBBBBBBBBBbbbbbbbbbb
+            ggggggggggGGGGGGGGGGGGGggggggggggbbbbbbbbbBBBBBBBBBBBBBbbbbbbbbb
+            ggggggggggGGGGGGGGGGGGGggggggggggbbbbbbbbbBBBBBBBBBBBBBbbbbbbbbb
+            gggggggggGGGGGGGGGGGGGGGgggggggggbbbbbbbbBBBBBBBBBBBBBBBbbbbbbbb
+            gggggggggGGGGGGGGGGGGGGGgggggggggbbbbbbbbBBBBBBBBBBBBBBBbbbbbbbb
+            gggggggggGGGGGGGGGGGGGGGgggggggggbbbbbbbbBBBBBBBBBBBBBBBbbbbbbbb
+            gggggggggGGGGGGGGGGGGGGGgggggggggbbbbbbbbBBBBBBBBBBBBBBBbbbbbbbb
+            gggggggggGGGGGGGGGGGGGGGgggggggggbbbbbbbbBBBBBBBBBBBBBBBbbbbbbbb
+            gggggggggGGGGGGGGGGGGGGGgggggggggggggggbbBBBBBBBBBBBBBBBgggggggg
+            gggggggggGGGGGGGGGGGGGGGgggggggggggggggbbBBBBBBBBBBBBBBBbggggggg
+            ggggggggggGGGGGGGGGGGGGggggggggggggggggbbbBBBBBBBBBBBBBbbggggggg
+            ggggggggggGGGGGGGGGGGGGggggggggggggggggbbbBBBBBBBBBBBBBbbggggggg
+            gggggggggggGGGGGGGGGGGgggggggggggggggggbbbbBBBBBBBBBBBbbbggggggg
+            gggggggggggggGGGGGGGgggggggggggggggggggbbbbbbBBBBBBBbbbbbggggggg
+            gggggggggggggggggggggggggggggggggggggggbbbbbbbbbbbbbbbbbbggggggg
+            gggggggggggggggggggggggggggggggggggggggbbbbbbbbbbbbbbbbbbggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            "
+            .replace(" ", "")
+        );
+    }
+
+    #[test]
     fn pixel_config_layout() {
         // Pick any shader, since `struct Config` is in the common text
         crate::test::compare_struct_layout::<Config>(&merge_shader(), "Config");

--- a/fidget-wgpu/src/pixel/mod.rs
+++ b/fidget-wgpu/src/pixel/mod.rs
@@ -879,19 +879,17 @@ pub struct ImageReadBuffer {
 }
 
 impl ImageReadBuffer {
-    fn new(
-        device: &wgpu::Device,
-        name: String,
-        image_size: ImageSize,
-    ) -> Result<Self, BufferSizeError> {
-        Ok(Self {
+    fn new(device: &wgpu::Device, name: String) -> Self {
+        let image_size = 64.into();
+        Self {
             image_size,
             buffer: ImageReadArrayBuffer::new(
                 device,
                 name,
                 Buffers::image_buf_size(image_size),
-            )?,
-        })
+            )
+            .expect("64 should always be a valid size"),
+        }
     }
 
     fn grow_to_fit(
@@ -1197,8 +1195,7 @@ impl Context {
 
     /// Returns an [`ImageReadBuffer`] to read from a [`Buffers`] object
     pub fn image_buffer(&self) -> ImageReadBuffer {
-        ImageReadBuffer::new(&self.gpu.device, "image".to_owned(), 64.into())
-            .expect("64 should always be a valid size for ImageReadBuffer::new")
+        ImageReadBuffer::new(&self.gpu.device, "image".to_owned())
     }
 
     /// Renders the image, with a blocking wait to read pixel data from the GPU

--- a/fidget-wgpu/src/pixel/mod.rs
+++ b/fidget-wgpu/src/pixel/mod.rs
@@ -1666,11 +1666,7 @@ mod test {
             let shape = gpu.shape(&VmShape::from(shape.clone())).unwrap();
             pixel_ctx.submit(&shape, &mut buf, &render_config).unwrap();
             effects_ctx
-                .submit_merge(
-                    &[buf.image_storage_buffer()],
-                    true,
-                    &mut merge_buf,
-                )
+                .submit_merge(buf.image_storage_buffer(), true, &mut merge_buf)
                 .unwrap();
         }
         let shape_colors = shapes

--- a/fidget-wgpu/src/pixel/mod.rs
+++ b/fidget-wgpu/src/pixel/mod.rs
@@ -1662,6 +1662,7 @@ mod test {
 
         let gpu = pollster::block_on(Gpu::init_basic()).unwrap();
         let pixel_ctx = Context::new(&gpu);
+        let effects_ctx = effects::Context::new(&gpu);
         let mut buf = pixel_ctx.buffers();
 
         let (x, y, _z) = Tree::axes();
@@ -1716,6 +1717,15 @@ mod test {
                     }
                 }
             }
+
+            let mut out_buf = effects_ctx.merge_buffers(image_size).unwrap();
+            effects_ctx
+                .submit_merge(
+                    &[buf.image_storage_buffer()],
+                    false,
+                    &mut out_buf,
+                )
+                .unwrap();
         }
     }
 

--- a/fidget-wgpu/src/pixel/mod.rs
+++ b/fidget-wgpu/src/pixel/mod.rs
@@ -1462,7 +1462,7 @@ impl Context {
         self.gpu.queue.submit(Some(encoder.finish()));
     }
 
-    /// Synchronously populates and maps an CPU-readable image buffer
+    /// Synchronously populates and maps a CPU-readable image buffer
     ///
     /// The image is borrowed exclusively to avoid double-mapping
     ///
@@ -1490,7 +1490,7 @@ impl Context {
         }
     }
 
-    /// Asynchronously populates and maps an CPU-readable image buffer
+    /// Asynchronously populates and maps a CPU-readable image buffer
     ///
     /// The image is borrowed exclusively to avoid double-mapping
     ///

--- a/fidget-wgpu/src/pixel/mod.rs
+++ b/fidget-wgpu/src/pixel/mod.rs
@@ -21,6 +21,7 @@ use std::num::NonZeroU64;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 pub use fidget_raster::pixel::{RenderConfig, RenderSize};
+pub mod effects;
 
 const COMMON_SHADER: &str = include_str!("shaders/common.wgsl");
 const DISTANCE_PIXEL_SHADER: &str = include_str!("shaders/distance_pixel.wgsl");

--- a/fidget-wgpu/src/pixel/shaders/common.wgsl
+++ b/fidget-wgpu/src/pixel/shaders/common.wgsl
@@ -70,25 +70,3 @@ fn get_tape_offset_for_level(corner_pos: vec2u, level: u32) -> u32 {
     return 0;
 }
 
-/// Equivalent to RawDistancePixel in Rust, but storing a u32 instead of f32
-/// (because shaders are bad about handling NaN values)
-struct RawDistancePixel {
-    data: u32,
-}
-
-const DISTANCE_PIXEL_KEY: u32 = 0xF6 << 9;
-
-fn distance_pixel_fill(depth: u32, inside: bool) -> RawDistancePixel {
-    let data = 0x7FC00000u | (depth << 1) | u32(inside) | DISTANCE_PIXEL_KEY;
-    return RawDistancePixel(data);
-}
-
-fn distance_pixel_value(v: f32) -> RawDistancePixel {
-    if v != v {
-        // attempt to canonicalize NaN values, in case someone is trying to do
-        // something weird (???)
-        return RawDistancePixel(bitcast<u32>(nan_f32()));
-    } else {
-        return RawDistancePixel(bitcast<u32>(v));
-    }
-}

--- a/fidget-wgpu/src/pixel/shaders/distance_pixel.wgsl
+++ b/fidget-wgpu/src/pixel/shaders/distance_pixel.wgsl
@@ -1,0 +1,35 @@
+/// Equivalent to RawDistancePixel in Rust, but storing a u32 instead of f32
+/// (because shaders are bad about handling NaN values)
+struct RawDistancePixel {
+    data: u32,
+}
+
+// NAN with characteristic bit pattern in mantissa
+const DISTANCE_PIXEL_KEY: u32 = 0x7fc1ec00;
+
+fn distance_pixel_fill(depth: u32, inside: bool) -> RawDistancePixel {
+    let data = (depth << 1) | u32(inside) | DISTANCE_PIXEL_KEY;
+    return RawDistancePixel(data);
+}
+
+fn distance_pixel_is_fill(d: RawDistancePixel) -> bool {
+    return (d.data & DISTANCE_PIXEL_KEY) == DISTANCE_PIXEL_KEY;
+}
+
+fn distance_pixel_is_inside(d: RawDistancePixel) -> bool {
+    if distance_pixel_is_fill(d) {
+        return (d.data & 1u) != 0;
+    } else {
+        return bitcast<f32>(d.data) < 0.0;
+    }
+}
+
+fn distance_pixel_value(v: f32) -> RawDistancePixel {
+    if v != v {
+        // attempt to canonicalize NaN values, in case someone is trying to do
+        // something weird (???)
+        return RawDistancePixel(bitcast<u32>(nan_f32()));
+    } else {
+        return RawDistancePixel(bitcast<u32>(v));
+    }
+}

--- a/fidget-wgpu/src/voxel/effects/mod.rs
+++ b/fidget-wgpu/src/voxel/effects/mod.rs
@@ -99,7 +99,7 @@ pub struct PackedVoxel {
 /// Configuration for the color evaluation pass
 ///
 /// This is public because it's used in a public function signature, but it's
-/// not expected to be used.
+/// unlikely to be used by library end-users.
 #[derive(Copy, Clone, FromBytes, Immutable, IntoBytes, KnownLayout)]
 #[cfg_attr(test, derive(facet::Facet))]
 #[repr(C)]

--- a/fidget-wgpu/src/voxel/effects/mod.rs
+++ b/fidget-wgpu/src/voxel/effects/mod.rs
@@ -103,6 +103,7 @@ pub struct PackedVoxel {
 #[derive(Copy, Clone, FromBytes, Immutable, IntoBytes, KnownLayout)]
 #[cfg_attr(test, derive(facet::Facet))]
 #[repr(C)]
+#[doc(hidden)]
 pub struct ColorConfig {
     /// Screen-to-model transform matrix
     mat: [f32; 16],

--- a/fidget-wgpu/src/voxel/effects/mod.rs
+++ b/fidget-wgpu/src/voxel/effects/mod.rs
@@ -257,6 +257,10 @@ pub enum ColorError {
         /// Number of shapes in the color buffer
         shape_count: usize,
     },
+
+    /// Shape color has already been populated
+    #[error("shape color has already been populated")]
+    AlreadyHasColor,
 }
 
 /// Type indicating an image size mismatch
@@ -452,9 +456,9 @@ impl Context {
 
     /// Accumulates an image into a merged image buffer
     ///
-    /// If the merged buffer has been reset (with [`MergeBuffers::reset`]), then
-    /// it is resized to fit the incoming image; otherwise, an error is returned
-    /// if the image size does not match.
+    /// [`MergeBuffers::reset`] should be called before the first call to
+    /// `submit_merge`. For the first merge after a reset, the output buffer is
+    /// resized to fit the images; subsequent merges must be of the same size.
     pub fn submit_merge(
         &self,
         image: &DepthImageBuffer<GeomBufferTag>,

--- a/fidget-wgpu/src/voxel/effects/mod.rs
+++ b/fidget-wgpu/src/voxel/effects/mod.rs
@@ -99,10 +99,13 @@ pub struct PackedVoxel {
 }
 
 /// Configuration for the color evaluation pass
+///
+/// This is public because it's used in a public function signature, but it's
+/// not expected to be used.
 #[derive(Copy, Clone, FromBytes, Immutable, IntoBytes, KnownLayout)]
 #[cfg_attr(test, derive(facet::Facet))]
 #[repr(C)]
-struct ColorConfig {
+pub struct ColorConfig {
     /// Screen-to-model transform matrix
     mat: [f32; 16],
 
@@ -665,12 +668,8 @@ impl Context {
     pub fn color_buffers(
         &self,
         colors: &[ShapeColor<VmShape>],
-    ) -> Result<ShapeColorBuffers, ShapeColorError> {
-        ShapeColorBuffers::new(
-            colors,
-            &self.gpu.device,
-            std::mem::size_of::<ColorConfig>(),
-        )
+    ) -> Result<ShapeColorBuffers<ColorConfig>, ShapeColorError> {
+        ShapeColorBuffers::new(colors, &self.gpu.device)
     }
 
     /// Submits a color evaluation pass
@@ -682,7 +681,7 @@ impl Context {
         &self,
         merge: &MergeBuffers,
         world_to_model: &nalgebra::Matrix4<f32>,
-        shape: &ShapeColorBuffers,
+        shape: &ShapeColorBuffers<ColorConfig>,
         out: &mut ShadeBuffers,
     ) -> Result<(), ColorError> {
         self.submit_color_with_vars(
@@ -703,7 +702,7 @@ impl Context {
         &self,
         merge: &MergeBuffers,
         world_to_model: &nalgebra::Matrix4<f32>,
-        shape: &ShapeColorBuffers,
+        shape: &ShapeColorBuffers<ColorConfig>,
         vars: &ShapeVars<f32>,
         out: &mut ShadeBuffers,
     ) -> Result<(), ColorError> {
@@ -1110,7 +1109,7 @@ impl ColorContext {
         &self,
         image: &MergeBuffers,
         world_to_model: &nalgebra::Matrix4<f32>,
-        shape: &ShapeColorBuffers,
+        shape: &ShapeColorBuffers<ColorConfig>,
         vars: &ShapeVars<f32>,
         out: &mut ShadeBuffers,
         gpu: &Gpu,

--- a/fidget-wgpu/src/voxel/effects/mod.rs
+++ b/fidget-wgpu/src/voxel/effects/mod.rs
@@ -21,10 +21,8 @@ use crate::{
 use fidget_core::{
     render::VoxelSize,
     shape::{MissingVar, ShapeVars},
-    var::Var,
     vm::VmShape,
 };
-use std::num::NonZeroU64;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 /// WGPU context for applying various effects
@@ -1137,42 +1135,8 @@ impl ColorContext {
             image_size: [size.width(), size.height()],
             _pad: 0,
         };
-
-        {
-            // We load the `ColorConfig`; tape data is already in the buffer
-            let config_len = std::mem::size_of_val(&config);
-            let mut writer = gpu
-                .queue
-                .write_buffer_with(
-                    &shape.config,
-                    0,
-                    (config_len as u64).try_into().unwrap(),
-                )
-                .unwrap();
-            writer.copy_from_slice(config.as_bytes());
-        }
-
-        // Copy vars (if present)
-        if let Some(var_size) = NonZeroU64::new(shape.vars.size()) {
-            let mut writer = gpu
-                .queue
-                .write_buffer_with(&shape.vars, 0, var_size)
-                .unwrap();
-            for (v, i) in shape.var_map.iter() {
-                match v {
-                    Var::X | Var::Y | Var::Z => (),
-                    Var::V(vi) => {
-                        let Some(value) = vars.get(vi) else {
-                            return Err(MissingVar { var: vi }.into());
-                        };
-                        let offset = i * std::mem::size_of::<f32>();
-                        writer
-                            .slice(offset..offset + 4)
-                            .copy_from_slice(value.as_bytes());
-                    }
-                }
-            }
-        }
+        shape.write_config(&config, &gpu.queue);
+        shape.write_vars(vars, &gpu.queue)?;
 
         // Create a command encoder and dispatch the compute work
         let mut encoder = gpu.device.create_command_encoder(

--- a/fidget-wgpu/src/voxel/effects/mod.rs
+++ b/fidget-wgpu/src/voxel/effects/mod.rs
@@ -122,17 +122,17 @@ struct ColorConfig {
 #[derive(Copy, Clone, FromBytes, Immutable, IntoBytes, KnownLayout)]
 #[cfg_attr(test, derive(facet::Facet))]
 #[repr(C)]
-struct MergeConfig {
+pub(crate) struct MergeConfig {
     /// Image size, in pixels
-    image_size: [u32; 2],
+    pub image_size: [u32; 2],
 
     /// Whether or not to denoise when merging (non-zero is true)
-    denoise: u32,
+    pub denoise: u32,
 
     /// Offset applied to indices when merging
     ///
     /// When this is 0, we initialize the output image
-    index_base: u32,
+    pub index_base: u32,
 }
 
 #[derive(Copy, Clone, FromBytes, Immutable, IntoBytes, KnownLayout)]

--- a/fidget-wgpu/src/voxel/effects/mod.rs
+++ b/fidget-wgpu/src/voxel/effects/mod.rs
@@ -1,4 +1,4 @@
-//! On-GPU effects
+//! Voxel post-processing effects
 //!
 //! These effects let us set up a simple rendering pipeline:
 //!

--- a/fidget-wgpu/src/voxel/effects/mod.rs
+++ b/fidget-wgpu/src/voxel/effects/mod.rs
@@ -1290,7 +1290,6 @@ mod test {
             .submit(
                 &shape,
                 &mut buf,
-                None,
                 &crate::voxel::RenderConfig {
                     image_size,
                     world_to_model: nalgebra::Matrix4::identity(),

--- a/fidget-wgpu/src/voxel/effects/shaders/common.wgsl
+++ b/fidget-wgpu/src/voxel/effects/shaders/common.wgsl
@@ -2,7 +2,7 @@ struct PackedVoxel {
     /// Bit-packed values for normal and index
     ///
     /// Normal is stored as an `[i8; 2]`, normalized to a length of 127 with the
-    /// Z component implied and positive.
+    /// Z component implied and positive.  Index is a 16-bit value.
     norm_index: u32,
 
     /// Depth of the voxel

--- a/fidget-wgpu/src/voxel/mod.rs
+++ b/fidget-wgpu/src/voxel/mod.rs
@@ -96,12 +96,11 @@
 //!
 //! Lower-level building blocks are also available: [`Context::submit`] submits
 //! the render operations to the GPU, and [`Context::map_image`] /
-//! [`Context::map_image_async`] map the image buffer back to the GPU.
+//! [`Context::map_image_async`] copy and map the image buffer back to the CPU.
 //!
-//! To reuse the image buffer within a more complex GPU pipeline – without
-//! copying to the mappable buffer or CPU – [`Context::submit`] may be called
-//! with `None` for its `out` argument.  In this case, the output is available
-//! in [`Buffers::image_storage_buffer`] for subsequent pipelines.
+//! To reuse the image buffer within a more complex GPU pipeline, rendering
+//! output is available in [`Buffers::image_storage_buffer`] for subsequent
+//! pipelines.
 
 use crate::{
     Gpu, RegPipeline, RenderShape, TAPE_DATA_CAPACITY, TapeWord,
@@ -2182,8 +2181,8 @@ impl Context {
         out: &mut ImageReadBuffer,
         settings: RenderConfig,
     ) -> Result<Image, SubmitError> {
-        self.submit_with_vars(shape, vars, buffers, Some(out), &settings)?;
-        let image = self.map_image(out);
+        self.submit_with_vars(shape, vars, buffers, &settings)?;
+        let image = self.map_image(buffers, out);
         Ok(image.image())
     }
 
@@ -2230,25 +2229,13 @@ impl Context {
     /// The resulting image (as a buffer of [`GeometryPixel`] data) is available
     /// on the GPU in
     /// [`buffers.image_storage_buffer()`](Buffers::image_storage_buffer).
-    ///
-    /// If `out` is present, then the rendered image is also copied to that
-    /// [`ImageReadBuffer`] (which may then be mapped for CPU reading by
-    /// [`map_image`](Self::map_image) or
-    /// [`map_image_async`](Self::map_image_async)).
     pub fn submit(
         &self,
         shape: &RenderShape,
         buffers: &mut Buffers,
-        out: Option<&mut ImageReadBuffer>,
         settings: &RenderConfig,
     ) -> Result<(), SubmitError> {
-        self.submit_with_vars(
-            shape,
-            &Default::default(),
-            buffers,
-            out,
-            settings,
-        )
+        self.submit_with_vars(shape, &Default::default(), buffers, settings)
     }
 
     /// Submits a single image to be rendered on the GPU, with extra variables
@@ -2259,7 +2246,6 @@ impl Context {
         shape: &RenderShape,
         vars: &ShapeVars<f32>,
         buffers: &mut Buffers,
-        out: Option<&mut ImageReadBuffer>,
         settings: &RenderConfig,
     ) -> Result<(), SubmitError> {
         buffers.set_image_size(&self.gpu.device, settings.image_size)?;
@@ -2402,39 +2388,46 @@ impl Context {
         }
         drop(compute_pass);
 
-        // Resolve the raw GPU ticks into the resolve buffer, then copy them
-        // into the last 16 bytes of the image buffer
-        if let Some(image) = out {
-            image
-                .grow_to_fit(&self.gpu.device, buffers.image_size)
-                .expect(
-                    "buffers.image_size should always be \
-                     a valid size for ImageReadBuffer::grow_to_fit",
-                );
-            if let Some(timestamps) = &buffers.timestamps {
-                encoder.resolve_query_set(timestamps, 0..2, &buffers.ts_buf, 0);
-                encoder.copy_buffer_to_buffer(
-                    &buffers.ts_buf,
-                    0,
-                    image.buffer.data(),
-                    buffers.geom.size_bytes(), // offset past the image data
-                    buffers.ts_buf.size(),
-                );
-            }
-
-            // Copy from the STORAGE | COPY_SRC -> COPY_DST | MAP_READ buffer
-            encoder.copy_buffer_to_buffer(
-                buffers.geom.data(),
-                0,
-                image.buffer.data(),
-                0,
-                buffers.geom.size_bytes(),
-            );
-        }
-
         // Submit the commands and wait for the GPU to complete
         self.gpu.queue.submit(Some(encoder.finish()));
         Ok(())
+    }
+
+    fn copy_image(&self, buffers: &Buffers, image_out: &mut ImageReadBuffer) {
+        let mut encoder = self.gpu.device.create_command_encoder(
+            &wgpu::CommandEncoderDescriptor {
+                label: Some("map_image"),
+            },
+        );
+        image_out
+            .grow_to_fit(&self.gpu.device, buffers.image_size)
+            .expect(
+                "buffers.image_size should always be \
+                     a valid size for ImageReadBuffer::grow_to_fit",
+            );
+        // Resolve the raw GPU ticks into the resolve buffer, then copy them
+        // into the last 16 bytes of the image buffer
+        if let Some(timestamps) = &buffers.timestamps {
+            encoder.resolve_query_set(timestamps, 0..2, &buffers.ts_buf, 0);
+            encoder.copy_buffer_to_buffer(
+                &buffers.ts_buf,
+                0,
+                image_out.buffer.data(),
+                buffers.geom.size_bytes(), // offset past the image data
+                buffers.ts_buf.size(),
+            );
+        }
+
+        // Copy from the STORAGE | COPY_SRC -> COPY_DST | MAP_READ buffer
+        encoder.copy_buffer_to_buffer(
+            buffers.geom.data(),
+            0,
+            image_out.buffer.data(),
+            0,
+            buffers.geom.size_bytes(),
+        );
+
+        self.gpu.queue.submit(Some(encoder.finish()));
     }
 
     /// Synchronously maps an image read buffer
@@ -2448,8 +2441,10 @@ impl Context {
     #[cfg(not(target_arch = "wasm32"))]
     pub fn map_image<'a>(
         &self,
+        buffers: &Buffers,
         image: &'a mut ImageReadBuffer,
     ) -> MappedImage<'a> {
+        self.copy_image(buffers, image);
         let slice = image.buffer.map_async(|_| {});
         self.gpu
             .device
@@ -2477,8 +2472,10 @@ impl Context {
     #[cfg(any(target_arch = "wasm32", doc))]
     pub async fn map_image_async<'a>(
         &self,
+        buffers: &Buffers,
         image: &'a mut ImageReadBuffer,
     ) -> MappedImage<'a> {
+        self.copy_image(buffers, image);
         let (tx, rx) = flume::bounded(0);
         let slice = image.buffer.map_async(move |_| tx.send(()).unwrap());
         rx.recv_async().await.unwrap();
@@ -2830,9 +2827,7 @@ mod test {
         // Render and accumulate each shape
         for (shape, _) in shapes {
             let shape = gpu.shape(&VmShape::from(shape.clone())).unwrap();
-            voxel_ctx
-                .submit(&shape, &mut buf, None, &render_config)
-                .unwrap();
+            voxel_ctx.submit(&shape, &mut buf, &render_config).unwrap();
             effects_ctx
                 .submit_merge(buf.image_storage_buffer(), true, &mut merge_buf)
                 .unwrap();

--- a/fidget-wgpu/src/voxel/mod.rs
+++ b/fidget-wgpu/src/voxel/mod.rs
@@ -2219,8 +2219,8 @@ impl Context {
         out: &mut ImageReadBuffer,
         settings: RenderConfig,
     ) -> Result<Image, SubmitError> {
-        self.submit_with_vars(shape, vars, buffers, Some(out), &settings)?;
-        let image = self.map_image_async(out).await;
+        self.submit_with_vars(shape, vars, buffers, &settings)?;
+        let image = self.map_image_async(buffers, out).await;
         Ok(image.image())
     }
 


### PR DESCRIPTION
This is the parallel to `fidget_wgpu::voxel::effects`.  The output is slightly different: we get separate distance and color images, because the final draw-to-screen pass may want to upsample distance values with linear interpolation (versus baking a final RGB image at the buffer size).