### PR TITLE
Do f32-f64 conversion for Vec2/3 types in Rhai

### DIFF
--- a/fidget-rhai/src/lib.rs
+++ b/fidget-rhai/src/lib.rs
@@ -396,4 +396,32 @@ mod test {
         let expected = std::f32::consts::SQRT_2;
         assert!((result - expected).abs() < 1e-10);
     }
+
+    #[test]
+    fn vec2_types() {
+        crate::engine()
+            .run(
+                r#"
+                let p = vec2(0.4, 0.5);
+                let c = sphere([p.x, p.y, 0.3], 2.0);
+                p.x = 1.2;
+                "#,
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn vec3_types() {
+        crate::engine()
+            .run(
+                r#"
+                let p = vec3(0.4, 0.5, 0.7);
+                let c = sphere(p, 2.0);
+                p.x = 1.2;
+                p.y = 1.2;
+                p.z = 1.2;
+                "#,
+            )
+            .unwrap();
+    }
 }

--- a/fidget-rhai/src/types.rs
+++ b/fidget-rhai/src/types.rs
@@ -94,8 +94,16 @@ fn register_vec2(engine: &mut rhai::Engine) {
                 vec2_from_rhai_array(&ctx, array)
             },
         )
-        .register_get_set("x", |v: &mut Vec2| v.x, |v: &mut Vec2, x| v.x = x)
-        .register_get_set("y", |v: &mut Vec2| v.y, |v: &mut Vec2, y| v.y = y);
+        .register_get_set(
+            "x",
+            |v: &mut Vec2| v.x as f64,
+            |v: &mut Vec2, x: f64| v.x = x as f32,
+        )
+        .register_get_set(
+            "y",
+            |v: &mut Vec2| v.y as f64,
+            |v: &mut Vec2, y: f64| v.y = y as f32,
+        );
 }
 
 fn register_vec3(engine: &mut rhai::Engine) {
@@ -126,9 +134,21 @@ fn register_vec3(engine: &mut rhai::Engine) {
                 vec3_from_rhai_array(&ctx, array, None)
             },
         )
-        .register_get_set("x", |v: &mut Vec3| v.x, |v: &mut Vec3, x| v.x = x)
-        .register_get_set("y", |v: &mut Vec3| v.y, |v: &mut Vec3, y| v.y = y)
-        .register_get_set("z", |v: &mut Vec3| v.z, |v: &mut Vec3, z| v.z = z);
+        .register_get_set(
+            "x",
+            |v: &mut Vec3| v.x as f64,
+            |v: &mut Vec3, x: f64| v.x = x as f32,
+        )
+        .register_get_set(
+            "y",
+            |v: &mut Vec3| v.y as f64,
+            |v: &mut Vec3, y: f64| v.y = y as f32,
+        )
+        .register_get_set(
+            "z",
+            |v: &mut Vec3| v.z as f64,
+            |v: &mut Vec3, z: f64| v.z = z as f32,
+        );
 }
 
 impl FromDynamic for Vec2 {


### PR DESCRIPTION
#459 accidentally regressed Rhai's handling of `Vec2` and `Vec3`.  Rhai floating-point types are `f64` internally; the change to `Vec2` and `Vec3` added `f32` runtime types, which weren't handled well (they are not automatically converted).  This PR adds edge conversions (`f32` inside the `VecX`, `f64` inside Rhai).