### PR TITLE
Add `RawDistancePixel::distance`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@
 - `VarMap` now implements `Debug`
 - `VarMap::has_free_vars` checks whether there are non-XYZ vars in the map
 - `RawDistancePixel` now implements `zerocopy::IntoBytes`
+- Restored `RawDistancePixel::distance` to get a distance value; it's now a
+  simple `Option<f32>` (not the previous weird `Result<f32, PixelFill>`).
 - `submit*` functions in WebGPU voxel rendering no longer take an optional `out`
   parameter; it's instead passed into `map_image[_async]`.
 

--- a/fidget-raster/src/pixel.rs
+++ b/fidget-raster/src/pixel.rs
@@ -220,6 +220,16 @@ impl RawDistancePixel {
             DistancePixel::Fill { inside, depth }
         }
     }
+
+    /// Returns the distance value if this is a [`DistancePixel::Value`]
+    #[inline]
+    pub fn distance(self) -> Option<f32> {
+        if let DistancePixel::Value(v) = self.unpack() {
+            Some(v)
+        } else {
+            None
+        }
+    }
 }
 
 impl From<DistancePixel> for RawDistancePixel {


### PR DESCRIPTION
This was removed in the transition, but is a reasonably shorthand function (now that we've removed the confusing semantics of `Result<f32, PixelFill>`).