### PR TITLE
Tweaks to WebGPU buffer APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
   simple `Option<f32>` (not the previous weird `Result<f32, PixelFill>`).
 - `submit*` functions in WebGPU voxel rendering no longer take an optional `out`
   parameter; it's instead passed into `map_image[_async]`.
+- More reorganization of `fidget::wgpu` buffer APIs
 
 # 0.5.0
 This is a large release with a bunch of small features, reorganization, and one

--- a/demos/cli/src/main.rs
+++ b/demos/cli/src/main.rs
@@ -447,8 +447,8 @@ fn run3d_wgpu(
                 &merge_buf,
                 if ssao { Some(&ssao_buf) } else { None },
                 &mut shade_buf,
-                Some(&mut out_buf),
             )?;
+            gpu.copy(shade_buf.output(), &mut out_buf);
             let out = gpu.map(&mut out_buf);
             out.image().as_bytes().to_vec()
         }

--- a/demos/web-editor/crate/Cargo.lock
+++ b/demos/web-editor/crate/Cargo.lock
@@ -734,6 +734,7 @@ dependencies = [
  "log",
  "naga",
  "nalgebra",
+ "pollster",
  "static_assertions",
  "thiserror",
  "wgpu",
@@ -1492,6 +1493,12 @@ dependencies = [
  "flate2",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
 name = "portable-atomic"

--- a/fidget-bytecode/rustc-ice-2026-09-07T22_47_58-88619.txt
+++ b/fidget-bytecode/rustc-ice-2026-09-07T22_47_58-88619.txt
@@ -1,0 +1,39 @@
+thread 'rustc' panicked at /rustc-dev/f5eca4fcfa908d1e038afd19c6e746f075859130/compiler/rustc_middle/src/query/on_disk_cache.rs:663:9:
+cannot decode `AttrId` with `CacheDecoder`
+stack backtrace:
+   0:        0x111f8a214 - <std[b9b2ea19604012fc]::backtrace::Backtrace>::create
+   1:        0x10fe08538 - std[b9b2ea19604012fc]::panicking::update_hook::<alloc[2936732e9dff64f9]::boxed::Box<rustc_driver_impl[af5d728f7692f4f1]::install_ice_hook::{closure#1}>>::{closure#0}
+   2:        0x111f9b864 - std[b9b2ea19604012fc]::panicking::panic_with_hook
+   3:        0x111f7f7e8 - std[b9b2ea19604012fc]::panicking::panic_handler::{closure#0}
+   4:        0x111f76160 - std[b9b2ea19604012fc]::sys::backtrace::__rust_end_short_backtrace::<std[b9b2ea19604012fc]::panicking::panic_handler::{closure#0}, !>
+   5:        0x111f80d8c - __rustc[af02054c5d8a4591]::rust_begin_unwind
+   6:        0x114fbc20c - core[e51672913656d187]::panicking::panic_fmt
+   7:        0x110b90428 - <rustc_middle[ea55ef0647322b56]::query::on_disk_cache::OnDiskCache>::load_side_effect
+   8:        0x1117067fc - <rustc_query_impl[74f8fd548954c2e1]::dep_kind_vtables::non_query::SideEffect::{closure#0} as core[e51672913656d187]::ops::function::FnOnce<(rustc_middle[ea55ef0647322b56]::ty::context::TyCtxt, rustc_middle[ea55ef0647322b56]::dep_graph::dep_node::DepNode, rustc_middle[ea55ef0647322b56]::dep_graph::serialized::SerializedDepNodeIndex)>>::call_once
+   9:        0x110bbe3c0 - <rustc_middle[ea55ef0647322b56]::dep_graph::graph::DepGraphData>::try_mark_previous_green
+  10:        0x110bbe234 - <rustc_middle[ea55ef0647322b56]::dep_graph::graph::DepGraphData>::try_mark_green
+  11:        0x11149b87c - rustc_query_impl[74f8fd548954c2e1]::execution::ensure_can_skip_execution::<rustc_middle[ea55ef0647322b56]::query::caches::DefaultCache<rustc_span[91418ac2216fffb7]::def_id::LocalModDefId, rustc_middle[ea55ef0647322b56]::query::erase::ErasedData<[u8; 0usize]>>>
+  12:        0x1115d1318 - rustc_query_impl[74f8fd548954c2e1]::query_impl::lint_mod::execute_query_incr::__rust_end_short_backtrace
+  13:        0x1108aed30 - rustc_lint[4d80144d49fc24a8]::late::check_crate::{closure#1}
+  14:        0x110904104 - rustc_lint[4d80144d49fc24a8]::late::check_crate
+  15:        0x11072a994 - rustc_interface[e1e3761b472e4558]::passes::analysis::{closure#0}::{closure#0}::{closure#2}
+  16:        0x10fdab000 - rustc_data_structures[2b2a31026d8abb23]::sync::parallel::par_fns
+  17:        0x11072cf8c - rustc_interface[e1e3761b472e4558]::passes::analysis::{closure#0}::{closure#0}
+  18:        0x10fdab000 - rustc_data_structures[2b2a31026d8abb23]::sync::parallel::par_fns
+  19:        0x1107663fc - rustc_interface[e1e3761b472e4558]::passes::analysis
+  20:        0x111419334 - rustc_query_impl[74f8fd548954c2e1]::execution::try_execute_query::<rustc_middle[ea55ef0647322b56]::query::caches::SingleCache<rustc_middle[ea55ef0647322b56]::query::erase::ErasedData<[u8; 0usize]>>, true>
+  21:        0x1115d085c - rustc_query_impl[74f8fd548954c2e1]::query_impl::analysis::execute_query_incr::__rust_end_short_backtrace
+  22:        0x10fdfc1f4 - rustc_interface[e1e3761b472e4558]::passes::create_and_enter_global_ctxt::<core[e51672913656d187]::option::Option<rustc_interface[e1e3761b472e4558]::queries::Linker>, rustc_driver_impl[af5d728f7692f4f1]::run_compiler::{closure#0}::{closure#2}>
+  23:        0x10fe0b830 - rustc_interface[e1e3761b472e4558]::interface::run_compiler::<(), rustc_driver_impl[af5d728f7692f4f1]::run_compiler::{closure#0}>::{closure#1}
+  24:        0x10fe009b0 - std[b9b2ea19604012fc]::sys::backtrace::__rust_begin_short_backtrace::<rustc_interface[e1e3761b472e4558]::util::run_in_thread_with_globals<rustc_interface[e1e3761b472e4558]::util::run_in_thread_pool_with_globals<rustc_interface[e1e3761b472e4558]::interface::run_compiler<(), rustc_driver_impl[af5d728f7692f4f1]::run_compiler::{closure#0}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>
+  25:        0x10fe1162c - <std[b9b2ea19604012fc]::thread::lifecycle::spawn_unchecked<rustc_interface[e1e3761b472e4558]::util::run_in_thread_with_globals<rustc_interface[e1e3761b472e4558]::util::run_in_thread_pool_with_globals<rustc_interface[e1e3761b472e4558]::interface::run_compiler<(), rustc_driver_impl[af5d728f7692f4f1]::run_compiler::{closure#0}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>::{closure#1} as core[e51672913656d187]::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
+  26:        0x111fa60a8 - <std[b9b2ea19604012fc]::sys::thread::unix::Thread>::new::thread_start
+  27:        0x1878d9c58 - __pthread_cond_wait
+
+
+rustc version: 1.96.0-nightly (f5eca4fcf 2026-04-09)
+platform: aarch64-apple-darwin
+
+query stack during panic:
+#0 [analysis] running analysis passes on crate `fidget_bytecode`
+end of query stack

--- a/fidget-bytecode/rustc-ice-2026-09-07T22_48_02-88812.txt
+++ b/fidget-bytecode/rustc-ice-2026-09-07T22_48_02-88812.txt
@@ -1,0 +1,39 @@
+thread 'rustc' panicked at /rustc-dev/f5eca4fcfa908d1e038afd19c6e746f075859130/compiler/rustc_middle/src/query/on_disk_cache.rs:663:9:
+cannot decode `AttrId` with `CacheDecoder`
+stack backtrace:
+   0:        0x10fb82214 - <std[b9b2ea19604012fc]::backtrace::Backtrace>::create
+   1:        0x10da00538 - std[b9b2ea19604012fc]::panicking::update_hook::<alloc[2936732e9dff64f9]::boxed::Box<rustc_driver_impl[af5d728f7692f4f1]::install_ice_hook::{closure#1}>>::{closure#0}
+   2:        0x10fb93864 - std[b9b2ea19604012fc]::panicking::panic_with_hook
+   3:        0x10fb777e8 - std[b9b2ea19604012fc]::panicking::panic_handler::{closure#0}
+   4:        0x10fb6e160 - std[b9b2ea19604012fc]::sys::backtrace::__rust_end_short_backtrace::<std[b9b2ea19604012fc]::panicking::panic_handler::{closure#0}, !>
+   5:        0x10fb78d8c - __rustc[af02054c5d8a4591]::rust_begin_unwind
+   6:        0x112bb420c - core[e51672913656d187]::panicking::panic_fmt
+   7:        0x10e788428 - <rustc_middle[ea55ef0647322b56]::query::on_disk_cache::OnDiskCache>::load_side_effect
+   8:        0x10f2fe7fc - <rustc_query_impl[74f8fd548954c2e1]::dep_kind_vtables::non_query::SideEffect::{closure#0} as core[e51672913656d187]::ops::function::FnOnce<(rustc_middle[ea55ef0647322b56]::ty::context::TyCtxt, rustc_middle[ea55ef0647322b56]::dep_graph::dep_node::DepNode, rustc_middle[ea55ef0647322b56]::dep_graph::serialized::SerializedDepNodeIndex)>>::call_once
+   9:        0x10e7b63c0 - <rustc_middle[ea55ef0647322b56]::dep_graph::graph::DepGraphData>::try_mark_previous_green
+  10:        0x10e7b6234 - <rustc_middle[ea55ef0647322b56]::dep_graph::graph::DepGraphData>::try_mark_green
+  11:        0x10f09387c - rustc_query_impl[74f8fd548954c2e1]::execution::ensure_can_skip_execution::<rustc_middle[ea55ef0647322b56]::query::caches::DefaultCache<rustc_span[91418ac2216fffb7]::def_id::LocalModDefId, rustc_middle[ea55ef0647322b56]::query::erase::ErasedData<[u8; 0usize]>>>
+  12:        0x10f1c9318 - rustc_query_impl[74f8fd548954c2e1]::query_impl::lint_mod::execute_query_incr::__rust_end_short_backtrace
+  13:        0x10e4a6d30 - rustc_lint[4d80144d49fc24a8]::late::check_crate::{closure#1}
+  14:        0x10e4fc104 - rustc_lint[4d80144d49fc24a8]::late::check_crate
+  15:        0x10e322994 - rustc_interface[e1e3761b472e4558]::passes::analysis::{closure#0}::{closure#0}::{closure#2}
+  16:        0x10d9a3000 - rustc_data_structures[2b2a31026d8abb23]::sync::parallel::par_fns
+  17:        0x10e324f8c - rustc_interface[e1e3761b472e4558]::passes::analysis::{closure#0}::{closure#0}
+  18:        0x10d9a3000 - rustc_data_structures[2b2a31026d8abb23]::sync::parallel::par_fns
+  19:        0x10e35e3fc - rustc_interface[e1e3761b472e4558]::passes::analysis
+  20:        0x10f011334 - rustc_query_impl[74f8fd548954c2e1]::execution::try_execute_query::<rustc_middle[ea55ef0647322b56]::query::caches::SingleCache<rustc_middle[ea55ef0647322b56]::query::erase::ErasedData<[u8; 0usize]>>, true>
+  21:        0x10f1c885c - rustc_query_impl[74f8fd548954c2e1]::query_impl::analysis::execute_query_incr::__rust_end_short_backtrace
+  22:        0x10d9f41f4 - rustc_interface[e1e3761b472e4558]::passes::create_and_enter_global_ctxt::<core[e51672913656d187]::option::Option<rustc_interface[e1e3761b472e4558]::queries::Linker>, rustc_driver_impl[af5d728f7692f4f1]::run_compiler::{closure#0}::{closure#2}>
+  23:        0x10da03830 - rustc_interface[e1e3761b472e4558]::interface::run_compiler::<(), rustc_driver_impl[af5d728f7692f4f1]::run_compiler::{closure#0}>::{closure#1}
+  24:        0x10d9f89b0 - std[b9b2ea19604012fc]::sys::backtrace::__rust_begin_short_backtrace::<rustc_interface[e1e3761b472e4558]::util::run_in_thread_with_globals<rustc_interface[e1e3761b472e4558]::util::run_in_thread_pool_with_globals<rustc_interface[e1e3761b472e4558]::interface::run_compiler<(), rustc_driver_impl[af5d728f7692f4f1]::run_compiler::{closure#0}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>
+  25:        0x10da0962c - <std[b9b2ea19604012fc]::thread::lifecycle::spawn_unchecked<rustc_interface[e1e3761b472e4558]::util::run_in_thread_with_globals<rustc_interface[e1e3761b472e4558]::util::run_in_thread_pool_with_globals<rustc_interface[e1e3761b472e4558]::interface::run_compiler<(), rustc_driver_impl[af5d728f7692f4f1]::run_compiler::{closure#0}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>::{closure#1} as core[e51672913656d187]::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
+  26:        0x10fb9e0a8 - <std[b9b2ea19604012fc]::sys::thread::unix::Thread>::new::thread_start
+  27:        0x1878d9c58 - __pthread_cond_wait
+
+
+rustc version: 1.96.0-nightly (f5eca4fcf 2026-04-09)
+platform: aarch64-apple-darwin
+
+query stack during panic:
+#0 [analysis] running analysis passes on crate `fidget_bytecode`
+end of query stack

--- a/fidget-wgpu/Cargo.toml
+++ b/fidget-wgpu/Cargo.toml
@@ -21,11 +21,11 @@ heck.workspace = true
 log.workspace = true
 naga.workspace = true
 nalgebra.workspace = true
+pollster.workspace = true
 static_assertions.workspace = true
 thiserror.workspace = true
 wgpu.workspace = true
 zerocopy.workspace = true
 
 [dev-dependencies]
-pollster.workspace = true
 facet.workspace = true

--- a/fidget-wgpu/src/buf.rs
+++ b/fidget-wgpu/src/buf.rs
@@ -3,6 +3,7 @@
 //! This module is mostly internal to the crate, but is public because its types
 //! appear as return values and arguments.
 use fidget_core::render::{ImageSize, VoxelSize};
+use fidget_raster::RenderSize;
 use zerocopy::FromBytes;
 
 /// Handle around a growable GPU buffer
@@ -227,35 +228,44 @@ impl<T: BufferTag, B: BufferItemCount + Copy> GenericFlexBuffer<T, B> {
 
 /// Buffer for reading data back from the GPU
 ///
-/// Once mapped, this is wrapped by a [`MappedImage`]
-pub type ImageReadBuffer<T> = ImageBuffer<MappedBufferTag<T>>;
+/// Once mapped, this can be wrapped by a [`MappedImage`] (if the `S` parameter
+/// is an image size).
+pub type ReadBuffer<T, S> = GenericFlexBuffer<MappedBufferTag<T>, S>;
 
-/// Handle to a mapped [`ImageReadBuffer`], which unmaps the image when dropped
-pub struct MappedImage<'a, T: BufferTag> {
-    buf: &'a ImageReadBuffer<T>,
+/// Handle to a mapped [`ReadBuffer`] containing an image
+///
+/// The buffer is automatically unmapped when this handle is dropped
+pub struct MappedImage<'a, T: BufferTag, S: BufferItemCount + RenderSize + Copy>
+{
+    buf: &'a ReadBuffer<T, S>,
     slice: wgpu::BufferSlice<'a>,
 }
 
-impl<T: BufferTag> Drop for MappedImage<'_, T> {
+impl<T: BufferTag, S: BufferItemCount + RenderSize + Copy> Drop
+    for MappedImage<'_, T, S>
+{
     fn drop(&mut self) {
         self.buf.data().unmap();
     }
 }
 
-impl<'a, T: BufferTag> MappedImage<'a, T> {
-    /// Blocking function to build a new mapped image
-    pub fn map(
-        device: &wgpu::Device,
-        image: &'a mut ImageReadBuffer<T>,
+impl<'a, T, S> MappedImage<'a, T, S>
+where
+    T: BufferTag,
+    T::T: zerocopy::FromBytes + zerocopy::Immutable + Copy,
+    S: BufferItemCount + RenderSize + Copy,
+{
+    /// Basic constructor
+    pub(crate) fn new(
+        buf: &'a ReadBuffer<T, S>,
+        slice: wgpu::BufferSlice<'a>,
     ) -> Self {
-        let slice = image.map_async(|_| {});
-        device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
-        MappedImage { buf: image, slice }
+        Self { buf, slice }
     }
 
     /// Returns the image's data
-    pub fn image(&self) -> fidget_raster::Image<u32, ImageSize> {
-        let result = <[u32]>::ref_from_bytes(&self.slice.get_mapped_range())
+    pub fn image(&self) -> fidget_raster::Image<T::T, S> {
+        let result = <[T::T]>::ref_from_bytes(&self.slice.get_mapped_range())
             .unwrap()
             .to_owned();
         fidget_raster::Image::build(result, self.buf.size()).unwrap()

--- a/fidget-wgpu/src/lib.rs
+++ b/fidget-wgpu/src/lib.rs
@@ -8,6 +8,7 @@ use fidget_core::{
     var::{Var, VarMap},
     vm::VmShape,
 };
+use fidget_raster::RenderSize;
 
 use heck::ToShoutySnakeCase;
 use std::collections::{BTreeMap, HashMap};
@@ -120,27 +121,20 @@ impl Gpu {
     }
 
     /// Returns a readable buffer for the given image buffer
-    pub fn read_buffer_for<
-        T: buf::BufferTag,
-        B: buf::BufferItemCount + Copy + Into<fidget_core::render::ImageSize>,
-    >(
+    pub fn read_buffer_for<T, B>(
         &self,
         buf: &buf::GenericFlexBuffer<T, B>,
-    ) -> buf::ImageReadBuffer<T> {
-        buf::ImageBuffer::new(
+    ) -> buf::ReadBuffer<T, B>
+    where
+        T: buf::BufferTag,
+        B: buf::BufferItemCount + Copy,
+    {
+        buf::ReadBuffer::new(
             &self.device,
             format!("{} (read)", buf.name()),
-            buf.size().into(),
+            buf.size(),
         )
-        .expect("buf.size should always be a valid size for ImageBuffer::new")
-    }
-
-    /// Maps a readable image buffer, returning a mapped image
-    pub fn map<'a, T: buf::BufferTag>(
-        &self,
-        buf: &'a mut buf::ImageReadBuffer<T>,
-    ) -> buf::MappedImage<'a, T> {
-        buf::MappedImage::map(&self.device, buf)
+        .expect("buf.size should always be a valid size for ReadBuffer::new")
     }
 
     /// Debug function to read from a buffer to a `Vec<T>`
@@ -189,6 +183,87 @@ impl Gpu {
         colors: &[ShapeColor<VmShape>],
     ) -> Result<ShapeColorBuffers, ShapeColorError> {
         ShapeColorBuffers::new(colors, &self.device)
+    }
+
+    /// Copies from a GPU-resident buffer to a host-mappable buffer
+    ///
+    /// The host-mappable destination buffer is resized to fit the data.
+    pub fn copy<A, S>(
+        &self,
+        src: &buf::GenericFlexBuffer<A, S>,
+        dst: &mut buf::ReadBuffer<A, S>,
+    ) where
+        A: buf::BufferTag,
+        S: buf::BufferItemCount + Copy,
+    {
+        let mut encoder = self.device.create_command_encoder(
+            &wgpu::CommandEncoderDescriptor {
+                label: Some("read_buffer"),
+            },
+        );
+        self.encode_copy(src, dst, &mut encoder);
+        self.queue.submit(Some(encoder.finish()));
+    }
+
+    /// Low-level command to submit a buffer copy to a command encoder
+    ///
+    /// See [`copy`](Self::copy) for details
+    pub fn encode_copy<A, S>(
+        &self,
+        src: &buf::GenericFlexBuffer<A, S>,
+        dst: &mut buf::ReadBuffer<A, S>,
+        encoder: &mut wgpu::CommandEncoder,
+    ) where
+        A: buf::BufferTag,
+        S: buf::BufferItemCount + Copy,
+    {
+        dst.grow_to_fit(&self.device, src.size())
+            .expect("dst buffer should be resizable to match src buffer");
+        encoder.copy_buffer_to_buffer(
+            src.data(),
+            0,
+            dst.data(),
+            0,
+            src.size_bytes(),
+        );
+    }
+
+    /// Blocking function to build a new mapped image
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn map<'a, T, S>(
+        &self,
+        image: &'a mut buf::ReadBuffer<T, S>,
+    ) -> buf::MappedImage<'a, T, S>
+    where
+        T: buf::BufferTag,
+        T::T: Immutable + FromBytes + Copy,
+        S: buf::BufferItemCount + RenderSize + Copy,
+    {
+        pollster::block_on(self.map_async(image))
+    }
+
+    /// Async function to build a new mapped image
+    ///
+    /// This can be called on either native or web platforms.  On native
+    /// platforms, the single `await` is trivial (guaranteed to always be
+    /// ready); on the web, the mapping sends us back to the event loop until
+    /// it's ready.
+    pub async fn map_async<'a, T, S>(
+        &self,
+        image: &'a mut buf::ReadBuffer<T, S>,
+    ) -> buf::MappedImage<'a, T, S>
+    where
+        T: buf::BufferTag,
+        T::T: Immutable + FromBytes + Copy,
+        S: buf::BufferItemCount + RenderSize + Copy,
+    {
+        let (tx, rx) = flume::bounded(1);
+        let slice = image.map_async(move |_| tx.send(()).unwrap());
+        self.device
+            .poll(wgpu::PollType::wait_indefinitely())
+            .unwrap();
+        rx.recv_async().await.unwrap();
+        buf::MappedImage::new(image, slice)
     }
 }
 

--- a/fidget-wgpu/src/voxel/effects/mod.rs
+++ b/fidget-wgpu/src/voxel/effects/mod.rs
@@ -12,8 +12,8 @@
 use crate::{
     Gpu, RegPipeline, ShapeColorBuffers,
     buf::{
-        BufferSizeError, DepthImageBuffer, ImageBuffer, ImageReadBuffer,
-        buffer_ro, buffer_rw, buffer_uniform,
+        BufferSizeError, DepthImageBuffer, ImageBuffer, buffer_ro, buffer_rw,
+        buffer_uniform,
     },
     shaders, tag,
     voxel::GeomBufferTag,
@@ -546,7 +546,6 @@ impl Context {
         image: &MergeBuffers,
         ssao: Option<&SsaoBuffers>,
         buf: &mut ShadeBuffers,
-        out: Option<&mut ImageReadBuffer<ShadedImageTag>>,
     ) -> Result<(), ShadeError> {
         let size = image.out.size();
         if buf.has_color {
@@ -634,21 +633,6 @@ impl Context {
             );
         }
         buf.has_color = false;
-        if let Some(image) = out {
-            image
-                .grow_to_fit(&self.gpu.device, buf.out.size().into())
-                .expect(
-                    "buf.out.size should always be \
-                     a valid size for grow_to_fit",
-                );
-            encoder.copy_buffer_to_buffer(
-                buf.out.data(),
-                0,
-                image.data(),
-                0,
-                buf.out.size_bytes(),
-            );
-        }
         self.gpu.queue.submit(Some(encoder.finish()));
         Ok(())
     }

--- a/fidget-wgpu/src/voxel/mod.rs
+++ b/fidget-wgpu/src/voxel/mod.rs
@@ -2933,7 +2933,7 @@ mod test {
             out.colors.len()
         );
 
-        let (_out, img_size) = out.shaded.take();
+        let (shaded, img_size) = out.shaded.take();
         assert_eq!(img_size.width(), size);
         assert_eq!(img_size.height(), size);
 
@@ -2943,6 +2943,15 @@ mod test {
                 assert_eq!(c.a, 0);
             } else {
                 assert_eq!(c.a, 0xFF);
+            }
+        }
+        for (m, c) in out.merged.iter().zip(shaded.iter()) {
+            let p = m.z;
+            if p == 0 {
+                assert_eq!(*c, 0);
+            } else {
+                // Check that the alpha channel is fully opaque
+                assert_eq!(c & (0xFF << 24), (0xFF << 24));
             }
         }
     }

--- a/fidget-wgpu/src/voxel/mod.rs
+++ b/fidget-wgpu/src/voxel/mod.rs
@@ -2809,7 +2809,7 @@ mod test {
     struct RenderOutput {
         merged: Vec<PackedVoxel>,
         colors: Vec<Rgba>,
-        shaded: fidget_raster::Image<u32, ImageSize>,
+        shaded: fidget_raster::Image<u32, VoxelSize>,
     }
 
     fn render(
@@ -2867,13 +2867,9 @@ mod test {
         // Compute shaded image (with color, overwriting shade_buf)
         let mut shade_out = gpu.read_buffer_for(shade_buf.output());
         effects_ctx
-            .submit_shade(
-                &merge_buf,
-                Some(&ssao_buf),
-                &mut shade_buf,
-                Some(&mut shade_out),
-            )
+            .submit_shade(&merge_buf, Some(&ssao_buf), &mut shade_buf)
             .unwrap();
+        gpu.copy(shade_buf.output(), &mut shade_out);
 
         let img = gpu.map(&mut shade_out);
         let shaded = img.image();


### PR DESCRIPTION
- Remove output buffer from `fidget_wgpu::voxel::effects::submit_shade`
- Replace `ImageReadBuffer` with a more generic `ReadBuffer`