### PR TITLE
Small `fidget_wgpu` tweaks for Halfspace integration

### DIFF
--- a/fidget-wgpu/src/lib.rs
+++ b/fidget-wgpu/src/lib.rs
@@ -139,6 +139,25 @@ impl Gpu {
         .expect("buf.size should always be a valid size for ReadBuffer::new")
     }
 
+    /// Builds a new readable buffer
+    ///
+    /// The buffer has an arbitrary starting size and will be resized when used
+    /// in [`copy`](Self::copy).
+    ///
+    /// If the target buffer is known, use
+    /// [`read_buffer_for`](Self::read_buffer_for) to avoid this reallocation.
+    pub fn read_buffer<T>(&self, name: &str) -> buf::ReadBuffer<T>
+    where
+        T: buf::BufferTag,
+        T::S: TryFrom<u32>,
+    {
+        let Ok(size) = 64u32.try_into() else {
+            panic!("could not build size");
+        };
+        buf::ReadBuffer::new(&self.device, name.to_owned(), size)
+            .expect("64 should always be a valid size for ReadBuffer::new")
+    }
+
     /// Helper function to read from a buffer to a `Vec`
     ///
     /// Under the hood, this function simply calls

--- a/fidget-wgpu/src/pixel/effects/mod.rs
+++ b/fidget-wgpu/src/pixel/effects/mod.rs
@@ -317,10 +317,7 @@ impl Context {
     }
 
     /// Builds a new set of [`MergeBuffers`] for the given image size
-    pub fn merge_buffers(
-        &self,
-        image_size: ImageSize,
-    ) -> Result<MergeBuffers, BufferSizeError> {
+    pub fn merge_buffers(&self) -> MergeBuffers {
         let config = self.gpu.device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("config"),
             size: std::mem::size_of::<MergeConfig>() as u64,
@@ -329,21 +326,23 @@ impl Context {
         });
         let distance = FlexBuffer::new(
             &self.gpu.device,
-            "merge output".to_owned(),
-            image_size,
-        )?;
+            "pixel merge distance".to_owned(),
+            64.into(),
+        )
+        .unwrap();
         let color = FlexBuffer::new(
             &self.gpu.device,
-            "merge output".to_owned(),
-            image_size,
-        )?;
-        Ok(MergeBuffers {
+            "pixel merge color".to_owned(),
+            64.into(),
+        )
+        .unwrap();
+        MergeBuffers {
             config,
             distance,
             color,
             image_count: 0,
             has_color: false,
-        })
+        }
     }
 
     /// Submits a color evaluation pass

--- a/fidget-wgpu/src/pixel/effects/shaders/merge.wgsl
+++ b/fidget-wgpu/src/pixel/effects/shaders/merge.wgsl
@@ -128,6 +128,22 @@ fn merge_pixel(
     let b_inside = distance_pixel_is_inside(b.distance);
     if a_inside && !b_inside {
         return a;
+    } else if !a_inside && b_inside {
+        return b;
+    } else if a_inside && b_inside {
+        return b;
+    } else if !distance_pixel_is_fill(a.distance) &&
+              !distance_pixel_is_fill(b.distance)
+    {
+        // Outside pixels are only rendered in SDF mode, which is pixel-perfect
+        // (so we should always have distance values).  In this case, we'll do a
+        // true `min` for outside pixels, instead of the `b`-over-`a` logic
+        // which is used for inside pixels
+        if a.distance.data < b.distance.data {
+            return a;
+        } else {
+            return b;
+        }
     } else {
         return b;
     }

--- a/fidget-wgpu/src/pixel/mod.rs
+++ b/fidget-wgpu/src/pixel/mod.rs
@@ -1371,8 +1371,7 @@ mod test {
         let effects_ctx = effects::Context::new(&gpu);
 
         let mut buf = pixel_ctx.buffers();
-        let mut merge_buf =
-            effects_ctx.merge_buffers(render_config.image_size).unwrap();
+        let mut merge_buf = effects_ctx.merge_buffers();
 
         // Render and accumulate each shape
         for (shape, _) in shapes {
@@ -1585,32 +1584,32 @@ mod test {
             gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
             gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
             gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggGGGGGGGgggggggggggggggggggggggggBBBBBBBgggggggggggg
-            gggggggggggGGGGGGGGGGGgggggggggggggggggggggBBBBBBBBBBBgggggggggg
-            ggggggggggGGGGGGGGGGGGGgggggggggggggggggggBBBBBBBBBBBBBggggggggg
-            ggggggggggGGGGGGGGGGGGGgggggggggggggggggggBBBBBBBBBBBBBggggggggg
-            gggggggggGGGGGGGGGGGGGGGgggggggggggggggggBBBBBBBBBBBBBBBgggggggg
-            gggggggggGGGGGGGGGGGGGGGgggggggggggggggggBBBBBBBBBBBBBBBgggggggg
-            gggggggggGGGGGGGGGGGGGGGgggggggggggggggggBBBBBBBBBBBBBBBgggggggg
-            gggggggggGGGGGGGGGGGGGGGgggggggggggggggggBBBBBBBBBBBBBBBgggggggg
-            gggggggggGGGGGGGGGGGGGGGgggggggggggggggggBBBBBBBBBBBBBBBgggggggg
-            gggggggggGGGGGGGGGGGGGGGgggggggggggggggggBBBBBBBBBBBBBBBgggggggg
-            gggggggggGGGGGGGGGGGGGGGgggggggggggggggggBBBBBBBBBBBBBBBgggggggg
-            ggggggggggGGGGGGGGGGGGGgggggggggggggggggggBBBBBBBBBBBBBggggggggg
-            ggggggggggGGGGGGGGGGGGGgggggggggggggggggggBBBBBBBBBBBBBggggggggg
-            gggggggggggGGGGGGGGGGGgggggggggggggggggggggBBBBBBBBBBBgggggggggg
-            gggggggggggggGGGGGGGgggggggggggggggggggggggggBBBBBBBgggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
-            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggbbbbbbbbbbbbbbbbbbggggggg
+            gggggggggggggggggggggggggggggggggggggggbbbbbbbbbbbbbbbbbbggggggg
+            gggggggggggggggggggggggggggggggggggggggbbbbbbbbbbbbbbbbbbggggggg
+            gggggggggggggggggggggggggggggggggggggggbbbbbbbbbbbbbbbbbbggggggg
+            gggggggggggggggggggggggggggggggggggggggbbbbbbbbbbbbbbbbbbggggggg
+            gggggggggggggggggggggggggggggggggggggggbbbbbbbbbbbbbbbbbbggggggg
+            gggggggggggggggggggggggggggggggggggggggbbbbbbbbbbbbbbbbbbggggggg
+            gggggggggggggggggggggggggggggggggggggggbbbbbbbbbbbbbbbbbbggggggg
+            gggggggggggggggggggggggggggggggggbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            gggggggggggggGGGGGGGgggggggggggggbbbbbbbbbbbbBBBBBBBbbbbbbbbbbbb
+            gggggggggggGGGGGGGGGGGgggggggggggbbbbbbbbbbBBBBBBBBBBBbbbbbbbbbb
+            ggggggggggGGGGGGGGGGGGGggggggggggbbbbbbbbbBBBBBBBBBBBBBbbbbbbbbb
+            ggggggggggGGGGGGGGGGGGGggggggggggbbbbbbbbbBBBBBBBBBBBBBbbbbbbbbb
+            gggggggggGGGGGGGGGGGGGGGgggggggggbbbbbbbbBBBBBBBBBBBBBBBbbbbbbbb
+            gggggggggGGGGGGGGGGGGGGGgggggggggbbbbbbbbBBBBBBBBBBBBBBBbbbbbbbb
+            gggggggggGGGGGGGGGGGGGGGgggggggggbbbbbbbbBBBBBBBBBBBBBBBbbbbbbbb
+            gggggggggGGGGGGGGGGGGGGGgggggggggbbbbbbbbBBBBBBBBBBBBBBBbbbbbbbb
+            gggggggggGGGGGGGGGGGGGGGgggggggggbbbbbbbbBBBBBBBBBBBBBBBbbbbbbbb
+            gggggggggGGGGGGGGGGGGGGGgggggggggggggggbbBBBBBBBBBBBBBBBgggggggg
+            gggggggggGGGGGGGGGGGGGGGgggggggggggggggbbBBBBBBBBBBBBBBBbggggggg
+            ggggggggggGGGGGGGGGGGGGggggggggggggggggbbbBBBBBBBBBBBBBbbggggggg
+            ggggggggggGGGGGGGGGGGGGggggggggggggggggbbbBBBBBBBBBBBBBbbggggggg
+            gggggggggggGGGGGGGGGGGgggggggggggggggggbbbbBBBBBBBBBBBbbbggggggg
+            gggggggggggggGGGGGGGgggggggggggggggggggbbbbbbBBBBBBBbbbbbggggggg
+            gggggggggggggggggggggggggggggggggggggggbbbbbbbbbbbbbbbbbbggggggg
+            gggggggggggggggggggggggggggggggggggggggbbbbbbbbbbbbbbbbbbggggggg
             gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
             gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
             gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg

--- a/fidget-wgpu/src/voxel/effects/shaders/shade.wgsl
+++ b/fidget-wgpu/src/voxel/effects/shaders/shade.wgsl
@@ -62,7 +62,7 @@ fn shade_main(
         accum *= occlusion[i] * 0.6 + 0.4;
     }
     let brightness = clamp(accum, 0.0, 1.0);
-    let alpha = 0xFF << 24;
+    let alpha = 0xFFu << 24;
     if (config.flags & SHADE_CONFIG_HAS_COLOR) != 0 {
         let color = vec4f(unpack4xU8(out[i])) * brightness;
         out[i] = pack4xU8(vec4u(color)) | alpha;


### PR DESCRIPTION
- Get a readable buffer by tag, instead of needing an exemplary
- Make `merge_buffers` infallible, since we resize elsewhere
- Tweak merge logic to produce min-shaped SDFs outside the model
- WGSL syntax tweak for Chrome