### PR TITLE
Make `ShapeColorBuffer` not pixel/voxel-specific

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - Move `fidget_wgpu::effects` to `fidget_wgpu::voxel::effects`
 - Add evaluation of per-pixel colors to `fidget_wgpu::voxel::effects`; see
   `fidget_wgpu::voxel::effects::Context::submit_color` as the main entry point.
+    - Move `ShapeColorBuffers` construction to top-level `Gpu` object
 - Add `fidget_bytecode::Bytecode::build_with_input_map` for building a
   `Bytecode` object with a particular remapping function for inputs.  This is
   helpful if you're going to combine multiple bytecode tapes and want them to

--- a/fidget-wgpu/src/lib.rs
+++ b/fidget-wgpu/src/lib.rs
@@ -182,6 +182,14 @@ impl Gpu {
     ) -> Result<RenderShape, RenderShapeError> {
         RenderShape::new(shape, &self.device)
     }
+
+    /// Build a set of buffers for doing shape color evaluation
+    pub fn color_buffers(
+        &self,
+        colors: &[ShapeColor<VmShape>],
+    ) -> Result<ShapeColorBuffers, ShapeColorError> {
+        ShapeColorBuffers::new(colors, &self.device)
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -320,7 +328,7 @@ impl RenderShape {
 ////////////////////////////////////////////////////////////////////////////////
 
 /// Color buffers for rendering a shape's diffuse color
-pub struct ShapeColorBuffers<C> {
+pub struct ShapeColorBuffers {
     /// Unified [`VarMap`] object
     var_map: VarMap,
 
@@ -349,9 +357,6 @@ pub struct ShapeColorBuffers<C> {
     /// This doesn't live in a `Buffers` object because it's dynamically sized
     /// based on the shape; everything in `Buffers` is based on image size.
     vars: wgpu::Buffer,
-
-    // Marker for the config type
-    _config: std::marker::PhantomData<C>,
 }
 
 /// Generic shape color generator
@@ -367,7 +372,11 @@ pub enum ShapeColor<T> {
     },
 }
 
-impl<C: IntoBytes + Immutable> ShapeColorBuffers<C> {
+impl ShapeColorBuffers {
+    const fn expected_config_size() -> usize {
+        std::mem::size_of::<voxel::effects::ColorConfig>()
+    }
+
     fn new(
         colors: &[ShapeColor<VmShape>],
         device: &wgpu::Device,
@@ -438,7 +447,7 @@ impl<C: IntoBytes + Immutable> ShapeColorBuffers<C> {
             .copy_from_slice(shape_start.as_bytes());
         shape_start_buf.unmap();
 
-        let config_size = std::mem::size_of::<C>();
+        let config_size = Self::expected_config_size();
         let config_buf = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("shape_start"),
             size: u64::try_from(
@@ -461,7 +470,6 @@ impl<C: IntoBytes + Immutable> ShapeColorBuffers<C> {
             vars,
             config_bind_group: Default::default(),
             reg_count,
-            _config: std::marker::PhantomData,
         })
     }
 
@@ -471,8 +479,21 @@ impl<C: IntoBytes + Immutable> ShapeColorBuffers<C> {
             .map(|a| self.var_map.get(&a).map(|v| v as u32).unwrap_or(u32::MAX))
     }
 
-    fn write_config(&self, c: &C, queue: &wgpu::Queue) {
+    /// Writes a config value
+    ///
+    /// # Panics
+    /// If the config object is not the expected size
+    fn write_config<C: IntoBytes + Immutable>(
+        &self,
+        c: &C,
+        queue: &wgpu::Queue,
+    ) {
         let config_len = std::mem::size_of::<C>();
+        assert_eq!(
+            config_len,
+            Self::expected_config_size(),
+            "wrong config object size"
+        );
         let mut writer = queue
             .write_buffer_with(
                 &self.config,
@@ -628,9 +649,17 @@ mod test {
             Some(m.offset)
         });
         if let Some(dynamic_array_offset) = dynamic_array_offset {
-            assert_eq!(dynamic_array_offset as usize, std::mem::size_of::<T>());
+            assert_eq!(
+                dynamic_array_offset as usize,
+                std::mem::size_of::<T>(),
+                "dynamic array offset is incorrect; invalid last member size?"
+            );
         } else {
-            assert_eq!(span as usize, std::mem::size_of::<T>());
+            assert_eq!(
+                span as usize,
+                std::mem::size_of::<T>(),
+                "overall size is incorrect"
+            );
         }
 
         let facet::Type::User(facet::UserType::Struct(shape)) = T::SHAPE.ty

--- a/fidget-wgpu/src/pixel/effects/mod.rs
+++ b/fidget-wgpu/src/pixel/effects/mod.rs
@@ -18,7 +18,7 @@
 //! (which is not particularly meaningful to users); in that case,
 //! [`MappedImage::color`] will return `None`.
 use crate::{
-    Gpu, RegPipeline, ShapeColor, ShapeColorBuffers, ShapeColorError,
+    Gpu, RegPipeline, ShapeColorBuffers,
     buf::{
         ArrayBuffer, BufferSizeError, ImageBuffer, buffer_ro, buffer_rw,
         buffer_uniform,
@@ -26,7 +26,7 @@ use crate::{
     pixel::{PixelBufferTag, RawDistancePixel},
     shaders, tag,
 };
-use fidget_core::{render::ImageSize, shape::ShapeVars, vm::VmShape};
+use fidget_core::{render::ImageSize, shape::ShapeVars};
 use fidget_raster::RgbaImage;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
@@ -335,7 +335,7 @@ impl Context {
         &self,
         merge: &mut MergeBuffers,
         settings: ColorSettings,
-        shape: &ShapeColorBuffers<ColorConfig>,
+        shape: &ShapeColorBuffers,
     ) -> Result<(), ColorError> {
         self.submit_color_with_vars(merge, settings, shape, &Default::default())
     }
@@ -349,7 +349,7 @@ impl Context {
         &self,
         merge: &mut MergeBuffers,
         settings: ColorSettings,
-        shape: &ShapeColorBuffers<ColorConfig>,
+        shape: &ShapeColorBuffers,
         vars: &ShapeVars<f32>,
     ) -> Result<(), ColorError> {
         self.color_ctx
@@ -394,14 +394,6 @@ impl Context {
             has_color: image_in.has_color,
             slice,
         }
-    }
-
-    /// Build a set of buffers for doing shape color evaluation
-    pub fn color_buffers(
-        &self,
-        colors: &[ShapeColor<VmShape>],
-    ) -> Result<ShapeColorBuffers<ColorConfig>, ShapeColorError> {
-        ShapeColorBuffers::new(colors, &self.gpu.device)
     }
 }
 
@@ -503,14 +495,10 @@ impl MappedImage<'_> {
 ////////////////////////////////////////////////////////////////////////////////
 
 /// Configuration for the color evaluation pass
-///
-/// This is public because it's used in a public function signature, but it's
-/// unlikely to be used by library end-users.
 #[derive(Copy, Clone, FromBytes, Immutable, IntoBytes, KnownLayout)]
 #[cfg_attr(test, derive(facet::Facet))]
 #[repr(C)]
-#[doc(hidden)]
-pub struct ColorConfig {
+pub(crate) struct ColorConfig {
     /// Screen-to-model transform matrix (mat3x3)
     mat: [f32; 12],
 
@@ -529,7 +517,7 @@ pub struct ColorConfig {
     only_filled: u32,
 
     // alignment
-    _pad: u32,
+    _pad: [u32; 3],
     // this is followed by a tape_data flexible array member
 }
 
@@ -610,7 +598,7 @@ impl ColorContext {
         &self,
         image: &mut MergeBuffers,
         settings: ColorSettings,
-        shape: &ShapeColorBuffers<ColorConfig>,
+        shape: &ShapeColorBuffers,
         vars: &ShapeVars<f32>,
         gpu: &Gpu,
     ) -> Result<(), ColorError> {
@@ -636,7 +624,7 @@ impl ColorContext {
             axes: shape.axes(),
             image_size: [size.width(), size.height()],
             only_filled: settings.only_filled.into(),
-            _pad: 0,
+            _pad: [0; 3],
             z: settings.z,
         };
         shape.write_config(&config, &gpu.queue);
@@ -710,6 +698,14 @@ mod test {
         crate::test::compare_struct_layout::<ColorConfig>(
             &color_shader(16),
             "Config",
+        );
+    }
+
+    #[test]
+    fn color_config_size() {
+        assert_eq!(
+            std::mem::size_of::<ColorConfig>(),
+            ShapeColorBuffers::expected_config_size(),
         );
     }
 }

--- a/fidget-wgpu/src/pixel/effects/shaders/color.wgsl
+++ b/fidget-wgpu/src/pixel/effects/shaders/color.wgsl
@@ -17,7 +17,7 @@ struct Config {
     only_filled: u32,
 
     // manual alignment
-    _pad: u32,
+    _pad: array<u32, 3>,
 
     /// Tape data, tightly packed per-tile (flexible array member)
     tape_data: array<TapeWord>,

--- a/fidget-wgpu/src/pixel/mod.rs
+++ b/fidget-wgpu/src/pixel/mod.rs
@@ -1680,7 +1680,7 @@ mod test {
                 }
             })
             .collect::<Vec<_>>();
-        let shape_colors = effects_ctx.color_buffers(&shape_colors).unwrap();
+        let shape_colors = gpu.color_buffers(&shape_colors).unwrap();
 
         // Compute per-pixel colors
         effects_ctx

--- a/fidget-wgpu/src/voxel/effects/mod.rs
+++ b/fidget-wgpu/src/voxel/effects/mod.rs
@@ -10,7 +10,7 @@
 //! - Apply shading to a [`PackedVoxel`] buffer, producing an RGBA image buffer
 
 use crate::{
-    Gpu, RegPipeline, ShapeColor, ShapeColorBuffers, ShapeColorError,
+    Gpu, RegPipeline, ShapeColorBuffers,
     buf::{
         BufferSizeError, DepthImageBuffer, ImageBuffer, ImageReadBuffer,
         buffer_ro, buffer_rw, buffer_uniform,
@@ -21,7 +21,6 @@ use crate::{
 use fidget_core::{
     render::VoxelSize,
     shape::{MissingVar, ShapeVars},
-    vm::VmShape,
 };
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
@@ -97,14 +96,10 @@ pub struct PackedVoxel {
 }
 
 /// Configuration for the color evaluation pass
-///
-/// This is public because it's used in a public function signature, but it's
-/// unlikely to be used by library end-users.
 #[derive(Copy, Clone, FromBytes, Immutable, IntoBytes, KnownLayout)]
 #[cfg_attr(test, derive(facet::Facet))]
 #[repr(C)]
-#[doc(hidden)]
-pub struct ColorConfig {
+pub(crate) struct ColorConfig {
     /// Screen-to-model transform matrix
     mat: [f32; 16],
 
@@ -667,14 +662,6 @@ impl Context {
         self.ssao_ctx.submit(image, buf, &self.gpu)
     }
 
-    /// Build a set of buffers for doing shape color evaluation
-    pub fn color_buffers(
-        &self,
-        colors: &[ShapeColor<VmShape>],
-    ) -> Result<ShapeColorBuffers<ColorConfig>, ShapeColorError> {
-        ShapeColorBuffers::new(colors, &self.gpu.device)
-    }
-
     /// Submits a color evaluation pass
     ///
     /// Image size is set from the `MergeBuffers`; the transform matrix is
@@ -684,7 +671,7 @@ impl Context {
         &self,
         merge: &MergeBuffers,
         world_to_model: &nalgebra::Matrix4<f32>,
-        shape: &ShapeColorBuffers<ColorConfig>,
+        shape: &ShapeColorBuffers,
         out: &mut ShadeBuffers,
     ) -> Result<(), ColorError> {
         self.submit_color_with_vars(
@@ -705,7 +692,7 @@ impl Context {
         &self,
         merge: &MergeBuffers,
         world_to_model: &nalgebra::Matrix4<f32>,
-        shape: &ShapeColorBuffers<ColorConfig>,
+        shape: &ShapeColorBuffers,
         vars: &ShapeVars<f32>,
         out: &mut ShadeBuffers,
     ) -> Result<(), ColorError> {
@@ -1112,7 +1099,7 @@ impl ColorContext {
         &self,
         image: &MergeBuffers,
         world_to_model: &nalgebra::Matrix4<f32>,
-        shape: &ShapeColorBuffers<ColorConfig>,
+        shape: &ShapeColorBuffers,
         vars: &ShapeVars<f32>,
         out: &mut ShadeBuffers,
         gpu: &Gpu,
@@ -1341,6 +1328,14 @@ mod test {
         crate::test::compare_struct_layout::<BlurConfig>(
             &blur_shader(),
             "BlurConfig",
+        );
+    }
+
+    #[test]
+    fn color_config_size() {
+        assert_eq!(
+            std::mem::size_of::<ColorConfig>(),
+            ShapeColorBuffers::expected_config_size(),
         );
     }
 }

--- a/fidget-wgpu/src/voxel/mod.rs
+++ b/fidget-wgpu/src/voxel/mod.rs
@@ -2844,7 +2844,7 @@ mod test {
                 }
             })
             .collect::<Vec<_>>();
-        let shape_colors = effects_ctx.color_buffers(&shape_colors).unwrap();
+        let shape_colors = gpu.color_buffers(&shape_colors).unwrap();
 
         // Compute SSAO buffer
         let mut ssao_buf = effects_ctx.ssao_buffers();


### PR DESCRIPTION
It's convenient to construct a single `ShapeColorBuffers` object and use it for both pixel and voxel evaluation; we'll just make sure the config region at the start is large enough for both.