### PR TITLE
Move item count to tag

### DIFF
--- a/fidget-wgpu/src/buf.rs
+++ b/fidget-wgpu/src/buf.rs
@@ -10,9 +10,9 @@ use zerocopy::FromBytes;
 ///
 /// The buffer keeps track of both its current size and capacity (which may be
 /// larger).  It is used to prevent GPU buffer allocation churn.
-pub struct GenericFlexBuffer<T, B> {
+pub struct FlexBuffer<T: BufferTag> {
     /// Current size, which may be smaller than the buffer's capacity
-    size: B,
+    size: T::S,
     /// Actual GPU buffer
     data: wgpu::Buffer,
     /// Buffer label (to be used when reallocating)
@@ -21,25 +21,18 @@ pub struct GenericFlexBuffer<T, B> {
     _t: std::marker::PhantomData<T>,
 }
 
-/// Resizable array buffer
-pub type ArrayBuffer<T> = GenericFlexBuffer<T, usize>;
-
-/// Resizable image buffer
-pub type ImageBuffer<T> = GenericFlexBuffer<T, ImageSize>;
-
-/// Resizable image buffer
-pub type DepthImageBuffer<T> = GenericFlexBuffer<T, VoxelSize>;
-
-/// Tag associated with a particular [`GenericFlexBuffer`]
+/// Tag associated with a particular [`FlexBuffer`]
 ///
 /// The tag type serves two purposes:
 ///
-/// - It declares the storage type and usage bits for the buffer
+/// - It declares the storage type, usage bits, and size type for the buffer
 /// - It makes buffers strongly typed, so that two buffers with equivalent
 ///   storage and usage bits can be distinct types.
 pub trait BufferTag {
     /// Data type stored in the buffer
     type T;
+    /// Size type
+    type S: BufferItemCount + Copy;
     /// Usage bits for the buffer
     ///
     /// This must be a union of [`wgpu::BufferUsages`] values
@@ -52,6 +45,7 @@ pub struct MappedBufferTag<T: BufferTag> {
 }
 impl<T: BufferTag> BufferTag for MappedBufferTag<T> {
     type T = T::T;
+    type S = T::S;
     fn usage() -> u32 {
         wgpu::BufferUsages::COPY_DST.bits()
             | wgpu::BufferUsages::MAP_READ.bits()
@@ -61,11 +55,12 @@ impl<T: BufferTag> BufferTag for MappedBufferTag<T> {
 /// Helper macro to declare a buffer tag
 #[macro_export]
 macro_rules! tag {
-    ($vis:vis $name:ident,  $t:ty, $($flag:ident)|+ $(,$doc:expr)?) => {
+    ($vis:vis $name:ident, $t:ty, $s:ty, $($flag:ident)|+ $(,$doc:expr)?) => {
         $(#[doc = $doc])?
         $vis struct $name;
         impl $crate::buf::BufferTag for $name {
             type T = $t;
+            type S = $s;
             fn usage() -> u32 {
                 $( wgpu::BufferUsages::$flag.bits() )|+
             }
@@ -100,11 +95,11 @@ impl BufferItemCount for VoxelSize {
     }
 }
 
-impl<T: BufferTag, B: BufferItemCount + Copy> GenericFlexBuffer<T, B> {
+impl<T: BufferTag> FlexBuffer<T> {
     pub(crate) fn new(
         device: &wgpu::Device,
         name: String,
-        size: B,
+        size: T::S,
     ) -> Result<Self, BufferSizeError> {
         Self::check_size(size)?;
         let size_bytes = Self::calculate_buffer_size(size);
@@ -126,7 +121,7 @@ impl<T: BufferTag, B: BufferItemCount + Copy> GenericFlexBuffer<T, B> {
     /// Calculate size from buffer item count
     ///
     /// Size is rounded up to the nearest multiple of 4 for alignment
-    pub fn calculate_buffer_size(item_count: B) -> u64 {
+    pub fn calculate_buffer_size(item_count: T::S) -> u64 {
         let out = u64::try_from(item_count.item_count())
             .unwrap()
             .checked_mul(u64::try_from(std::mem::size_of::<T::T>()).unwrap())
@@ -142,7 +137,7 @@ impl<T: BufferTag, B: BufferItemCount + Copy> GenericFlexBuffer<T, B> {
         Self::calculate_buffer_size(self.size)
     }
 
-    pub(crate) fn check_size(size: B) -> Result<(), BufferSizeError> {
+    pub(crate) fn check_size(size: T::S) -> Result<(), BufferSizeError> {
         let size = Self::calculate_buffer_size(size);
         let usage = wgpu::BufferUsages::from_bits(T::usage()).unwrap();
 
@@ -165,7 +160,7 @@ impl<T: BufferTag, B: BufferItemCount + Copy> GenericFlexBuffer<T, B> {
     pub(crate) fn grow_to_fit(
         &mut self,
         device: &wgpu::Device,
-        size: B,
+        size: T::S,
     ) -> Result<(), BufferSizeError> {
         Self::check_size(size)?;
         let new_size = Self::calculate_buffer_size(size);
@@ -224,40 +219,39 @@ impl<T: BufferTag, B: BufferItemCount + Copy> GenericFlexBuffer<T, B> {
     }
 
     /// Returns the size of the buffer (which is generic)
-    pub fn size(&self) -> B {
+    pub fn size(&self) -> T::S {
         self.size
     }
 }
 
 /// Buffer for reading data back from the GPU
 ///
-/// Once mapped, this can be wrapped by a [`MappedImage`] (if the `S` parameter
-/// is an image size).
-pub type ReadBuffer<T, S> = GenericFlexBuffer<MappedBufferTag<T>, S>;
+/// Once mapped, this can be wrapped by a [`MappedImage`] (if the tag's size
+/// parameter is an image size).
+pub type ReadBuffer<T> = FlexBuffer<MappedBufferTag<T>>;
 
 /// Handle to a mapped [`ReadBuffer`]
 ///
 /// The buffer is automatically unmapped when this handle is dropped
-pub struct MappedBuffer<'a, T: BufferTag, S: BufferItemCount + Copy> {
-    buf: &'a ReadBuffer<T, S>,
+pub struct MappedBuffer<'a, T: BufferTag> {
+    buf: &'a ReadBuffer<T>,
     slice: wgpu::BufferSlice<'a>,
 }
 
-impl<T: BufferTag, S: BufferItemCount + Copy> Drop for MappedBuffer<'_, T, S> {
+impl<T: BufferTag> Drop for MappedBuffer<'_, T> {
     fn drop(&mut self) {
         self.buf.data().unmap();
     }
 }
 
-impl<'a, T, S> MappedBuffer<'a, T, S>
+impl<'a, T> MappedBuffer<'a, T>
 where
     T: BufferTag,
     T::T: zerocopy::FromBytes + zerocopy::Immutable + Copy,
-    S: BufferItemCount + Copy,
 {
     /// Basic constructor
     pub(crate) fn new(
-        buf: &'a ReadBuffer<T, S>,
+        buf: &'a ReadBuffer<T>,
         slice: wgpu::BufferSlice<'a>,
     ) -> Self {
         Self { buf, slice }
@@ -276,29 +270,28 @@ where
 /// Handle to a mapped [`ReadBuffer`] containing an image
 ///
 /// The buffer is automatically unmapped when this handle is dropped
-pub struct MappedImage<'a, T: BufferTag, S: BufferItemCount + RenderSize + Copy>(
-    MappedBuffer<'a, T, S>,
-);
+pub struct MappedImage<'a, T: BufferTag>(MappedBuffer<'a, T>)
+where
+    T::S: RenderSize;
 
-impl<'a, T, S> From<MappedBuffer<'a, T, S>> for MappedImage<'a, T, S>
+impl<'a, T> From<MappedBuffer<'a, T>> for MappedImage<'a, T>
 where
     T: BufferTag,
-    T::T: Copy,
-    S: BufferItemCount + RenderSize + Copy,
+    T::S: RenderSize,
 {
-    fn from(value: MappedBuffer<'a, T, S>) -> Self {
+    fn from(value: MappedBuffer<'a, T>) -> Self {
         Self(value)
     }
 }
 
-impl<'a, T, S> MappedImage<'a, T, S>
+impl<'a, T> MappedImage<'a, T>
 where
     T: BufferTag,
     T::T: zerocopy::FromBytes + zerocopy::Immutable + Copy,
-    S: BufferItemCount + RenderSize + Copy,
+    T::S: RenderSize,
 {
     /// Returns the image's data
-    pub fn image(&self) -> fidget_raster::Image<T::T, S> {
+    pub fn image(&self) -> fidget_raster::Image<T::T, T::S> {
         fidget_raster::Image::build(self.0.to_vec(), self.0.buf.size()).unwrap()
     }
 }

--- a/fidget-wgpu/src/lib.rs
+++ b/fidget-wgpu/src/lib.rs
@@ -120,14 +120,16 @@ impl Gpu {
         Ok(Gpu { device, queue })
     }
 
-    /// Returns a readable buffer for the given image buffer
-    pub fn read_buffer_for<T, B>(
+    /// Returns a readable buffer for the given buffer
+    ///
+    /// See [`copy`](Self::copy) and [`map`](Self::map) for how to use the
+    /// resulting read buffer.
+    pub fn read_buffer_for<T>(
         &self,
-        buf: &buf::GenericFlexBuffer<T, B>,
-    ) -> buf::ReadBuffer<T, B>
+        buf: &buf::FlexBuffer<T>,
+    ) -> buf::ReadBuffer<T>
     where
         T: buf::BufferTag,
-        B: buf::BufferItemCount + Copy,
     {
         buf::ReadBuffer::new(
             &self.device,
@@ -188,13 +190,12 @@ impl Gpu {
     /// Copies from a GPU-resident buffer to a host-mappable buffer
     ///
     /// The host-mappable destination buffer is resized to fit the data.
-    pub fn copy<A, S>(
+    pub fn copy<A>(
         &self,
-        src: &buf::GenericFlexBuffer<A, S>,
-        dst: &mut buf::ReadBuffer<A, S>,
+        src: &buf::FlexBuffer<A>,
+        dst: &mut buf::ReadBuffer<A>,
     ) where
         A: buf::BufferTag,
-        S: buf::BufferItemCount + Copy,
     {
         let mut encoder = self.device.create_command_encoder(
             &wgpu::CommandEncoderDescriptor {
@@ -208,14 +209,13 @@ impl Gpu {
     /// Low-level command to submit a buffer copy to a command encoder
     ///
     /// See [`copy`](Self::copy) for details
-    pub fn encode_copy<A, S>(
+    pub fn encode_copy<A>(
         &self,
-        src: &buf::GenericFlexBuffer<A, S>,
-        dst: &mut buf::ReadBuffer<A, S>,
+        src: &buf::FlexBuffer<A>,
+        dst: &mut buf::ReadBuffer<A>,
         encoder: &mut wgpu::CommandEncoder,
     ) where
         A: buf::BufferTag,
-        S: buf::BufferItemCount + Copy,
     {
         dst.grow_to_fit(&self.device, src.size())
             .expect("dst buffer should be resizable to match src buffer");
@@ -229,15 +229,14 @@ impl Gpu {
     }
 
     /// Blocking function to build a new mapped buffer
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn map<'a, T, S>(
+    #[cfg(any(not(target_arch = "wasm32"), doc))]
+    pub fn map<'a, T>(
         &self,
-        image: &'a mut buf::ReadBuffer<T, S>,
-    ) -> buf::MappedBuffer<'a, T, S>
+        image: &'a mut buf::ReadBuffer<T>,
+    ) -> buf::MappedBuffer<'a, T>
     where
         T: buf::BufferTag,
         T::T: Immutable + FromBytes + Copy,
-        S: buf::BufferItemCount + Copy,
     {
         pollster::block_on(self.map_async(image))
     }
@@ -248,14 +247,13 @@ impl Gpu {
     /// platforms, the single `await` is trivial (guaranteed to always be
     /// ready); on the web, the mapping sends us back to the event loop until
     /// it's ready.
-    pub async fn map_async<'a, T, S>(
+    pub async fn map_async<'a, T>(
         &self,
-        data: &'a mut buf::ReadBuffer<T, S>,
-    ) -> buf::MappedBuffer<'a, T, S>
+        data: &'a mut buf::ReadBuffer<T>,
+    ) -> buf::MappedBuffer<'a, T>
     where
         T: buf::BufferTag,
         T::T: Immutable + FromBytes + Copy,
-        S: buf::BufferItemCount + Copy,
     {
         let (tx, rx) = flume::bounded(1);
         let slice = data.map_async(move |_| tx.send(()).unwrap());
@@ -267,15 +265,15 @@ impl Gpu {
     }
 
     /// Blocking function to build a new mapped image
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn map_image<'a, T, S>(
+    #[cfg(any(not(target_arch = "wasm32"), doc))]
+    pub fn map_image<'a, T>(
         &self,
-        data: &'a mut buf::ReadBuffer<T, S>,
-    ) -> buf::MappedImage<'a, T, S>
+        data: &'a mut buf::ReadBuffer<T>,
+    ) -> buf::MappedImage<'a, T>
     where
         T: buf::BufferTag,
         T::T: Immutable + FromBytes + Copy,
-        S: buf::BufferItemCount + RenderSize + Copy,
+        T::S: RenderSize,
     {
         pollster::block_on(self.map_image_async(data))
     }
@@ -286,14 +284,14 @@ impl Gpu {
     /// platforms, the single `await` is trivial (guaranteed to always be
     /// ready); on the web, the mapping sends us back to the event loop until
     /// it's ready.
-    pub async fn map_image_async<'a, T, S>(
+    pub async fn map_image_async<'a, T>(
         &self,
-        data: &'a mut buf::ReadBuffer<T, S>,
-    ) -> buf::MappedImage<'a, T, S>
+        data: &'a mut buf::ReadBuffer<T>,
+    ) -> buf::MappedImage<'a, T>
     where
         T: buf::BufferTag,
         T::T: Immutable + FromBytes + Copy,
-        S: buf::BufferItemCount + RenderSize + Copy,
+        T::S: RenderSize,
     {
         self.map_async(data).await.into()
     }

--- a/fidget-wgpu/src/pixel/effects/mod.rs
+++ b/fidget-wgpu/src/pixel/effects/mod.rs
@@ -19,10 +19,7 @@
 //! [`MappedImage::color`] will return `None`.
 use crate::{
     Gpu, RegPipeline, ShapeColorBuffers,
-    buf::{
-        ArrayBuffer, BufferSizeError, ImageBuffer, buffer_ro, buffer_rw,
-        buffer_uniform,
-    },
+    buf::{BufferSizeError, FlexBuffer, buffer_ro, buffer_rw, buffer_uniform},
     pixel::{PixelBufferTag, RawDistancePixel},
     shaders, tag,
 };
@@ -85,6 +82,7 @@ tag!(
     pub MergedPixelBufferTag,
     // This is a hack; we store two images side by side, not interleaved
     [u32; 2],
+    ImageSize,
     STORAGE | COPY_SRC,
     "Buffer tag for on-GPU merged images"
 );
@@ -97,7 +95,7 @@ pub struct MergeBuffers {
     ///
     /// The first image is [`RawDistancePixel`] data; the second is initially
     /// the shape index then is rewritten to be color.
-    out: ImageBuffer<MergedPixelBufferTag>,
+    out: FlexBuffer<MergedPixelBufferTag>,
 
     /// Number of images merged together
     image_count: usize,
@@ -128,7 +126,7 @@ impl MergeBuffers {
     /// interleaved.  The first is distance (as [`RawDistancePixel`] values);
     /// the second is either shape index or RGBA color depending on
     /// [`has_color`](Self::has_color).
-    pub fn output(&self) -> &ImageBuffer<MergedPixelBufferTag> {
+    pub fn output(&self) -> &FlexBuffer<MergedPixelBufferTag> {
         &self.out
     }
 }
@@ -217,7 +215,7 @@ impl Context {
     /// resized to fit the images; subsequent merges must be of the same size.
     pub fn submit_merge(
         &self,
-        image: &ImageBuffer<PixelBufferTag>,
+        image: &FlexBuffer<PixelBufferTag>,
         remove_nans: bool,
         buf: &mut MergeBuffers,
     ) -> Result<(), MergeError> {
@@ -313,7 +311,7 @@ impl Context {
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
-        let out = ImageBuffer::new(
+        let out = FlexBuffer::new(
             &self.gpu.device,
             "merge output".to_owned(),
             image_size,
@@ -440,8 +438,8 @@ impl ImageReadBuffer {
     }
 }
 
-tag!(ImageReadTag, u32, COPY_DST | MAP_READ);
-type ImageReadArrayBuffer = ArrayBuffer<ImageReadTag>;
+tag!(ImageReadTag, u32, usize, COPY_DST | MAP_READ);
+type ImageReadArrayBuffer = FlexBuffer<ImageReadTag>;
 
 /// Handle to a mapped image, which unmaps the image when dropped
 pub struct MappedImage<'a> {

--- a/fidget-wgpu/src/pixel/mod.rs
+++ b/fidget-wgpu/src/pixel/mod.rs
@@ -5,8 +5,8 @@
 use crate::{
     Gpu, RegPipeline, RenderShape, TAPE_DATA_CAPACITY, TapeWord,
     buf::{
-        ArrayBuffer, BufferItemCount, BufferSizeError, BufferType, ImageBuffer,
-        buffer_ro, buffer_rw,
+        BufferItemCount, BufferSizeError, BufferType, FlexBuffer, buffer_ro,
+        buffer_rw,
     },
     shaders, tag,
 };
@@ -405,8 +405,8 @@ struct Config {
     // This is followed by a flexible array member containing tape data
 }
 
-tag!(TileTapesBufferTag, u32, STORAGE | COPY_DST);
-tag!(pub PixelBufferTag, RawDistancePixel, STORAGE | COPY_SRC | COPY_DST,
+tag!(TileTapesBufferTag, u32, usize, STORAGE | COPY_DST);
+tag!(pub PixelBufferTag, RawDistancePixel, ImageSize, STORAGE | COPY_SRC | COPY_DST,
     "Tag for a on-GPU buffer storing [`RawDistancePixel`] values");
 
 /// Buffers for rendering
@@ -427,7 +427,7 @@ pub struct Buffers {
     config_buf: wgpu::Buffer,
 
     /// Map from tile to the relevant tape (as a start index)
-    tile_tapes: ArrayBuffer<TileTapesBufferTag>,
+    tile_tapes: FlexBuffer<TileTapesBufferTag>,
 
     /// Root tile buffers (64²)
     tile64: TileBuffers<64>,
@@ -436,7 +436,7 @@ pub struct Buffers {
     tile8: TileBuffers<8>,
 
     /// Pixel data
-    pixels: ImageBuffer<PixelBufferTag>,
+    pixels: FlexBuffer<PixelBufferTag>,
 
     /// Query set for timestamps
     ///
@@ -477,7 +477,7 @@ impl Buffers {
         });
 
         let render_size = TileRenderSize::from(image_size);
-        let tile_tapes = ArrayBuffer::new(
+        let tile_tapes = FlexBuffer::new(
             device,
             "tile tape".to_string(),
             Self::tile_tapes_buf_size(render_size),
@@ -485,7 +485,7 @@ impl Buffers {
         .unwrap();
 
         let pixels =
-            ImageBuffer::new(device, "pixels".to_string(), image_size).unwrap();
+            FlexBuffer::new(device, "pixels".to_string(), image_size).unwrap();
 
         let ts_buf = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("ts"),
@@ -669,7 +669,7 @@ impl Buffers {
     /// [`RawDistancePixel`] image data without copying to the CPU.  It requires
     /// a exclusive borrow of the `Buffers` object (and then extends that
     /// lifetime) so that other callers can't simultaneously touch the buffer.
-    pub fn image_storage_buffer(&mut self) -> &ImageBuffer<PixelBufferTag> {
+    pub fn image_storage_buffer(&mut self) -> &FlexBuffer<PixelBufferTag> {
         &self.pixels
     }
 }
@@ -858,8 +858,8 @@ impl BindGroups {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-tag!(ImageReadTag, u8, COPY_DST | MAP_READ);
-type ImageReadArrayBuffer = ArrayBuffer<ImageReadTag>;
+tag!(ImageReadTag, u8, usize, COPY_DST | MAP_READ);
+type ImageReadArrayBuffer = FlexBuffer<ImageReadTag>;
 
 /// Buffer for reading data back from the GPU
 ///
@@ -956,16 +956,16 @@ impl MappedImage<'_> {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-tag!(TilesBufferTag, u32, STORAGE | COPY_DST | INDIRECT);
-tag!(ValuesBufferTag, u32, STORAGE | COPY_DST);
+tag!(TilesBufferTag, u32, usize, STORAGE | COPY_DST | INDIRECT);
+tag!(ValuesBufferTag, u32, ImageSize, STORAGE | COPY_DST);
 
 /// Root tile buffers store strata-packed tile lists
 struct TileBuffers<const N: usize> {
     /// Output tiles
-    tiles: ArrayBuffer<TilesBufferTag>,
+    tiles: FlexBuffer<TilesBufferTag>,
 
     /// Tile values (empty / full)
-    values: ImageBuffer<ValuesBufferTag>,
+    values: FlexBuffer<ValuesBufferTag>,
 }
 
 /// Error type when resizing root tile buffers
@@ -1004,7 +1004,7 @@ impl<const N: usize> TileBuffers<N> {
         render_size: TileRenderSize,
     ) -> Result<Self, TileBuffersError> {
         // Allocate enough words to write all of the output tiles
-        let tiles = ArrayBuffer::new(
+        let tiles = FlexBuffer::new(
             device,
             format!("tiles_out{N}"),
             Self::tiles_buf_size(render_size),
@@ -1015,15 +1015,12 @@ impl<const N: usize> TileBuffers<N> {
         })?;
 
         let values_buf_size = Self::values_buf_size(render_size);
-        let values = ImageBuffer::new(
-            device,
-            format!("tile{N}_values"),
-            values_buf_size,
-        )
-        .map_err(|err| TileBuffersError {
-            buf: TileBufferName::Values,
-            err,
-        })?;
+        let values =
+            FlexBuffer::new(device, format!("tile{N}_values"), values_buf_size)
+                .map_err(|err| TileBuffersError {
+                    buf: TileBufferName::Values,
+                    err,
+                })?;
         Ok(Self { tiles, values })
     }
 

--- a/fidget-wgpu/src/voxel/effects/mod.rs
+++ b/fidget-wgpu/src/voxel/effects/mod.rs
@@ -11,15 +11,12 @@
 
 use crate::{
     Gpu, RegPipeline, ShapeColorBuffers,
-    buf::{
-        BufferSizeError, DepthImageBuffer, ImageBuffer, buffer_ro, buffer_rw,
-        buffer_uniform,
-    },
+    buf::{BufferSizeError, FlexBuffer, buffer_ro, buffer_rw, buffer_uniform},
     shaders, tag,
     voxel::GeomBufferTag,
 };
 use fidget_core::{
-    render::VoxelSize,
+    render::{ImageSize, VoxelSize},
     shape::{MissingVar, ShapeVars},
 };
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
@@ -147,20 +144,20 @@ struct ShadeConfig {
 const SHADE_CONFIG_HAS_SSAO: u32 = 1u32;
 const SHADE_CONFIG_HAS_COLOR: u32 = 2u32;
 
-tag!(pub MergeVoxelBufferTag, PackedVoxel, STORAGE | COPY_SRC,
+tag!(pub MergeVoxelBufferTag, PackedVoxel, VoxelSize, STORAGE | COPY_SRC,
     "Buffer tag for on-GPU merged ([`PackedVoxel`]) images"
 );
 
 /// Handle to a set of buffers used when merging images
 pub struct MergeBuffers {
     config: wgpu::Buffer,
-    out: DepthImageBuffer<MergeVoxelBufferTag>,
+    out: FlexBuffer<MergeVoxelBufferTag>,
     image_count: usize,
 }
 
 impl MergeBuffers {
     /// Returns a handle to the output buffer
-    pub fn output(&self) -> &DepthImageBuffer<MergeVoxelBufferTag> {
+    pub fn output(&self) -> &FlexBuffer<MergeVoxelBufferTag> {
         &self.out
     }
 
@@ -174,7 +171,7 @@ impl MergeBuffers {
 }
 
 tag!(
-    pub ShadedImageTag, u32, STORAGE | COPY_SRC,
+    pub ShadedImageTag, u32, VoxelSize, STORAGE | COPY_SRC,
     "Buffer tag for on-GPU shaded (RGBA) images"
 );
 
@@ -182,12 +179,12 @@ tag!(
 pub struct ShadeBuffers {
     config: wgpu::Buffer,
     has_color: bool,
-    out: DepthImageBuffer<ShadedImageTag>,
+    out: FlexBuffer<ShadedImageTag>,
 }
 
 impl ShadeBuffers {
     /// Returns a reference to the output buffer
-    pub fn output(&self) -> &DepthImageBuffer<ShadedImageTag> {
+    pub fn output(&self) -> &FlexBuffer<ShadedImageTag> {
         &self.out
     }
 }
@@ -369,7 +366,7 @@ impl Context {
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
-        let out = DepthImageBuffer::new(
+        let out = FlexBuffer::new(
             &self.gpu.device,
             "merge output".to_owned(),
             64.into(),
@@ -394,7 +391,7 @@ impl Context {
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
-        let out = DepthImageBuffer::new(
+        let out = FlexBuffer::new(
             &self.gpu.device,
             "shade output".to_owned(),
             64.into(),
@@ -421,7 +418,7 @@ impl Context {
                 mapped_at_creation: false,
             });
         let image_size = 64.into();
-        let raw_occlusion = ImageBuffer::new(
+        let raw_occlusion = FlexBuffer::new(
             &self.gpu.device,
             "ssao raw occlusion".to_owned(),
             image_size,
@@ -435,7 +432,7 @@ impl Context {
                     | wgpu::BufferUsages::COPY_DST,
                 mapped_at_creation: false,
             });
-        let blurred_occlusion = ImageBuffer::new(
+        let blurred_occlusion = FlexBuffer::new(
             &self.gpu.device,
             "ssao blurred occlusion".to_owned(),
             image_size,
@@ -456,7 +453,7 @@ impl Context {
     /// resized to fit the images; subsequent merges must be of the same size.
     pub fn submit_merge(
         &self,
-        image: &DepthImageBuffer<GeomBufferTag>,
+        image: &FlexBuffer<GeomBufferTag>,
         denoise: bool,
         buf: &mut MergeBuffers,
     ) -> Result<(), MergeError> {
@@ -693,28 +690,28 @@ impl Context {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-tag!(pub SsaoRawBufferTag, f32, STORAGE | COPY_SRC,
+tag!(pub SsaoRawBufferTag, f32, ImageSize, STORAGE | COPY_SRC,
     "Tag for a raw SSAO occlusion buffer");
-tag!(pub SsaoBlurredBufferTag, f32, STORAGE | COPY_SRC,
+tag!(pub SsaoBlurredBufferTag, f32, ImageSize, STORAGE | COPY_SRC,
     "Tag for a blurred SSAO occlusion buffer");
 
 /// Handle to a set of buffers used when running an SSAO pass
 pub struct SsaoBuffers {
     ssao_config: wgpu::Buffer, // TODO add a `ConfigBuffer` type?
-    raw_occlusion: ImageBuffer<SsaoRawBufferTag>,
+    raw_occlusion: FlexBuffer<SsaoRawBufferTag>,
 
     blur_config: wgpu::Buffer,
-    blurred_occlusion: ImageBuffer<SsaoBlurredBufferTag>,
+    blurred_occlusion: FlexBuffer<SsaoBlurredBufferTag>,
 }
 
 impl SsaoBuffers {
     /// Returns a shared handle to the raw SSAO occlusion buffer
-    pub fn raw_occlusion(&self) -> &ImageBuffer<SsaoRawBufferTag> {
+    pub fn raw_occlusion(&self) -> &FlexBuffer<SsaoRawBufferTag> {
         &self.raw_occlusion
     }
 
     /// Returns a shared handle to the blurred SSAO occlusion buffer
-    pub fn blurred_occlusion(&self) -> &ImageBuffer<SsaoBlurredBufferTag> {
+    pub fn blurred_occlusion(&self) -> &FlexBuffer<SsaoBlurredBufferTag> {
         &self.blurred_occlusion
     }
 }

--- a/fidget-wgpu/src/voxel/mod.rs
+++ b/fidget-wgpu/src/voxel/mod.rs
@@ -105,8 +105,8 @@
 use crate::{
     Gpu, RegPipeline, RenderShape, TAPE_DATA_CAPACITY, TapeWord,
     buf::{
-        ArrayBuffer, BufferItemCount, BufferSizeError, BufferType,
-        DepthImageBuffer, ImageBuffer, buffer_ro, buffer_ro_dyn, buffer_rw,
+        BufferItemCount, BufferSizeError, BufferType, FlexBuffer, buffer_ro,
+        buffer_ro_dyn, buffer_rw,
     },
     shaders, tag,
 };
@@ -1025,17 +1025,17 @@ pub struct Context {
     clear_ctx: ClearContext,
 }
 
-tag!(TilesBufferTag, u32, STORAGE | INDIRECT);
-tag!(SortedBufferTag, u32, STORAGE | INDIRECT);
-tag!(ZminBufferTag, u32, STORAGE | COPY_DST);
+tag!(TilesBufferTag, u32, usize, STORAGE | INDIRECT);
+tag!(SortedBufferTag, u32, usize, STORAGE | INDIRECT);
+tag!(ZminBufferTag, u32, ImageSize, STORAGE | COPY_DST);
 
 struct TileBuffers<const N: u64> {
     /// Tiles written by the stage outputting N³ tiles
-    tiles: ArrayBuffer<TilesBufferTag>,
+    tiles: FlexBuffer<TilesBufferTag>,
     /// Sorted version of [`tiles`](Self::tiles)
-    sorted: ArrayBuffer<SortedBufferTag>,
+    sorted: FlexBuffer<SortedBufferTag>,
     /// Minimum Z height at each XY tile
-    zmin: ImageBuffer<ZminBufferTag>,
+    zmin: FlexBuffer<ZminBufferTag>,
 }
 
 impl<const N: u64> TileBuffers<N> {
@@ -1046,18 +1046,18 @@ impl<const N: u64> TileBuffers<N> {
     ) -> Result<Self, TileBuffersError> {
         let tile_buf_size = Self::tile_buf_size(render_size);
         let tiles =
-            ArrayBuffer::new(device, format!("active_tile{N}"), tile_buf_size)
+            FlexBuffer::new(device, format!("active_tile{N}"), tile_buf_size)
                 .map_err(|err| TileBuffersError {
-                    buf: TileBufferName::Tiles,
-                    err,
-                })?;
+                buf: TileBufferName::Tiles,
+                err,
+            })?;
         let sorted =
-            ArrayBuffer::new(device, format!("sorted_tile{N}"), tile_buf_size)
+            FlexBuffer::new(device, format!("sorted_tile{N}"), tile_buf_size)
                 .map_err(|err| TileBuffersError {
-                    buf: TileBufferName::Sorted,
-                    err,
-                })?;
-        let zmin = ImageBuffer::new(
+                buf: TileBufferName::Sorted,
+                err,
+            })?;
+        let zmin = FlexBuffer::new(
             device,
             format!("tile{N}_zmin"),
             Self::zmin_buf_size(render_size),
@@ -1148,19 +1148,24 @@ impl<const N: u64> TileBuffers<N> {
     }
 }
 
-tag!(RootTilesBufferTag, u32, STORAGE | COPY_DST);
-tag!(RootStrataBufferTag, u8, STORAGE | INDIRECT | COPY_DST);
-tag!(RootZminBufferTag, u32, STORAGE | COPY_DST);
-tag!(RootZmaxBufferTag, u32, STORAGE | COPY_DST);
+tag!(RootTilesBufferTag, u32, usize, STORAGE | COPY_DST);
+tag!(
+    RootStrataBufferTag,
+    u8,
+    usize,
+    STORAGE | INDIRECT | COPY_DST
+);
+tag!(RootZminBufferTag, u32, ImageSize, STORAGE | COPY_DST);
+tag!(RootZmaxBufferTag, u32, ImageSize, STORAGE | COPY_DST);
 
 /// Root tile buffers store strata-packed tile lists
 struct RootTileBuffers {
     /// Initial output tiles
-    tiles: ArrayBuffer<RootTilesBufferTag>,
+    tiles: FlexBuffer<RootTilesBufferTag>,
     /// Strata-sorted output tiles
-    strata: ArrayBuffer<RootStrataBufferTag>,
-    zmin: ImageBuffer<RootZminBufferTag>,
-    zmax: ImageBuffer<RootZmaxBufferTag>,
+    strata: FlexBuffer<RootStrataBufferTag>,
+    zmin: FlexBuffer<RootZminBufferTag>,
+    zmax: FlexBuffer<RootZmaxBufferTag>,
 }
 
 impl RootTileBuffers {
@@ -1173,7 +1178,7 @@ impl RootTileBuffers {
         const N: usize = 64;
 
         // Allocate enough words to write all of the output tiles
-        let tiles = ArrayBuffer::new(
+        let tiles = FlexBuffer::new(
             device,
             format!("tiles_out{N}"),
             Self::tiles_buf_size(render_size),
@@ -1183,7 +1188,7 @@ impl RootTileBuffers {
             err,
         })?;
 
-        let strata = ArrayBuffer::new(
+        let strata = FlexBuffer::new(
             device,
             format!("strata_tile{N}"),
             Self::strata_buf_size(render_size),
@@ -1194,18 +1199,16 @@ impl RootTileBuffers {
         })?;
 
         let z_buf_size = Self::z_buf_size(render_size);
-        let zmin =
-            ImageBuffer::new(device, format!("tile{N}_zmin"), z_buf_size)
-                .map_err(|err| RootTileBuffersError {
-                    buf: RootTileBufferName::Zmin,
-                    err,
-                })?;
-        let zmax =
-            ImageBuffer::new(device, format!("tile{N}_zmax"), z_buf_size)
-                .map_err(|err| RootTileBuffersError {
-                    buf: RootTileBufferName::Zmax,
-                    err,
-                })?;
+        let zmin = FlexBuffer::new(device, format!("tile{N}_zmin"), z_buf_size)
+            .map_err(|err| RootTileBuffersError {
+                buf: RootTileBufferName::Zmin,
+                err,
+            })?;
+        let zmax = FlexBuffer::new(device, format!("tile{N}_zmax"), z_buf_size)
+            .map_err(|err| RootTileBuffersError {
+                buf: RootTileBufferName::Zmax,
+                err,
+            })?;
         Ok(Self {
             tiles,
             strata,
@@ -1304,9 +1307,9 @@ impl RootTileBuffers {
     }
 }
 
-tag!(TileTapesBufferTag, u32, STORAGE | COPY_DST);
-tag!(VoxelsBufferTag, u32, STORAGE | COPY_DST);
-tag!(pub GeomBufferTag, GeometryPixel, STORAGE | COPY_SRC | COPY_DST,
+tag!(TileTapesBufferTag, u32, usize, STORAGE | COPY_DST);
+tag!(VoxelsBufferTag, u32, usize, STORAGE | COPY_DST);
+tag!(pub GeomBufferTag, GeometryPixel, VoxelSize, STORAGE | COPY_SRC | COPY_DST,
     "Tag for a on-GPU buffer storing [`GeometryPixel`] values");
 
 /// Buffers for rendering
@@ -1336,7 +1339,7 @@ pub struct Buffers {
     z_hist_buf: wgpu::Buffer,
 
     /// Map from tile to the relevant tape (as a start index)
-    tile_tapes: ArrayBuffer<TileTapesBufferTag>,
+    tile_tapes: FlexBuffer<TileTapesBufferTag>,
 
     /// Root tile Z heights (64³)
     tile64: RootTileBuffers,
@@ -1348,12 +1351,12 @@ pub struct Buffers {
     tile4: TileBuffers<4>,
 
     /// Z heights for voxel tile evaluation (rounded up)
-    voxels: ArrayBuffer<VoxelsBufferTag>, // XXX should this be an ImageBuffer?
+    voxels: FlexBuffer<VoxelsBufferTag>, // XXX should this be an ImageBuffer?
 
     /// Buffer of [`GeometryPixel`] data, generated by the normal pass
     ///
     /// This is at the original image size
-    geom: DepthImageBuffer<GeomBufferTag>,
+    geom: FlexBuffer<GeomBufferTag>,
 
     /// Query set for timestamps
     ///
@@ -1412,8 +1415,8 @@ impl ImageReadBuffer {
     }
 }
 
-tag!(ImageReadTag, u8, COPY_DST | MAP_READ);
-type ImageReadArrayBuffer = ArrayBuffer<ImageReadTag>;
+tag!(ImageReadTag, u8, usize, COPY_DST | MAP_READ);
+type ImageReadArrayBuffer = FlexBuffer<ImageReadTag>;
 
 /// Cached bind groups (constructed on-demand)
 #[derive(Default)]
@@ -1759,7 +1762,7 @@ impl Buffers {
     /// [`GeometryPixel`] image data without copying to the CPU.  It requires a
     /// exclusive borrow of the `Buffers` object (and then extends that
     /// lifetime) so that other callers can't simultaneously touch the buffer.
-    pub fn image_storage_buffer(&mut self) -> &DepthImageBuffer<GeomBufferTag> {
+    pub fn image_storage_buffer(&mut self) -> &FlexBuffer<GeomBufferTag> {
         &self.geom
     }
 
@@ -1784,13 +1787,13 @@ impl Buffers {
         });
 
         let render_size = TileRenderSize::from(image_size);
-        let voxels = ArrayBuffer::new(
+        let voxels = FlexBuffer::new(
             device,
             "voxels".to_string(),
             Self::voxels_buf_size(render_size),
         )
         .unwrap();
-        let tile_tapes = ArrayBuffer::new(
+        let tile_tapes = FlexBuffer::new(
             device,
             "tile tape".to_string(),
             Self::tile_tapes_buf_size(render_size),
@@ -1798,8 +1801,7 @@ impl Buffers {
         .unwrap();
 
         let geom =
-            DepthImageBuffer::new(device, "geom".to_string(), image_size)
-                .unwrap();
+            FlexBuffer::new(device, "geom".to_string(), image_size).unwrap();
 
         let ts_buf = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("ts"),


### PR DESCRIPTION
This is a small simplification to reduce the number of generics in `GenericFlexBuffer`.

In addition, it renames `GenericFlexBuffer` to `FlexBuffer`.