### PR TITLE
Move the `RenderShape` off the GPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,17 @@
 # 0.5.1 (unpublished)
+The most significant change in this verison is unlocking all-GPU rendering: we
+can start with a shape on the CPU, then perform a full rendering pipeline
+(including shading and post-processing) entirely on the GPU.  The APIs were
+codesigned along with [Halfspace](https://github.com/mkeeter/halfspace),
+with a goal of moving its heavy work to the GPU for native-equivalent
+performance on the web.
+
+As such, this release includes *many* changes to `fidget::wgpu`, which I break
+out into a separate section below.  It also includes a bunch of other changes!
+
 - In `fidget::raster`, reorganize `RenderConfig` to separate out the render
   settings (transform, size, etc) from evaluation settings (thread count,
   cancellation, etc); the latter are now in a new `EvalConfig`.
-- `fidget::wgpu` now uses the `RenderConfig` type from `fidget::raster` instead
-  of its own, slightly-different `RenderConfig`.  This was, in fact, the
-  motivation for the reorganization!
-    - Render size in `fidget::wgpu::voxel` is now set by the `RenderConfig`,
-      instead of by the `Buffers` object.  This means that buffers are generated
-      without a size, and resized when passed to render functions.  Functions
-      which do resizing have a new possible error variant if the render size is
-      too large for WGPU buffers.
-    - Removed size from many buffer construction functions in
-      `fidget::wgpu::voxel`, since they're resized when used in evaluation.
-    - Add `fidget::wgpu::buf::DepthImageBuffer`, which is a flexible image
-      buffer taking a `VoxelSize` (so that it preserves depth).
 - Add `z` to `fidget::raster::pixel::RenderConfig` to set the Z evaluation level
 - Move `PartialEq` implementation from `Tree` to `TreeOp`; switch to
   `OrderedFloat` semantics so that pointer comparisons are valid.  Previously,
@@ -22,12 +20,6 @@
 - Add a `Hash` implementation to `Tree` and `TreeOp`, again using `OrderedFloat`
   semantics.  This allows trees to be stored in hashmaps; thanks to @virtualritz
   for the suggestion!
-- Add `fidget::wgpu::pixel` module for 2D rasterization on the GPU.  This is
-  sometimes slower than the CPU evaluator for very complex expressions, but is
-  blazingly fast for simpler expressions.  Plus, it allows for an all-GPU
-  evaluation architecture when embedding Fidget into other applications.
-    - The `fidget::wgpu::pixel::effects` module is also new; it includes merging
-      and color evaluation for 2D images.
 - Move more VM functions onto `Grad` and `Interval` (out of the VM
   implementation); add a `FloatExt` trait which adds them to `f32` as well.
 - Fix a JIT bug in the gradient evaluator on Windows, where we assumed that
@@ -46,14 +38,37 @@
       **agree exactly** with the canonical operator definition.  This required
       removing the JIT implementation for `modulo`, which was not exactly in
       agreement with the non-JIT implementation.
-- Move `fidget_wgpu::effects` to `fidget_wgpu::voxel::effects`
-- Add evaluation of per-pixel colors to `fidget_wgpu::voxel::effects`; see
-  `fidget_wgpu::voxel::effects::Context::submit_color` as the main entry point.
-    - Move `ShapeColorBuffers` construction to top-level `Gpu` object
 - Add `fidget_bytecode::Bytecode::build_with_input_map` for building a
   `Bytecode` object with a particular remapping function for inputs.  This is
   helpful if you're going to combine multiple bytecode tapes and want them to
   share a common input indexing order.
+
+## `fidget::wgpu` changes
+This section may not be all-inclusive; sorry!  I _did_ warn you that
+`fidget::wgpu` was "even more experimental than the rest of Fidget"!.
+
+- `fidget::wgpu` now uses the `RenderConfig` type from `fidget::raster` instead
+  of its own, slightly-different `RenderConfig`.  This was, in fact, the
+  motivation for the reorganization!
+    - Render size in `fidget::wgpu::voxel` is now set by the `RenderConfig`,
+      instead of by the `Buffers` object.  This means that buffers are generated
+      without a size, and resized when passed to render functions.  Functions
+      which do resizing have a new possible error variant if the render size is
+      too large for WGPU buffers.
+    - Removed size from many buffer construction functions in
+      `fidget::wgpu::voxel`, since they're resized when used in evaluation.
+    - Add `fidget::wgpu::buf::DepthImageBuffer`, which is a flexible image
+      buffer taking a `VoxelSize` (so that it preserves depth).
+- Add `fidget::wgpu::pixel` module for 2D rasterization on the GPU.  This is
+  sometimes slower than the CPU evaluator for very complex expressions, but is
+  blazingly fast for simpler expressions.  Plus, it allows for an all-GPU
+  evaluation architecture when embedding Fidget into other applications.
+    - The `fidget::wgpu::pixel::effects` module is also new; it includes merging
+      and color evaluation for 2D images.
+- Move `fidget_wgpu::effects` to `fidget_wgpu::voxel::effects`
+- Add evaluation of per-pixel colors to `fidget_wgpu::voxel::effects`; see
+  `fidget_wgpu::voxel::effects::Context::submit_color` as the main entry point.
+    - Move `ShapeColorBuffers` construction to top-level `Gpu` object
 - `VarMap` now implements `Debug`
 - `VarMap::has_free_vars` checks whether there are non-XYZ vars in the map
 - `RawDistancePixel` now implements `zerocopy::IntoBytes`
@@ -65,6 +80,8 @@
 - More reorganization of `fidget::wgpu` buffer APIs
 - Remove timestamps from `fidget::wgpu` pixel and voxel rendering; they will
   come back in a new form at some point in the future
+- Make `RenderShape` _not_ store GPU objects, so it can be constructed
+  independently through `RenderShape::new`.
 
 # 0.5.0
 This is a large release with a bunch of small features, reorganization, and one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 0.5.1 (unpublished)
-The most significant change in this verison is unlocking all-GPU rendering: we
+The most significant change in this version is unlocking all-GPU rendering: we
 can start with a shape on the CPU, then perform a full rendering pipeline
 (including shading and post-processing) entirely on the GPU.  The APIs were
 codesigned along with [Halfspace](https://github.com/mkeeter/halfspace),

--- a/demos/cli/src/main.rs
+++ b/demos/cli/src/main.rs
@@ -398,7 +398,7 @@ fn run3d_wgpu(
     let start = std::time::Instant::now();
     let mut buffers = ctx.buffers();
     let mut out = gpu.read_buffer_for(buffers.output());
-    let shape = gpu.shape(&shape)?;
+    let shape = fidget::wgpu::RenderShape::new(&shape)?;
     for _ in 0..settings.n {
         image = ctx.run(&shape, &mut buffers, &mut out, cfg)?;
     }
@@ -690,7 +690,7 @@ fn run2d_wgpu(
     let start = std::time::Instant::now();
     let mut buffers = ctx.buffers();
     let mut out = gpu.read_buffer_for(buffers.output());
-    let shape = gpu.shape(&shape)?;
+    let shape = fidget::wgpu::RenderShape::new(&shape)?;
     let mut postprocess_time = std::time::Duration::ZERO;
     for _ in 0..settings.n {
         let img = ctx.run(&shape, &mut buffers, &mut out, cfg)?;

--- a/fidget-wgpu/src/buf.rs
+++ b/fidget-wgpu/src/buf.rs
@@ -157,12 +157,16 @@ impl<T: BufferTag> FlexBuffer<T> {
     /// but we always update the internal `item_count` (e.g. so that
     /// [`bind_active`](Self::bind_active) returns the correct subset of the
     /// buffer).
+    ///
+    /// Returns a comparison between the previous item count and the new item
+    /// count (set by `size`).
     pub(crate) fn grow_to_fit(
         &mut self,
         device: &wgpu::Device,
         size: T::S,
-    ) -> Result<(), BufferSizeError> {
+    ) -> Result<std::cmp::Ordering, BufferSizeError> {
         Self::check_size(size)?;
+        let r = self.size.item_count().cmp(&size.item_count());
         let new_size = Self::calculate_buffer_size(size);
         if new_size > self.capacity() {
             let usage = self.data.usage();
@@ -174,7 +178,7 @@ impl<T: BufferTag> FlexBuffer<T> {
             });
         }
         self.size = size;
-        Ok(())
+        Ok(r)
     }
 
     /// Returns a binding resource for the active slice of the buffer

--- a/fidget-wgpu/src/lib.rs
+++ b/fidget-wgpu/src/lib.rs
@@ -401,8 +401,20 @@ impl RenderShape {
         let vs = self.shape.inner().vars();
         let mut changed = false;
         if vs.has_free_vars() {
-            // If we have to change the vars buffer size, then clear the cached
-            // bind group.  TODO: only do this if we grow the buffer, since
+            // Do an initial pass to check for errors before resizing the buffer
+            for (v, _i) in vs.iter() {
+                match v {
+                    Var::X | Var::Y | Var::Z => (),
+                    Var::V(vi) => {
+                        if vars.get(vi).is_none() {
+                            return Err(MissingVar { var: vi }.into());
+                        };
+                    }
+                }
+            }
+            // If we have to change the vars buffer size, then we'll return
+            // `true` indicating that things have changed and bind groups should
+            // be invalidated.  TODO: only do this if we grow the buffer, since
             // binding an overly-large buffer is fine?
             let r = buf.grow_to_fit(&gpu.device, vs.len())?;
             if !matches!(r, std::cmp::Ordering::Equal) {
@@ -422,9 +434,7 @@ impl RenderShape {
                 match v {
                     Var::X | Var::Y | Var::Z => (),
                     Var::V(vi) => {
-                        let Some(value) = vars.get(vi) else {
-                            return Err(MissingVar { var: vi }.into());
-                        };
+                        let value = vars.get(vi).unwrap(); // checked above
                         let offset = i * std::mem::size_of::<f32>();
                         writer
                             .slice(offset..offset + 4)

--- a/fidget-wgpu/src/lib.rs
+++ b/fidget-wgpu/src/lib.rs
@@ -396,10 +396,10 @@ impl RenderShape {
         gpu: &Gpu,
         vars: &ShapeVars<f32>,
         buf: &mut buf::FlexBuffer<voxel::VarsBufferTag>,
-    ) -> Result<bool, CopyVarsError> {
+    ) -> Result<CopyVarsChanged, CopyVarsError> {
         // Copy vars (if present)
         let vs = self.shape.inner().vars();
-        let mut changed = false;
+        let mut changed = CopyVarsChanged::BufferUnchanged;
         if vs.has_free_vars() {
             // Do an initial pass to check for errors before resizing the buffer
             for (v, _i) in vs.iter() {
@@ -418,7 +418,7 @@ impl RenderShape {
             // binding an overly-large buffer is fine?
             let r = buf.grow_to_fit(&gpu.device, vs.len())?;
             if !matches!(r, std::cmp::Ordering::Equal) {
-                changed = true;
+                changed = CopyVarsChanged::BufferChanged;
             }
             let mut writer = gpu
                 .queue
@@ -453,6 +453,13 @@ enum CopyVarsError {
     BufferSize(#[from] buf::BufferSizeError),
     #[error(transparent)]
     MissingVar(#[from] MissingVar),
+}
+
+#[must_use]
+#[derive(Copy, Clone, Debug)]
+enum CopyVarsChanged {
+    BufferChanged,
+    BufferUnchanged,
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/fidget-wgpu/src/lib.rs
+++ b/fidget-wgpu/src/lib.rs
@@ -386,6 +386,63 @@ impl RenderShape {
         [Var::X, Var::Y, Var::Z]
             .map(|a| vars.get(&a).map(|v| v as u32).unwrap_or(u32::MAX))
     }
+
+    /// Copies variables into a variables buffer
+    ///
+    /// Returns `true` if the buffer size changed, which could invalidate cached
+    /// bind groups.
+    fn copy_vars(
+        &self,
+        gpu: &Gpu,
+        vars: &ShapeVars<f32>,
+        buf: &mut buf::FlexBuffer<voxel::VarsBufferTag>,
+    ) -> Result<bool, CopyVarsError> {
+        // Copy vars (if present)
+        let vs = self.shape.inner().vars();
+        let mut changed = false;
+        if vs.has_free_vars() {
+            // If we have to change the vars buffer size, then clear the cached
+            // bind group.  TODO: only do this if we grow the buffer, since
+            // binding an overly-large buffer is fine?
+            let r = buf.grow_to_fit(&gpu.device, vs.len())?;
+            if !matches!(r, std::cmp::Ordering::Equal) {
+                changed = true;
+            }
+            let mut writer = gpu
+                .queue
+                .write_buffer_with(
+                    buf.data(),
+                    0,
+                    ((vars.len() * std::mem::size_of::<f32>()) as u64)
+                        .try_into()
+                        .unwrap(),
+                )
+                .unwrap();
+            for (v, i) in vs.iter() {
+                match v {
+                    Var::X | Var::Y | Var::Z => (),
+                    Var::V(vi) => {
+                        let Some(value) = vars.get(vi) else {
+                            return Err(MissingVar { var: vi }.into());
+                        };
+                        let offset = i * std::mem::size_of::<f32>();
+                        writer
+                            .slice(offset..offset + 4)
+                            .copy_from_slice(value.as_bytes());
+                    }
+                }
+            }
+        }
+        Ok(changed)
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+enum CopyVarsError {
+    #[error(transparent)]
+    BufferSize(#[from] buf::BufferSizeError),
+    #[error(transparent)]
+    MissingVar(#[from] MissingVar),
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/fidget-wgpu/src/lib.rs
+++ b/fidget-wgpu/src/lib.rs
@@ -182,14 +182,6 @@ impl Gpu {
         data.to_vec()
     }
 
-    /// Builds a new [`RenderShape`] object for the given shape
-    pub fn shape(
-        &self,
-        shape: &VmShape,
-    ) -> Result<RenderShape, RenderShapeError> {
-        RenderShape::new(shape, &self.device)
-    }
-
     /// Build a set of buffers for doing shape color evaluation
     pub fn color_buffers(
         &self,
@@ -339,25 +331,16 @@ impl RegPipeline {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-/// Shape for rendering
+/// Shape for rendering on the GPU
 ///
-/// This object is constructed by [`Gpu::shape`] and may only be used with
-/// that particular [`Gpu`].
+/// Note that this object does not allocate any memory on the GPU itself; it
+/// stores a bytecode-serialized version of the shape, which is copied to the
+/// GPU during rendering.
 pub struct RenderShape {
     /// Copy of our shape (kept around for access to the variable map)
     shape: VmShape,
     /// Serialized bytecode for the shape
     bytecode: Bytecode,
-    /// GPU buffer to contain variables
-    ///
-    /// This doesn't live in a `Buffers` object because it's dynamically sized
-    /// based on the shape; everything in `Buffers` is based on image size.
-    vars: wgpu::Buffer,
-    /// Lazily-constructed bind group for the vars array
-    ///
-    /// This is not cached in a buffer-specific `BindGroups` object because it
-    /// is shape-specific.
-    vars_bind_group: std::cell::OnceCell<wgpu::BindGroup>,
 }
 
 /// Error type when constructing a [`RenderShape`]
@@ -383,36 +366,17 @@ pub enum ShapeColorError {
 }
 
 impl RenderShape {
-    fn new(
-        shape: &VmShape,
-        device: &wgpu::Device,
-    ) -> Result<Self, RenderShapeError> {
+    /// Builds a new render shape
+    pub fn new(shape: &VmShape) -> Result<Self, RenderShapeError> {
         // Generate bytecode for the root tape
         let bytecode = Bytecode::new(shape.inner().data())?;
         if bytecode.len() / 2 > TAPE_DATA_CAPACITY {
             return Err(RenderShapeError::TooLong(bytecode.len() / 2));
         }
 
-        let vars = shape.inner().vars();
-
-        // Build a buffer for non-XYZ vars.  This buffer includes slots for XYZ
-        // as well, but we special-case them in evaluation.  If the tape has no
-        // variables, we'll allocate 4 bytes (because empty buffers are not
-        // allowed).
-        let vars = device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("vars"),
-            size: u64::try_from(std::mem::size_of::<f32>() * vars.len())
-                .unwrap()
-                .max(4),
-            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
-            mapped_at_creation: false,
-        });
-
         Ok(Self {
             shape: shape.clone(),
             bytecode,
-            vars,
-            vars_bind_group: Default::default(),
         })
     }
 
@@ -421,23 +385,6 @@ impl RenderShape {
         let vars = self.shape.inner().vars();
         [Var::X, Var::Y, Var::Z]
             .map(|a| vars.get(&a).map(|v| v as u32).unwrap_or(u32::MAX))
-    }
-
-    fn vars_bind_group(
-        &self,
-        device: &wgpu::Device,
-        layout: &wgpu::BindGroupLayout,
-    ) -> &wgpu::BindGroup {
-        self.vars_bind_group.get_or_init(|| {
-            device.create_bind_group(&wgpu::BindGroupDescriptor {
-                label: Some("vars bind group"),
-                layout,
-                entries: &[wgpu::BindGroupEntry {
-                    binding: 0,
-                    resource: self.vars.as_entire_binding(),
-                }],
-            })
-        })
     }
 }
 

--- a/fidget-wgpu/src/pixel/mod.rs
+++ b/fidget-wgpu/src/pixel/mod.rs
@@ -3,7 +3,8 @@
 //! See the [`voxel`](crate::voxel) module for details docs; this module is
 //! analogous (down to the naming of types).
 use crate::{
-    CopyVarsError, Gpu, RegPipeline, RenderShape, TAPE_DATA_CAPACITY, TapeWord,
+    CopyVarsChanged, CopyVarsError, Gpu, RegPipeline, RenderShape,
+    TAPE_DATA_CAPACITY, TapeWord,
     buf::{
         BufferSizeError, BufferType, FlexBuffer, ReadBuffer, buffer_ro,
         buffer_rw,
@@ -1149,7 +1150,10 @@ impl Context {
 
         // Copy vars (if present), then reset relevant bind groups if the buffer
         // size has changed.
-        if shape.copy_vars(&self.gpu, vars, &mut buffers.vars_buf)? {
+        if matches!(
+            shape.copy_vars(&self.gpu, vars, &mut buffers.vars_buf)?,
+            CopyVarsChanged::BufferChanged
+        ) {
             buffers.bind_groups.common = Default::default();
         }
 

--- a/fidget-wgpu/src/pixel/mod.rs
+++ b/fidget-wgpu/src/pixel/mod.rs
@@ -3,7 +3,7 @@
 //! See the [`voxel`](crate::voxel) module for details docs; this module is
 //! analogous (down to the naming of types).
 use crate::{
-    Gpu, RegPipeline, RenderShape, TAPE_DATA_CAPACITY, TapeWord,
+    CopyVarsError, Gpu, RegPipeline, RenderShape, TAPE_DATA_CAPACITY, TapeWord,
     buf::{
         BufferSizeError, BufferType, FlexBuffer, ReadBuffer, buffer_ro,
         buffer_rw,
@@ -12,10 +12,8 @@ use crate::{
     voxel::VarsBufferTag,
 };
 use fidget_core::{
-    eval::Function,
     render::ImageSize,
     shape::{MissingVar, ShapeVars},
-    var::Var,
 };
 use fidget_raster::pixel::{Image, RawDistancePixel};
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
@@ -665,6 +663,18 @@ pub enum SubmitError {
     Buffers(#[from] BuffersError),
 }
 
+impl From<CopyVarsError> for SubmitError {
+    fn from(value: CopyVarsError) -> Self {
+        match value {
+            CopyVarsError::MissingVar(v) => Self::MissingVar(v),
+            CopyVarsError::BufferSize(err) => Self::Buffers(BuffersError {
+                buf: BufferName::Vars,
+                err,
+            }),
+        }
+    }
+}
+
 /// Cached bind groups (constructed on-demand)
 #[derive(Default)]
 struct BindGroups {
@@ -1137,49 +1147,10 @@ impl Context {
                 .copy_from_slice(shape.bytecode.as_bytes());
         }
 
-        // Copy vars (if present)
-        let vs = shape.shape.inner().vars();
-        if vs.has_free_vars() {
-            // If we have to change the vars buffer size, then clear the cached
-            // bind group.  TODO: only do this if we grow the buffer, since
-            // binding an overly-large buffer is fine?
-            let r = buffers
-                .vars_buf
-                .grow_to_fit(&self.gpu.device, vs.len())
-                .map_err(|err| {
-                    SubmitError::Buffers(BuffersError {
-                        buf: BufferName::Vars,
-                        err,
-                    })
-                })?;
-            if !matches!(r, std::cmp::Ordering::Equal) {
-                buffers.bind_groups.common = Default::default();
-            }
-            let mut writer = self
-                .gpu
-                .queue
-                .write_buffer_with(
-                    buffers.vars_buf.data(),
-                    0,
-                    ((vars.len() * std::mem::size_of::<f32>()) as u64)
-                        .try_into()
-                        .unwrap(),
-                )
-                .unwrap();
-            for (v, i) in shape.shape.inner().vars().iter() {
-                match v {
-                    Var::X | Var::Y | Var::Z => (),
-                    Var::V(vi) => {
-                        let Some(value) = vars.get(vi) else {
-                            return Err(MissingVar { var: vi }.into());
-                        };
-                        let offset = i * std::mem::size_of::<f32>();
-                        writer
-                            .slice(offset..offset + 4)
-                            .copy_from_slice(value.as_bytes());
-                    }
-                }
-            }
+        // Copy vars (if present), then reset relevant bind groups if the buffer
+        // size has changed.
+        if shape.copy_vars(&self.gpu, vars, &mut buffers.vars_buf)? {
+            buffers.bind_groups.common = Default::default();
         }
 
         // Create a command encoder and dispatch the compute work

--- a/fidget-wgpu/src/pixel/mod.rs
+++ b/fidget-wgpu/src/pixel/mod.rs
@@ -9,6 +9,7 @@ use crate::{
         buffer_rw,
     },
     shaders, tag,
+    voxel::VarsBufferTag,
 };
 use fidget_core::{
     eval::Function,
@@ -17,7 +18,6 @@ use fidget_core::{
     var::Var,
 };
 use fidget_raster::pixel::{Image, RawDistancePixel};
-use std::num::NonZeroU64;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 pub use fidget_raster::pixel::{RenderConfig, RenderSize};
@@ -143,7 +143,6 @@ impl RootContext {
     fn new(
         device: &wgpu::Device,
         common_bind_group_layout: &wgpu::BindGroupLayout,
-        vars_bind_group_layout: &wgpu::BindGroupLayout,
     ) -> Self {
         // Create bind group layout and bind group
         let bind_group_layout =
@@ -159,7 +158,6 @@ impl RootContext {
                 label: None,
                 bind_group_layouts: &[
                     Some(common_bind_group_layout),
-                    Some(vars_bind_group_layout),
                     Some(&bind_group_layout),
                 ],
                 immediate_size: 0u32,
@@ -198,7 +196,7 @@ impl RootContext {
     ) {
         let bind_group = buffers.bind_groups.root_tiles(ctx, buffers);
         compute_pass.set_pipeline(self.root_pipeline.get(reg_count));
-        compute_pass.set_bind_group(2, bind_group, &[]);
+        compute_pass.set_bind_group(1, bind_group, &[]);
 
         // Workgroup is 8x8x8, so we divide by 8 here on each axis
         let nx = render_size.nx().div_ceil(8);
@@ -221,7 +219,6 @@ impl IntervalTilesContext {
     fn new(
         device: &wgpu::Device,
         common_bind_group_layout: &wgpu::BindGroupLayout,
-        vars_bind_group_layout: &wgpu::BindGroupLayout,
     ) -> Self {
         // Create bind group layout and bind group
         let bind_group_layout =
@@ -238,7 +235,6 @@ impl IntervalTilesContext {
                 label: None,
                 bind_group_layouts: &[
                     Some(common_bind_group_layout),
-                    Some(vars_bind_group_layout),
                     Some(&bind_group_layout),
                 ],
                 immediate_size: 0u32,
@@ -276,7 +272,7 @@ impl IntervalTilesContext {
     ) {
         let bind_group = buffers.bind_groups.interval_tiles(ctx, buffers);
         compute_pass.set_pipeline(self.tiles_pipeline.get(reg_count));
-        compute_pass.set_bind_group(2, bind_group, &[]);
+        compute_pass.set_bind_group(1, bind_group, &[]);
 
         // Indirect dispatch based on previous tile output
         compute_pass
@@ -299,7 +295,6 @@ impl PixelTilesContext {
     fn new(
         device: &wgpu::Device,
         common_bind_group_layout: &wgpu::BindGroupLayout,
-        vars_bind_group_layout: &wgpu::BindGroupLayout,
     ) -> Self {
         // Create bind group layout and bind group
         let bind_group_layout =
@@ -315,7 +310,6 @@ impl PixelTilesContext {
                 label: None,
                 bind_group_layouts: &[
                     Some(common_bind_group_layout),
-                    Some(vars_bind_group_layout),
                     Some(&bind_group_layout),
                 ],
                 immediate_size: 0u32,
@@ -353,7 +347,7 @@ impl PixelTilesContext {
     ) {
         let bind_group = buffers.bind_groups.pixel_tiles(ctx, buffers);
         compute_pass.set_pipeline(self.tiles_pipeline.get(reg_count));
-        compute_pass.set_bind_group(2, bind_group, &[]);
+        compute_pass.set_bind_group(1, bind_group, &[]);
 
         // Indirect dispatch based on previous tile output
         compute_pass
@@ -423,6 +417,9 @@ pub struct Buffers {
     /// Config and tape data buffer (constant size)
     config_buf: wgpu::Buffer,
 
+    /// Scratch space to upload variable values
+    vars_buf: FlexBuffer<VarsBufferTag>,
+
     /// Map from tile to the relevant tape (as a start index)
     tile_tapes: FlexBuffer<TileTapesBufferTag>,
 
@@ -477,9 +474,11 @@ impl Buffers {
 
         let tile64 = TileBuffers::new(device, render_size).unwrap();
         let tile8 = TileBuffers::new(device, render_size).unwrap();
+        let vars_buf = FlexBuffer::new(device, "vars".to_string(), 4).unwrap();
 
         Self {
             config_buf,
+            vars_buf,
             image_size,
             tile_tapes,
             tile64,
@@ -525,6 +524,7 @@ impl Buffers {
             tile64,
             tile8,
             config_buf: _,
+            vars_buf: _,
             pixels,
             bind_groups,
         } = self;
@@ -566,6 +566,7 @@ impl Buffers {
         let Buffers {
             image_size: _,
             config_buf,
+            vars_buf,
             tile_tapes,
             tile64,
             tile8,
@@ -573,6 +574,7 @@ impl Buffers {
             bind_groups: _,
         } = self;
         config_buf.size()
+            + vars_buf.capacity()
             + tile_tapes.capacity()
             + tile64.capacity()
             + tile8.capacity()
@@ -584,6 +586,7 @@ impl Buffers {
         // Destructure to make sure we take all members into account
         let Buffers {
             image_size: _,
+            vars_buf,
             config_buf,
             tile_tapes,
             tile64,
@@ -592,6 +595,7 @@ impl Buffers {
             bind_groups: _,
         } = self;
         config_buf.size()
+            + vars_buf.size_bytes()
             + tile_tapes.size_bytes()
             + tile64.size()
             + tile8.size()
@@ -633,6 +637,8 @@ pub enum BufferName {
     Pixel,
     /// CPU-mappable image pixels (as [`RawDistancePixel`] values)
     Image,
+    /// Variables
+    Vars,
 }
 
 impl std::fmt::Display for BufferName {
@@ -643,6 +649,7 @@ impl std::fmt::Display for BufferName {
             BufferName::TileTapes => write!(f, "`tile tapes`"),
             BufferName::Pixel => write!(f, "`pixel`"),
             BufferName::Image => write!(f, "`image`"),
+            BufferName::Vars => write!(f, "`vars`"),
         }
     }
 }
@@ -684,6 +691,10 @@ impl BindGroups {
                         wgpu::BindGroupEntry {
                             binding: 1,
                             resource: buffers.tile_tapes.bind_active(),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 2,
+                            resource: buffers.vars_buf.bind_active(),
                         },
                     ],
                 })
@@ -928,9 +939,6 @@ pub struct Context {
     /// Bind group layout for the common bind group (used by all stages)
     common_bind_group_layout: wgpu::BindGroupLayout,
 
-    /// Bind group layout for the vars bind group (also by all stages)
-    vars_bind_group_layout: wgpu::BindGroupLayout,
-
     /// Context for root tile evaluation (64²)
     root_ctx: RootContext,
 
@@ -960,43 +968,21 @@ impl Context {
                 entries: &[
                     buffer_rw(0), // config (including tape buffer)
                     buffer_rw(1), // tile_tape (hierarchical)
+                    buffer_ro(2), // vars
                 ],
             },
         );
-        let vars_bind_group_layout = gpu.device.create_bind_group_layout(
-            &wgpu::BindGroupLayoutDescriptor {
-                label: Some("vars bind group layout"),
-                entries: &[
-                    buffer_ro(0), // vars
-                ],
-            },
-        );
-
-        let root_ctx = RootContext::new(
-            &gpu.device,
-            &common_bind_group_layout,
-            &vars_bind_group_layout,
-        );
-        let tiles_ctx = IntervalTilesContext::new(
-            &gpu.device,
-            &common_bind_group_layout,
-            &vars_bind_group_layout,
-        );
-        let pixels_ctx = PixelTilesContext::new(
-            &gpu.device,
-            &common_bind_group_layout,
-            &vars_bind_group_layout,
-        );
-        let merge_ctx = MergeContext::new(
-            &gpu.device,
-            &common_bind_group_layout,
-            &vars_bind_group_layout,
-        );
+        let root_ctx = RootContext::new(&gpu.device, &common_bind_group_layout);
+        let tiles_ctx =
+            IntervalTilesContext::new(&gpu.device, &common_bind_group_layout);
+        let pixels_ctx =
+            PixelTilesContext::new(&gpu.device, &common_bind_group_layout);
+        let merge_ctx =
+            MergeContext::new(&gpu.device, &common_bind_group_layout);
 
         Self {
             gpu: gpu.clone(),
             common_bind_group_layout,
-            vars_bind_group_layout,
             root_ctx,
             tiles_ctx,
             pixels_ctx,
@@ -1152,11 +1138,33 @@ impl Context {
         }
 
         // Copy vars (if present)
-        if let Some(var_size) = NonZeroU64::new(shape.vars.size()) {
+        let vs = shape.shape.inner().vars();
+        if vs.has_free_vars() {
+            // If we have to change the vars buffer size, then clear the cached
+            // bind group.  TODO: only do this if we grow the buffer, since
+            // binding an overly-large buffer is fine?
+            let r = buffers
+                .vars_buf
+                .grow_to_fit(&self.gpu.device, vs.len())
+                .map_err(|err| {
+                    SubmitError::Buffers(BuffersError {
+                        buf: BufferName::Vars,
+                        err,
+                    })
+                })?;
+            if !matches!(r, std::cmp::Ordering::Equal) {
+                buffers.bind_groups.common = Default::default();
+            }
             let mut writer = self
                 .gpu
                 .queue
-                .write_buffer_with(&shape.vars, 0, var_size)
+                .write_buffer_with(
+                    buffers.vars_buf.data(),
+                    0,
+                    ((vars.len() * std::mem::size_of::<f32>()) as u64)
+                        .try_into()
+                        .unwrap(),
+                )
                 .unwrap();
             for (v, i) in shape.shape.inner().vars().iter() {
                 match v {
@@ -1191,9 +1199,6 @@ impl Context {
         // Build the common config buffer
         let common_bind_group = buffers.bind_groups.common(self, buffers);
         compute_pass.set_bind_group(0, common_bind_group, &[]);
-        let vars_bind_group = shape
-            .vars_bind_group(&self.gpu.device, &self.vars_bind_group_layout);
-        compute_pass.set_bind_group(1, vars_bind_group, &[]);
 
         // Populate root tiles (64x64x64, densely packed)
         self.root_ctx.run(
@@ -1242,7 +1247,6 @@ impl MergeContext {
     fn new(
         device: &wgpu::Device,
         common_bind_group_layout: &wgpu::BindGroupLayout,
-        vars_bind_group_layout: &wgpu::BindGroupLayout,
     ) -> Self {
         let shader_code = merge_shader();
 
@@ -1263,7 +1267,6 @@ impl MergeContext {
                 label: Some("merge pipeline layout"),
                 bind_group_layouts: &[
                     Some(common_bind_group_layout),
-                    Some(vars_bind_group_layout),
                     Some(&bind_group_layout),
                 ],
                 immediate_size: 0u32,
@@ -1301,7 +1304,7 @@ impl MergeContext {
     ) {
         let bind_group = buffers.bind_groups.merge(ctx, buffers);
         compute_pass.set_pipeline(&self.pipeline);
-        compute_pass.set_bind_group(2, bind_group, &[]);
+        compute_pass.set_bind_group(1, bind_group, &[]);
         compute_pass.dispatch_workgroups(
             render_size.width().div_ceil(8),
             render_size.height().div_ceil(8),
@@ -1375,7 +1378,8 @@ mod test {
 
         // Render and accumulate each shape
         for (shape, _) in shapes {
-            let shape = gpu.shape(&VmShape::from(shape.clone())).unwrap();
+            let shape =
+                RenderShape::new(&VmShape::from(shape.clone())).unwrap();
             pixel_ctx.submit(&shape, &mut buf, &render_config).unwrap();
             effects_ctx
                 .submit_merge(buf.output(), true, &mut merge_buf)

--- a/fidget-wgpu/src/pixel/shaders/common.wgsl
+++ b/fidget-wgpu/src/pixel/shaders/common.wgsl
@@ -45,7 +45,7 @@ struct Config {
 @group(0) @binding(1) var<storage, read_write> tile_tape: array<u32>;
 
 /// Array of values for (non-xyz) variables
-@group(1) @binding(0) var<storage, read> var_values: array<f32>;
+@group(0) @binding(2) var<storage, read> var_values: array<f32>;
 
 /// For a given position and recursion level, return the offset into `tile_tape`
 fn get_tape_offset_for_level(corner_pos: vec2u, level: u32) -> u32 {

--- a/fidget-wgpu/src/pixel/shaders/interval_root.wgsl
+++ b/fidget-wgpu/src/pixel/shaders/interval_root.wgsl
@@ -1,7 +1,6 @@
 // Interval root tile evaluation
-
-@group(2) @binding(0) var<storage, read_write> tiles_out: TileListOutput;
-@group(2) @binding(1) var<storage, read_write> tile_values: array<RawDistancePixel>;
+@group(1) @binding(0) var<storage, read_write> tiles_out: TileListOutput;
+@group(1) @binding(1) var<storage, read_write> tile_values: array<RawDistancePixel>;
 
 /// Root tile size
 const TILE_SIZE: u32 = 64;

--- a/fidget-wgpu/src/pixel/shaders/interval_tiles.wgsl
+++ b/fidget-wgpu/src/pixel/shaders/interval_tiles.wgsl
@@ -1,10 +1,10 @@
 // Interval evaluation stage for pixel rasterization
 
 /// Per-state IO bindings
-@group(2) @binding(0) var<storage, read> tiles_in: TileListInput;
+@group(1) @binding(0) var<storage, read> tiles_in: TileListInput;
 
-@group(2) @binding(1) var<storage, read_write> subtiles_out: TileListOutput;
-@group(2) @binding(2) var<storage, read_write> subtile_values: array<RawDistancePixel>;
+@group(1) @binding(1) var<storage, read_write> subtiles_out: TileListOutput;
+@group(1) @binding(2) var<storage, read_write> subtile_values: array<RawDistancePixel>;
 
 /// Input tile size; one input tile maps to a 8x8 workgroup
 const TILE_SIZE: u32 = 64;

--- a/fidget-wgpu/src/pixel/shaders/merge.wgsl
+++ b/fidget-wgpu/src/pixel/shaders/merge.wgsl
@@ -1,7 +1,7 @@
 /// Merge all tile stages into a pixel array
-@group(2) @binding(0) var<storage, read> tile64_values: array<RawDistancePixel>;
-@group(2) @binding(1) var<storage, read> tile8_values: array<RawDistancePixel>;
-@group(2) @binding(2) var<storage, read_write> pixels: array<RawDistancePixel>;
+@group(1) @binding(0) var<storage, read> tile64_values: array<RawDistancePixel>;
+@group(1) @binding(1) var<storage, read> tile8_values: array<RawDistancePixel>;
+@group(1) @binding(2) var<storage, read_write> pixels: array<RawDistancePixel>;
 
 // Dispatched as an 2D workgroup across render_size pixels
 @compute @workgroup_size(8, 8)

--- a/fidget-wgpu/src/pixel/shaders/pixel_tiles.wgsl
+++ b/fidget-wgpu/src/pixel/shaders/pixel_tiles.wgsl
@@ -1,8 +1,8 @@
 // VM interpreter for floating-point values, using voxel tiles
-@group(2) @binding(0) var<storage, read> tiles_in: TileListInput;
+@group(1) @binding(0) var<storage, read> tiles_in: TileListInput;
 
 /// Output array, as an image size (*not* rounded up)
-@group(2) @binding(1) var<storage, read_write> result: array<RawDistancePixel>;
+@group(1) @binding(1) var<storage, read_write> result: array<RawDistancePixel>;
 
 @compute @workgroup_size(8, 8)
 fn pixel_tiles_main(

--- a/fidget-wgpu/src/voxel/effects/mod.rs
+++ b/fidget-wgpu/src/voxel/effects/mod.rs
@@ -1346,6 +1346,7 @@ impl ColorContext {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::RenderShape;
     use fidget_core::{context::Tree, vm::VmShape};
     use fidget_raster::voxel::RenderSize;
 
@@ -1411,7 +1412,7 @@ mod test {
         let sphere =
             (x.square() + y.square() + z.square()).sqrt() - Tree::constant(0.5);
         let vm_shape = VmShape::from(sphere.min(z));
-        let shape = gpu.shape(&vm_shape).unwrap();
+        let shape = RenderShape::new(&vm_shape).unwrap();
 
         voxel_ctx
             .submit(

--- a/fidget-wgpu/src/voxel/mod.rs
+++ b/fidget-wgpu/src/voxel/mod.rs
@@ -97,7 +97,7 @@
 //! buffer.
 
 use crate::{
-    Gpu, RegPipeline, RenderShape, TAPE_DATA_CAPACITY, TapeWord,
+    CopyVarsError, Gpu, RegPipeline, RenderShape, TAPE_DATA_CAPACITY, TapeWord,
     buf::{
         BufferSizeError, BufferType, FlexBuffer, ReadBuffer, buffer_ro,
         buffer_ro_dyn, buffer_rw,
@@ -105,10 +105,8 @@ use crate::{
     shaders, tag,
 };
 use fidget_core::{
-    eval::Function,
     render::{ImageSize, VoxelSize},
     shape::{MissingVar, ShapeVars},
-    var::Var,
 };
 use fidget_raster::voxel::{GeometryPixel, Image};
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
@@ -249,6 +247,18 @@ pub enum SubmitError {
     /// Error while resizing buffers
     #[error(transparent)]
     Buffers(#[from] BuffersError),
+}
+
+impl From<CopyVarsError> for SubmitError {
+    fn from(value: CopyVarsError) -> Self {
+        match value {
+            CopyVarsError::MissingVar(v) => Self::MissingVar(v),
+            CopyVarsError::BufferSize(err) => Self::Buffers(BuffersError {
+                buf: BufferName::Vars,
+                err,
+            }),
+        }
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2131,49 +2141,10 @@ impl Context {
                 .copy_from_slice(shape.bytecode.as_bytes());
         }
 
-        // Copy vars (if present)
-        let vs = shape.shape.inner().vars();
-        if vs.has_free_vars() {
-            // If we have to change the vars buffer size, then clear the cached
-            // bind group.  TODO: only do this if we grow the buffer, since
-            // binding an overly-large buffer is fine?
-            let r = buffers
-                .vars_buf
-                .grow_to_fit(&self.gpu.device, vs.len())
-                .map_err(|err| {
-                    SubmitError::Buffers(BuffersError {
-                        buf: BufferName::Vars,
-                        err,
-                    })
-                })?;
-            if !matches!(r, std::cmp::Ordering::Equal) {
-                buffers.bind_groups.common = Default::default();
-            }
-            let mut writer = self
-                .gpu
-                .queue
-                .write_buffer_with(
-                    buffers.vars_buf.data(),
-                    0,
-                    ((vars.len() * std::mem::size_of::<f32>()) as u64)
-                        .try_into()
-                        .unwrap(),
-                )
-                .unwrap();
-            for (v, i) in shape.shape.inner().vars().iter() {
-                match v {
-                    Var::X | Var::Y | Var::Z => (),
-                    Var::V(vi) => {
-                        let Some(value) = vars.get(vi) else {
-                            return Err(MissingVar { var: vi }.into());
-                        };
-                        let offset = i * std::mem::size_of::<f32>();
-                        writer
-                            .slice(offset..offset + 4)
-                            .copy_from_slice(value.as_bytes());
-                    }
-                }
-            }
+        // Copy vars (if present), then reset relevant bind groups if the buffer
+        // size has changed.
+        if shape.copy_vars(&self.gpu, vars, &mut buffers.vars_buf)? {
+            buffers.bind_groups.common = Default::default();
         }
 
         // Create a command encoder and dispatch the compute work

--- a/fidget-wgpu/src/voxel/mod.rs
+++ b/fidget-wgpu/src/voxel/mod.rs
@@ -66,8 +66,8 @@
 //!
 //! With all that out of the way, usage is pretty simple:
 //! - Build a [`Context`]
-//! - Use [`Gpu::shape`] to convert from a [`VmShape`](fidget_core::vm::VmShape)
-//!   to a [`RenderShape`]
+//! - Use [`RenderShape::new`] to convert from a
+//!   [`VmShape`](fidget_core::vm::VmShape) to a [`RenderShape`]
 //! - Use [`Context::buffers`] to get [`Buffers`] at a particular image size
 //! - Use [`Gpu::read_buffer_for(buffers.output())`](Gpu::read_buffer_for) to
 //!   get an output buffer
@@ -461,7 +461,7 @@ impl RootContext {
         // Create bind group layout and bind group
         let bind_group_layout =
             device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-                label: Some("common"),
+                label: Some("root"),
                 entries: &[
                     buffer_rw(0), // tiles_out
                     buffer_rw(1), // tile64_zmax

--- a/fidget-wgpu/src/voxel/mod.rs
+++ b/fidget-wgpu/src/voxel/mod.rs
@@ -111,7 +111,6 @@ use fidget_core::{
     var::Var,
 };
 use fidget_raster::voxel::{GeometryPixel, Image};
-use std::num::NonZeroU64;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 pub mod effects;
@@ -211,6 +210,7 @@ pub enum BufferName {
     Heightmap,
     Geom,
     Image,
+    Vars,
 }
 
 impl std::fmt::Display for BufferName {
@@ -224,6 +224,7 @@ impl std::fmt::Display for BufferName {
             BufferName::Heightmap => write!(f, "`heightmap`"),
             BufferName::Geom => write!(f, "`geom`"),
             BufferName::Image => write!(f, "`image`"),
+            BufferName::Vars => write!(f, "`vars`"),
         }
     }
 }
@@ -446,12 +447,11 @@ impl RootContext {
     fn new(
         device: &wgpu::Device,
         common_bind_group_layout: &wgpu::BindGroupLayout,
-        vars_bind_group_layout: &wgpu::BindGroupLayout,
     ) -> Self {
         // Create bind group layout and bind group
         let bind_group_layout =
             device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-                label: None,
+                label: Some("common"),
                 entries: &[
                     buffer_rw(0), // tiles_out
                     buffer_rw(1), // tile64_zmax
@@ -460,10 +460,9 @@ impl RootContext {
 
         let pipeline_layout =
             device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-                label: None,
+                label: Some("root pipeline"),
                 bind_group_layouts: &[
                     Some(common_bind_group_layout),
-                    Some(vars_bind_group_layout),
                     Some(&bind_group_layout),
                 ],
                 immediate_size: 0u32,
@@ -472,7 +471,7 @@ impl RootContext {
             let shader_code = interval_root_shader(reg_count);
             let shader_module =
                 device.create_shader_module(wgpu::ShaderModuleDescriptor {
-                    label: None,
+                    label: Some("interval root"),
                     source: wgpu::ShaderSource::Wgsl(shader_code.into()),
                 });
             device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
@@ -501,7 +500,7 @@ impl RootContext {
     ) {
         let bind_group = buffers.bind_groups.root(ctx, buffers);
         compute_pass.set_pipeline(self.root_pipeline.get(reg_count));
-        compute_pass.set_bind_group(2, bind_group, &[]);
+        compute_pass.set_bind_group(1, bind_group, &[]);
 
         // Workgroup is 4x4x4, so we divide by 4 here on each axis
         let nx = render_size.nx().div_ceil(4);
@@ -524,12 +523,11 @@ impl RepackContext {
     fn new(
         device: &wgpu::Device,
         common_bind_group_layout: &wgpu::BindGroupLayout,
-        vars_bind_group_layout: &wgpu::BindGroupLayout,
     ) -> Self {
         // Create bind group layout and bind group
         let bind_group_layout =
             device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-                label: None,
+                label: Some("repack"),
                 entries: &[
                     buffer_ro(0), // tiles_out
                     buffer_ro(1), // tile64_zmin
@@ -541,10 +539,9 @@ impl RepackContext {
             let shader_code = repack_shader();
             let pipeline_layout = device.create_pipeline_layout(
                 &wgpu::PipelineLayoutDescriptor {
-                    label: None,
+                    label: Some("repack"),
                     bind_group_layouts: &[
                         Some(common_bind_group_layout),
-                        Some(vars_bind_group_layout),
                         Some(&bind_group_layout),
                     ],
                     immediate_size: 0u32,
@@ -552,7 +549,7 @@ impl RepackContext {
             );
             let shader_module =
                 device.create_shader_module(wgpu::ShaderModuleDescriptor {
-                    label: None,
+                    label: Some("repack"),
                     source: wgpu::ShaderSource::Wgsl(shader_code.into()),
                 });
             device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
@@ -581,7 +578,7 @@ impl RepackContext {
         let bind_group = buffers.bind_groups.repack(ctx, buffers);
 
         compute_pass.set_pipeline(&self.repack_pipeline);
-        compute_pass.set_bind_group(2, bind_group, &[]);
+        compute_pass.set_bind_group(1, bind_group, &[]);
 
         // Workgroup is 64x1x1, so we divide on the X axis.  It doesn't matter
         // much; we just need one thread per possible output tile from the
@@ -620,12 +617,11 @@ impl IntervalContext {
     fn new(
         device: &wgpu::Device,
         common_bind_group_layout: &wgpu::BindGroupLayout,
-        vars_bind_group_layout: &wgpu::BindGroupLayout,
     ) -> Self {
         // Create bind group layout and bind group
         let interval_bind_group_layout =
             device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-                label: None,
+                label: Some("interval"),
                 entries: &[
                     buffer_ro_dyn(0), // tiles_in
                     buffer_ro(1),     // tile_zmin
@@ -640,7 +636,6 @@ impl IntervalContext {
                 label: Some("interval pipeline layout"),
                 bind_group_layouts: &[
                     Some(common_bind_group_layout),
-                    Some(vars_bind_group_layout),
                     Some(&interval_bind_group_layout),
                 ],
                 immediate_size: 0u32,
@@ -726,7 +721,6 @@ impl IntervalContext {
                 label: Some("sort pipeline layout"),
                 bind_group_layouts: &[
                     Some(common_bind_group_layout),
-                    Some(vars_bind_group_layout),
                     Some(&sort_bind_group_layout),
                 ],
                 immediate_size: 0u32,
@@ -797,7 +791,7 @@ impl IntervalContext {
         let bind_group16 = buffers.bind_groups.interval16(ctx, buffers);
         compute_pass.set_pipeline(self.interval64_pipeline.get(reg_count));
         compute_pass.set_bind_group(
-            2,
+            1,
             bind_group16,
             &[u32::try_from(offset_bytes).unwrap()],
         );
@@ -808,19 +802,19 @@ impl IntervalContext {
 
         let bind_group_sort16 = buffers.bind_groups.sort16(ctx, buffers);
         compute_pass.set_pipeline(&self.sort16_pipeline);
-        compute_pass.set_bind_group(2, bind_group_sort16, &[]);
+        compute_pass.set_bind_group(1, bind_group_sort16, &[]);
         compute_pass
             .dispatch_workgroups_indirect(buffers.tile16.tiles.data(), 0);
 
         let bind_group4 = buffers.bind_groups.interval4(ctx, buffers);
         compute_pass.set_pipeline(self.interval16_pipeline.get(reg_count));
-        compute_pass.set_bind_group(2, bind_group4, &[0]);
+        compute_pass.set_bind_group(1, bind_group4, &[0]);
         compute_pass
             .dispatch_workgroups_indirect(buffers.tile16.sorted.data(), 0);
 
         let bind_group_sort4 = buffers.bind_groups.sort4(ctx, buffers);
         compute_pass.set_pipeline(&self.sort4_pipeline);
-        compute_pass.set_bind_group(2, bind_group_sort4, &[]);
+        compute_pass.set_bind_group(1, bind_group_sort4, &[]);
         compute_pass
             .dispatch_workgroups_indirect(buffers.tile4.tiles.data(), 0);
     }
@@ -840,7 +834,6 @@ impl VoxelContext {
     fn new(
         device: &wgpu::Device,
         common_bind_group_layout: &wgpu::BindGroupLayout,
-        vars_bind_group_layout: &wgpu::BindGroupLayout,
     ) -> Self {
         // Create bind group layout and bind group
         let bind_group_layout =
@@ -858,7 +851,6 @@ impl VoxelContext {
                 label: Some("voxel pipeline layout"),
                 bind_group_layouts: &[
                     Some(common_bind_group_layout),
-                    Some(vars_bind_group_layout),
                     Some(&bind_group_layout),
                 ],
                 immediate_size: 0u32,
@@ -906,7 +898,7 @@ impl VoxelContext {
     ) {
         let bind_group = buffers.bind_groups.voxel(ctx, buffers);
         compute_pass.set_pipeline(self.voxel_pipeline.get(reg_count));
-        compute_pass.set_bind_group(2, bind_group, &[]);
+        compute_pass.set_bind_group(1, bind_group, &[]);
 
         // Each workgroup is 4x4x4, i.e. covering a 4x4 splat of pixels with 4x
         // workers in the Z direction.
@@ -927,7 +919,6 @@ impl NormalsContext {
     fn new(
         device: &wgpu::Device,
         common_bind_group_layout: &wgpu::BindGroupLayout,
-        vars_bind_group_layout: &wgpu::BindGroupLayout,
     ) -> Self {
         // Create bind group layout and bind group
         let bind_group_layout =
@@ -944,7 +935,6 @@ impl NormalsContext {
                 label: Some("normals pipeline"),
                 bind_group_layouts: &[
                     Some(common_bind_group_layout),
-                    Some(vars_bind_group_layout),
                     Some(&bind_group_layout),
                 ],
                 immediate_size: 0u32,
@@ -981,7 +971,7 @@ impl NormalsContext {
     ) {
         let bind_group = buffers.bind_groups.normals(ctx, buffers);
         compute_pass.set_pipeline(self.normals_pipeline.get(reg_count));
-        compute_pass.set_bind_group(2, bind_group, &[]);
+        compute_pass.set_bind_group(1, bind_group, &[]);
 
         compute_pass.dispatch_workgroups(
             buffers.image_size.width().div_ceil(8),
@@ -999,9 +989,6 @@ pub struct Context {
 
     /// Bind group layout for the common bind group (used by all stages)
     common_bind_group_layout: wgpu::BindGroupLayout,
-
-    /// Bind group layout for the vars bind group (also by all stages)
-    vars_bind_group_layout: wgpu::BindGroupLayout,
 
     root_ctx: RootContext,
     repack_ctx: RepackContext,
@@ -1299,6 +1286,7 @@ tag!(TileTapesBufferTag, u32, usize, STORAGE | COPY_DST);
 tag!(VoxelsBufferTag, u32, VoxelSize, STORAGE | COPY_DST);
 tag!(pub GeomBufferTag, GeometryPixel, VoxelSize, STORAGE | COPY_SRC | COPY_DST,
     "Tag for a on-GPU buffer storing [`GeometryPixel`] values");
+tag!(pub(crate) VarsBufferTag, f32, usize, STORAGE | COPY_DST);
 
 /// Buffers for rendering
 ///
@@ -1313,6 +1301,9 @@ pub struct Buffers {
 
     /// Config and tape data buffer (constant size)
     config_buf: wgpu::Buffer,
+
+    /// Scratch space to upload variable values
+    vars_buf: FlexBuffer<VarsBufferTag>,
 
     /// Buffer for z histogram counters
     ///
@@ -1379,6 +1370,10 @@ impl BindGroups {
                         wgpu::BindGroupEntry {
                             binding: 1,
                             resource: buffers.tile_tapes.bind_active(),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 2,
+                            resource: buffers.vars_buf.bind_active(),
                         },
                     ],
                 })
@@ -1748,6 +1743,8 @@ impl Buffers {
             mapped_at_creation: false,
         });
 
+        let vars_buf = FlexBuffer::new(device, "vars".to_string(), 4).unwrap();
+
         Self {
             config_buf,
             image_size,
@@ -1757,6 +1754,7 @@ impl Buffers {
             tile4,
             voxels,
             geom,
+            vars_buf,
             z_hist_buf,
             bind_groups: Default::default(),
         }
@@ -1830,6 +1828,7 @@ impl Buffers {
             image_size: image_size_ref,
             config_buf: _,
             z_hist_buf: _,
+            vars_buf: _,
             tile_tapes,
             tile64,
             tile16,
@@ -1840,6 +1839,8 @@ impl Buffers {
         } = self;
         // Clear our cached bind groups if the image sizes is changing
         if *image_size_ref != image_size {
+            // TODO this also clears the common bind group, which isn't
+            // necessary (since it's not size-dependent)
             *bind_groups = Default::default();
         }
         *image_size_ref = image_size;
@@ -1890,6 +1891,7 @@ impl Buffers {
             config_buf,
             z_hist_buf,
             tile_tapes,
+            vars_buf,
             tile64,
             tile16,
             tile4,
@@ -1898,6 +1900,7 @@ impl Buffers {
             bind_groups: _,
         } = self;
         config_buf.size()
+            + vars_buf.capacity()
             + z_hist_buf.size()
             + tile_tapes.capacity()
             + tile64.capacity()
@@ -1913,6 +1916,7 @@ impl Buffers {
         let Buffers {
             image_size: _,
             config_buf,
+            vars_buf,
             z_hist_buf,
             tile_tapes,
             tile64,
@@ -1923,6 +1927,7 @@ impl Buffers {
             bind_groups: _,
         } = self;
         config_buf.size()
+            + vars_buf.size_bytes()
             + z_hist_buf.size()
             + tile_tapes.size_bytes()
             + tile64.size()
@@ -1943,59 +1948,29 @@ impl Context {
                 entries: &[
                     buffer_rw(0), // config (including tape buffer)
                     buffer_rw(1), // tile_tape (hierarchical)
-                ],
-            },
-        );
-        let vars_bind_group_layout = gpu.device.create_bind_group_layout(
-            &wgpu::BindGroupLayoutDescriptor {
-                label: Some("vars bind group layout"),
-                entries: &[
-                    buffer_ro(0), // vars
+                    buffer_ro(2), // vars
                 ],
             },
         );
 
-        let root_ctx = RootContext::new(
-            &gpu.device,
-            &common_bind_group_layout,
-            &vars_bind_group_layout,
-        );
-        let repack_ctx = RepackContext::new(
-            &gpu.device,
-            &common_bind_group_layout,
-            &vars_bind_group_layout,
-        );
-        let interval_ctx = IntervalContext::new(
-            &gpu.device,
-            &common_bind_group_layout,
-            &vars_bind_group_layout,
-        );
-        let voxel_ctx = VoxelContext::new(
-            &gpu.device,
-            &common_bind_group_layout,
-            &vars_bind_group_layout,
-        );
-        let normals_ctx = NormalsContext::new(
-            &gpu.device,
-            &common_bind_group_layout,
-            &vars_bind_group_layout,
-        );
-        let merge_ctx = MergeContext::new(
-            &gpu.device,
-            &common_bind_group_layout,
-            &vars_bind_group_layout,
-        );
-        let clear_ctx = ClearContext::new(
-            &gpu.device,
-            &common_bind_group_layout,
-            &vars_bind_group_layout,
-        );
+        let root_ctx = RootContext::new(&gpu.device, &common_bind_group_layout);
+        let repack_ctx =
+            RepackContext::new(&gpu.device, &common_bind_group_layout);
+        let interval_ctx =
+            IntervalContext::new(&gpu.device, &common_bind_group_layout);
+        let voxel_ctx =
+            VoxelContext::new(&gpu.device, &common_bind_group_layout);
+        let normals_ctx =
+            NormalsContext::new(&gpu.device, &common_bind_group_layout);
+        let merge_ctx =
+            MergeContext::new(&gpu.device, &common_bind_group_layout);
+        let clear_ctx =
+            ClearContext::new(&gpu.device, &common_bind_group_layout);
         let reset_ctx = ResetContext;
 
         Self {
             gpu: gpu.clone(),
             common_bind_group_layout,
-            vars_bind_group_layout,
             root_ctx,
             repack_ctx,
             interval_ctx,
@@ -2157,11 +2132,33 @@ impl Context {
         }
 
         // Copy vars (if present)
-        if let Some(var_size) = NonZeroU64::new(shape.vars.size()) {
+        let vs = shape.shape.inner().vars();
+        if vs.has_free_vars() {
+            // If we have to change the vars buffer size, then clear the cached
+            // bind group.  TODO: only do this if we grow the buffer, since
+            // binding an overly-large buffer is fine?
+            let r = buffers
+                .vars_buf
+                .grow_to_fit(&self.gpu.device, vs.len())
+                .map_err(|err| {
+                    SubmitError::Buffers(BuffersError {
+                        buf: BufferName::Vars,
+                        err,
+                    })
+                })?;
+            if !matches!(r, std::cmp::Ordering::Equal) {
+                buffers.bind_groups.common = Default::default();
+            }
             let mut writer = self
                 .gpu
                 .queue
-                .write_buffer_with(&shape.vars, 0, var_size)
+                .write_buffer_with(
+                    buffers.vars_buf.data(),
+                    0,
+                    ((vars.len() * std::mem::size_of::<f32>()) as u64)
+                        .try_into()
+                        .unwrap(),
+                )
                 .unwrap();
             for (v, i) in shape.shape.inner().vars().iter() {
                 match v {
@@ -2196,9 +2193,6 @@ impl Context {
         // Build the common config buffer
         let common_bind_group = buffers.bind_groups.common(self, buffers);
         compute_pass.set_bind_group(0, common_bind_group, &[]);
-        let vars_bind_group = shape
-            .vars_bind_group(&self.gpu.device, &self.vars_bind_group_layout);
-        compute_pass.set_bind_group(1, vars_bind_group, &[]);
 
         // Populate root tiles (64x64x64, densely packed)
         self.root_ctx.run(
@@ -2257,7 +2251,6 @@ impl ClearContext {
     fn new(
         device: &wgpu::Device,
         common_bind_group_layout: &wgpu::BindGroupLayout,
-        vars_bind_group_layout: &wgpu::BindGroupLayout,
     ) -> Self {
         // Create bind group layout and bind group
         let bind_group_layout =
@@ -2278,7 +2271,6 @@ impl ClearContext {
                 label: Some("clear pipeline layout"),
                 bind_group_layouts: &[
                     Some(common_bind_group_layout),
-                    Some(vars_bind_group_layout),
                     Some(&bind_group_layout),
                 ],
                 immediate_size: 0u32,
@@ -2316,7 +2308,7 @@ impl ClearContext {
     ) {
         let bind_group = buffers.bind_groups.clear(ctx, buffers);
         compute_pass.set_pipeline(&self.pipeline);
-        compute_pass.set_bind_group(2, bind_group, &[]);
+        compute_pass.set_bind_group(1, bind_group, &[]);
         compute_pass.dispatch_workgroups(1, 1, 1);
     }
 }
@@ -2330,7 +2322,6 @@ impl MergeContext {
     fn new(
         device: &wgpu::Device,
         common_bind_group_layout: &wgpu::BindGroupLayout,
-        vars_bind_group_layout: &wgpu::BindGroupLayout,
     ) -> Self {
         let shader_code = merge_shader();
 
@@ -2352,7 +2343,6 @@ impl MergeContext {
                 label: Some("merge pipeline layout"),
                 bind_group_layouts: &[
                     Some(common_bind_group_layout),
-                    Some(vars_bind_group_layout),
                     Some(&bind_group_layout),
                 ],
                 immediate_size: 0u32,
@@ -2390,7 +2380,7 @@ impl MergeContext {
         let render_size = buffers.render_size();
         let bind_group = buffers.bind_groups.merge(ctx, buffers);
         compute_pass.set_pipeline(&self.pipeline);
-        compute_pass.set_bind_group(2, bind_group, &[]);
+        compute_pass.set_bind_group(1, bind_group, &[]);
         compute_pass.dispatch_workgroups(
             render_size.width().div_ceil(8),
             render_size.height().div_ceil(8),
@@ -2521,7 +2511,8 @@ mod test {
 
         // Render and accumulate each shape
         for (shape, _) in shapes {
-            let shape = gpu.shape(&VmShape::from(shape.clone())).unwrap();
+            let shape =
+                RenderShape::new(&VmShape::from(shape.clone())).unwrap();
             voxel_ctx.submit(&shape, &mut buf, &render_config).unwrap();
             effects_ctx
                 .submit_merge(buf.output(), Default::default(), &mut merge_buf)

--- a/fidget-wgpu/src/voxel/mod.rs
+++ b/fidget-wgpu/src/voxel/mod.rs
@@ -97,7 +97,8 @@
 //! buffer.
 
 use crate::{
-    CopyVarsError, Gpu, RegPipeline, RenderShape, TAPE_DATA_CAPACITY, TapeWord,
+    CopyVarsChanged, CopyVarsError, Gpu, RegPipeline, RenderShape,
+    TAPE_DATA_CAPACITY, TapeWord,
     buf::{
         BufferSizeError, BufferType, FlexBuffer, ReadBuffer, buffer_ro,
         buffer_ro_dyn, buffer_rw,
@@ -2143,7 +2144,10 @@ impl Context {
 
         // Copy vars (if present), then reset relevant bind groups if the buffer
         // size has changed.
-        if shape.copy_vars(&self.gpu, vars, &mut buffers.vars_buf)? {
+        if matches!(
+            shape.copy_vars(&self.gpu, vars, &mut buffers.vars_buf)?,
+            CopyVarsChanged::BufferChanged
+        ) {
             buffers.bind_groups.common = Default::default();
         }
 

--- a/fidget-wgpu/src/voxel/shaders/clear.wgsl
+++ b/fidget-wgpu/src/voxel/shaders/clear.wgsl
@@ -1,11 +1,11 @@
-@group(2) @binding(0) var<storage, read_write> tile16_count: array<u32, 4>;
-@group(2) @binding(1) var<storage, read_write> tile16_sort: array<u32, 4>;
-@group(2) @binding(2) var<storage, read_write> tile4_count: array<u32, 4>;
-@group(2) @binding(3) var<storage, read_write> tile4_sort: array<u32, 4>;
+@group(1) @binding(0) var<storage, read_write> tile16_count: array<u32, 4>;
+@group(1) @binding(1) var<storage, read_write> tile16_sort: array<u32, 4>;
+@group(1) @binding(2) var<storage, read_write> tile4_count: array<u32, 4>;
+@group(1) @binding(3) var<storage, read_write> tile4_sort: array<u32, 4>;
 
 // zhist_buf is 4x u32, padding to 256 bytes, then 16x u32.  We only care about
 // clearing the u32 ranges, i.e indices 0..4 and 64..80.
-@group(2) @binding(4) var<storage, read_write> zhist_buf: array<u32, 80>;
+@group(1) @binding(4) var<storage, read_write> zhist_buf: array<u32, 80>;
 
 // Dispatched as a single workgroup
 @compute @workgroup_size(64)

--- a/fidget-wgpu/src/voxel/shaders/common.wgsl
+++ b/fidget-wgpu/src/voxel/shaders/common.wgsl
@@ -39,7 +39,7 @@ struct Config {
 @group(0) @binding(1) var<storage, read_write> tile_tape: array<u32>;
 
 /// Array of values for (non-xyz) variables
-@group(1) @binding(0) var<storage, read> var_values: array<f32>;
+@group(0) @binding(2) var<storage, read> var_values: array<f32>;
 
 /// For a given position and recursion level, return the offset into `tile_tape`
 fn get_tape_offset_for_level(corner_pos: vec3u, level: u32) -> u32 {

--- a/fidget-wgpu/src/voxel/shaders/interval_root.wgsl
+++ b/fidget-wgpu/src/voxel/shaders/interval_root.wgsl
@@ -1,7 +1,6 @@
 // Interval root tile evaluation
-
-@group(2) @binding(0) var<storage, read_write> tiles_out: TileListOutput;
-@group(2) @binding(1) var<storage, read_write> tile64_zmax: array<atomic<u32>>;
+@group(1) @binding(0) var<storage, read_write> tiles_out: TileListOutput;
+@group(1) @binding(1) var<storage, read_write> tile64_zmax: array<atomic<u32>>;
 
 /// Root tile size
 const TILE_SIZE: u32 = 64;

--- a/fidget-wgpu/src/voxel/shaders/interval_tiles.wgsl
+++ b/fidget-wgpu/src/voxel/shaders/interval_tiles.wgsl
@@ -4,12 +4,12 @@
 // from `tape_interpreter.wgsl`
 
 /// Per-state IO bindings
-@group(2) @binding(0) var<storage, read> tiles_in: TileListInput;
-@group(2) @binding(1) var<storage, read> tile_zmin: array<u32>;
+@group(1) @binding(0) var<storage, read> tiles_in: TileListInput;
+@group(1) @binding(1) var<storage, read> tile_zmin: array<u32>;
 
-@group(2) @binding(2) var<storage, read_write> subtiles_out: TileListOutput;
-@group(2) @binding(3) var<storage, read_write> subtile_zmin: array<atomic<u32>>;
-@group(2) @binding(4) var<storage, read_write> subtile_zhist: array<atomic<u32>>;
+@group(1) @binding(2) var<storage, read_write> subtiles_out: TileListOutput;
+@group(1) @binding(3) var<storage, read_write> subtile_zmin: array<atomic<u32>>;
+@group(1) @binding(4) var<storage, read_write> subtile_zhist: array<atomic<u32>>;
 
 /// Input tile size; one input tile maps to a 4x4x4 workgroup
 override TILE_SIZE: u32;

--- a/fidget-wgpu/src/voxel/shaders/merge.wgsl
+++ b/fidget-wgpu/src/voxel/shaders/merge.wgsl
@@ -1,8 +1,8 @@
 /// Merge all tile stages into a pixel array
-@group(2) @binding(0) var<storage, read_write> tile64_zmin: array<atomic<u32>>;
-@group(2) @binding(1) var<storage, read_write> tile16_zmin: array<atomic<u32>>;
-@group(2) @binding(2) var<storage, read_write> tile4_zmin: array<atomic<u32>>;
-@group(2) @binding(3) var<storage, read_write> voxels: array<u32>;
+@group(1) @binding(0) var<storage, read_write> tile64_zmin: array<atomic<u32>>;
+@group(1) @binding(1) var<storage, read_write> tile16_zmin: array<atomic<u32>>;
+@group(1) @binding(2) var<storage, read_write> tile4_zmin: array<atomic<u32>>;
+@group(1) @binding(3) var<storage, read_write> voxels: array<u32>;
 
 // Dispatched as an 2D workgroup across render_size pixels
 @compute @workgroup_size(8, 8)

--- a/fidget-wgpu/src/voxel/shaders/normals.wgsl
+++ b/fidget-wgpu/src/voxel/shaders/normals.wgsl
@@ -1,5 +1,5 @@
-@group(2) @binding(0) var<storage, read> image_heightmap: array<u32>;
-@group(2) @binding(1) var<storage, read_write> image_out: array<GeometryPixel>;
+@group(1) @binding(0) var<storage, read> image_heightmap: array<u32>;
+@group(1) @binding(1) var<storage, read_write> image_out: array<GeometryPixel>;
 
 @compute @workgroup_size(8, 8)
 fn normals_main(

--- a/fidget-wgpu/src/voxel/shaders/repack.wgsl
+++ b/fidget-wgpu/src/voxel/shaders/repack.wgsl
@@ -1,11 +1,11 @@
-@group(2) @binding(0) var<storage, read> tiles_out: TileListInput;
-@group(2) @binding(1) var<storage, read> tile64_zmax: array<u32>;
+@group(1) @binding(0) var<storage, read> tiles_out: TileListInput;
+@group(1) @binding(1) var<storage, read> tile64_zmax: array<u32>;
 
 // This is a set of per-strata `TileListOutput` arrays.  Each one is
 // `strata_size_bytes(..)` long, which is large enough to fit every tile.  We
 // can't represent this directly, so good luck poking the right memory locations
 // by hand!
-@group(2) @binding(2) var<storage, read_write> strata_tiles: array<atomic<u32>>;
+@group(1) @binding(2) var<storage, read_write> strata_tiles: array<atomic<u32>>;
 
 @compute @workgroup_size(64, 1, 1)
 fn repack_main(

--- a/fidget-wgpu/src/voxel/shaders/sort.wgsl
+++ b/fidget-wgpu/src/voxel/shaders/sort.wgsl
@@ -1,6 +1,6 @@
-@group(2) @binding(0) var<storage, read> subtiles_out: TileListInput;
-@group(2) @binding(1) var<storage, read_write> z_hist: array<atomic<u32>>;
-@group(2) @binding(2) var<storage, read_write> sorted_subtiles: TileListOutput;
+@group(1) @binding(0) var<storage, read> subtiles_out: TileListInput;
+@group(1) @binding(1) var<storage, read_write> z_hist: array<atomic<u32>>;
+@group(1) @binding(2) var<storage, read_write> sorted_subtiles: TileListOutput;
 
 /// Output tile size
 override SUBTILE_SIZE: u32;

--- a/fidget-wgpu/src/voxel/shaders/voxel_tiles.wgsl
+++ b/fidget-wgpu/src/voxel/shaders/voxel_tiles.wgsl
@@ -1,10 +1,9 @@
 // VM interpreter for floating-point values, using voxel tiles
-
-@group(2) @binding(0) var<storage, read> tiles_in: TileListInput;
-@group(2) @binding(1) var<storage, read> tile4_zmin: array<u32>;
+@group(1) @binding(0) var<storage, read> tiles_in: TileListInput;
+@group(1) @binding(1) var<storage, read> tile4_zmin: array<u32>;
 
 /// Output array, render size (image size rounded up to multiple of 64 voxels)
-@group(2) @binding(2) var<storage, read_write> result: array<atomic<u32>>;
+@group(1) @binding(2) var<storage, read_write> result: array<atomic<u32>>;
 
 @compute @workgroup_size(4, 4, 4)
 fn voxel_ray_main(

--- a/fidget/tests/voxel_render.rs
+++ b/fidget/tests/voxel_render.rs
@@ -117,8 +117,10 @@ mod wgpu {
             for r in [0.5, 0.75] {
                 let sphere = (x.square() + y.square() + z.square()).sqrt()
                     - Tree::constant(r);
-                let shape =
-                    gpu.shape(&fidget::vm::VmShape::from(sphere)).unwrap();
+                let shape = fidget_wgpu::RenderShape::new(
+                    &fidget::vm::VmShape::from(sphere),
+                )
+                .unwrap();
                 let image = ctx
                     .run(
                         &shape,
@@ -157,7 +159,7 @@ mod wgpu {
         let sphere = (x.square() + y.square() + z.square()).sqrt() - c;
         let shape = fidget::vm::VmShape::from(sphere);
         let ctx = fidget_wgpu::voxel::Context::new(&gpu);
-        let render_shape = gpu.shape(&shape).unwrap();
+        let render_shape = fidget::wgpu::RenderShape::new(&shape).unwrap();
 
         let size = 32;
         let image_size = RenderSize::from(size);


### PR DESCRIPTION
This makes it easier to build / cache / share in the main thread.