### PR TITLE
Move `ShapeColorBuffers` off the GPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,10 @@ This section may not be all-inclusive; sorry!  I _did_ warn you that
 - Remove timestamps from `fidget::wgpu` pixel and voxel rendering; they will
   come back in a new form at some point in the future
 - Make `RenderShape` _not_ store GPU objects, so it can be constructed
-  independently through `RenderShape::new`.
+  independently through `RenderShape::new` (and shared between threads).
+- Similarly, make `ShapeColorBuffers` not store GPU objects, so it can be
+  constructed independently through `ShapeColorBuffers::new` (and shared between
+  threads).
 
 # 0.5.0
 This is a large release with a bunch of small features, reorganization, and one

--- a/fidget-core/src/shape/mod.rs
+++ b/fidget-core/src/shape/mod.rs
@@ -187,6 +187,7 @@ impl<F> Shape<F> {
 /// Note that this cannot store `X`, `Y`, `Z` variables (which are passed in as
 /// first-class arguments); it only stores [`Var::V`] values (identified by
 /// their inner [`VarIndex`]).
+#[derive(Debug)]
 pub struct ShapeVars<F>(HashMap<VarIndex, F>);
 
 impl<F> Default for ShapeVars<F> {

--- a/fidget-wgpu/src/buf.rs
+++ b/fidget-wgpu/src/buf.rs
@@ -95,6 +95,76 @@ impl BufferItemCount for VoxelSize {
     }
 }
 
+/// Tag for a flex buffer which contains a config `C` followed by many `T`
+///
+/// Item count is reported in bytes
+pub(crate) struct FlexConfigSize<C, T> {
+    count: usize,
+    _c: std::marker::PhantomData<C>,
+    _t: std::marker::PhantomData<T>,
+}
+
+impl<C, T> From<usize> for FlexConfigSize<C, T> {
+    fn from(value: usize) -> Self {
+        Self {
+            count: value,
+            _c: std::marker::PhantomData,
+            _t: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<C, T> Clone for FlexConfigSize<C, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<C, T> Copy for FlexConfigSize<C, T> {}
+
+impl<C, T> BufferItemCount for FlexConfigSize<C, T> {
+    fn item_count(&self) -> usize {
+        self.count * std::mem::size_of::<T>() + std::mem::size_of::<C>()
+    }
+}
+
+pub(crate) struct FlexConfigTag<C, T> {
+    _c: std::marker::PhantomData<C>,
+    _t: std::marker::PhantomData<T>,
+}
+
+impl<C, T> BufferTag for FlexConfigTag<C, T>
+where
+    T: Copy,
+{
+    type T = u8;
+    type S = FlexConfigSize<C, T>;
+    fn usage() -> u32 {
+        wgpu::BufferUsages::COPY_DST.bits() | wgpu::BufferUsages::STORAGE.bits()
+    }
+}
+
+/// Buffer which contains one config `C` followed by many `T`
+pub(crate) type FlexConfigBuffer<C, T> = FlexBuffer<FlexConfigTag<C, T>>;
+
+impl<C, T> FlexConfigBuffer<C, T>
+where
+    C: zerocopy::IntoBytes + zerocopy::Immutable + Copy,
+    T: Copy,
+{
+    /// Writes a config value to the buffer
+    pub(crate) fn write_config(&self, c: &C, queue: &wgpu::Queue) {
+        let config_len = std::mem::size_of::<C>();
+        let mut writer = queue
+            .write_buffer_with(
+                self.data(),
+                0,
+                (config_len as u64).try_into().unwrap(),
+            )
+            .unwrap();
+        writer.copy_from_slice(c.as_bytes());
+    }
+}
+
 impl<T: BufferTag> FlexBuffer<T> {
     pub(crate) fn new(
         device: &wgpu::Device,

--- a/fidget-wgpu/src/color.rs
+++ b/fidget-wgpu/src/color.rs
@@ -1,0 +1,311 @@
+//! Data types for evaluating shape color
+//!
+//! In this module, only [`ShapeColor`] and [`ShapeColorBuffers`] should be used
+//! directly (through direct construction and [`ShapeColorBuffers::new`]
+//! respectively).  Other types are generic and are re-exported with a specific
+//! paramerization in an `effects` module; e.g. the generic
+//! [`ColorWorkspace<C>`] is specialized to
+//! [`voxel::effects::ColorWorkspace`](crate::voxel::effects::ColorWorkspace)
+use crate::{
+    CopyVarsChanged, CopyVarsError, Gpu,
+    buf::{BufferSizeError, FlexBuffer, FlexConfigBuffer},
+    tag,
+    voxel::VarsBufferTag,
+};
+use fidget_bytecode::{Bytecode, ReservedRegister};
+use fidget_core::{
+    eval::Function,
+    shape::ShapeVars,
+    var::{Var, VarMap},
+    vm::VmShape,
+};
+
+use std::collections::HashMap;
+use zerocopy::IntoBytes;
+
+tag!(ShapeStartBufferTag, u32, usize, STORAGE | COPY_DST);
+
+/// Generic workspace for evaluating diffuse color
+pub struct ColorWorkspace<C> {
+    /// Config and serialized tapes, appended end to end
+    config: FlexConfigBuffer<C, u32>,
+
+    /// Start of the channel tapes for each shape
+    ///
+    /// The high bit indicates whether this is RGB (0) or HSL (1)
+    shape_start: FlexBuffer<ShapeStartBufferTag>,
+
+    /// Scratch space to upload variable values
+    vars_buf: FlexBuffer<VarsBufferTag>,
+
+    /// Lazily-constructed bind group for the config buffers
+    bind_group: std::cell::OnceCell<wgpu::BindGroup>,
+}
+
+impl<C> ColorWorkspace<C>
+where
+    C: zerocopy::IntoBytes + zerocopy::Immutable + Copy,
+{
+    pub(crate) fn new(device: &wgpu::Device) -> Self {
+        let config =
+            FlexBuffer::new(device, "color config".to_owned(), 4.into())
+                .unwrap();
+        let shape_start =
+            FlexBuffer::new(device, "shape start".to_owned(), 4usize).unwrap();
+        let vars_buf =
+            FlexBuffer::new(device, "color vars".to_owned(), 4usize).unwrap();
+        Self {
+            config,
+            shape_start,
+            vars_buf,
+            bind_group: Default::default(),
+        }
+    }
+
+    pub(crate) fn config_bind_group(
+        &self,
+        device: &wgpu::Device,
+        layout: &wgpu::BindGroupLayout,
+    ) -> &wgpu::BindGroup {
+        self.bind_group.get_or_init(|| {
+            device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("config bind group"),
+                layout,
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: self.config.bind_active(),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: self.shape_start.bind_active(),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 2,
+                        resource: self.vars_buf.bind_active(),
+                    },
+                ],
+            })
+        })
+    }
+
+    pub(crate) fn copy_vars(
+        &mut self,
+        gpu: &Gpu,
+        vs: &VarMap,
+        vars: &ShapeVars<f32>,
+    ) -> Result<(), CopyVarsError> {
+        match crate::copy_vars(gpu, vs, vars, &mut self.vars_buf)? {
+            CopyVarsChanged::BufferChanged => {
+                self.bind_group = Default::default()
+            }
+            CopyVarsChanged::BufferUnchanged => (),
+        }
+        Ok(())
+    }
+
+    pub(crate) fn copy_tape(
+        &mut self,
+        gpu: &Gpu,
+        bytecode: &[u32],
+    ) -> Result<(), BufferSizeError> {
+        let r = self
+            .config
+            .grow_to_fit(&gpu.device, bytecode.len().into())?;
+        if !matches!(r, std::cmp::Ordering::Equal) {
+            self.bind_group = Default::default();
+        }
+        let Ok(byte_count) =
+            (std::mem::size_of_val(bytecode) as u64).try_into()
+        else {
+            return Ok(());
+        };
+        let mut writer = gpu
+            .queue
+            .write_buffer_with(
+                self.config.data(),
+                std::mem::size_of::<C>() as u64,
+                byte_count,
+            )
+            .unwrap();
+        writer.copy_from_slice(bytecode.as_bytes());
+        Ok(())
+    }
+
+    pub(crate) fn copy_shape_starts(
+        &mut self,
+        gpu: &Gpu,
+        shape_starts: &[u32],
+    ) -> Result<(), BufferSizeError> {
+        let r = self
+            .shape_start
+            .grow_to_fit(&gpu.device, shape_starts.len())?;
+        if !matches!(r, std::cmp::Ordering::Equal) {
+            self.bind_group = Default::default();
+        }
+        let Ok(byte_count) =
+            (std::mem::size_of_val(shape_starts) as u64).try_into()
+        else {
+            return Ok(());
+        };
+        let mut writer = gpu
+            .queue
+            .write_buffer_with(self.shape_start.data(), 0, byte_count)
+            .unwrap();
+        writer.copy_from_slice(shape_starts.as_bytes());
+        Ok(())
+    }
+
+    pub(crate) fn copy_config(&mut self, gpu: &Gpu, config: &C) {
+        self.config.write_config(config, &gpu.queue)
+    }
+}
+
+/// Error type when constructing a [`ShapeColorBuffers`]
+#[derive(Debug, thiserror::Error)]
+pub enum ShapeColorError {
+    /// The shape uses a reserved register
+    #[error(transparent)]
+    RegisterError(#[from] ReservedRegister),
+}
+
+/// Color buffers for rendering a shape's diffuse color
+///
+/// These buffers live purely on the CPU, so they can be shared between threads.
+/// The object may be heavy (and therefore does not implement `Clone`); to share
+/// it, wrap it in an `Arc` or similar.
+pub struct ShapeColorBuffers {
+    /// Unified [`VarMap`] object
+    var_map: VarMap,
+
+    /// Number of shapes available
+    shape_count: usize,
+
+    /// Index of each shape's start position in the bytecode data
+    shape_start: Vec<u32>,
+
+    /// Maximum number of registers used by any tape
+    reg_count: u8,
+
+    /// Raw bytecode, which should be copied to the GPU config buffer tail
+    bytecode: Vec<u32>,
+}
+
+// Accessor methods
+impl ShapeColorBuffers {
+    pub(crate) fn var_map(&self) -> &VarMap {
+        &self.var_map
+    }
+    pub(crate) fn shape_count(&self) -> usize {
+        self.shape_count
+    }
+    pub(crate) fn shape_start(&self) -> &[u32] {
+        &self.shape_start
+    }
+    pub(crate) fn reg_count(&self) -> u8 {
+        self.reg_count
+    }
+    pub(crate) fn bytecode(&self) -> &[u32] {
+        &self.bytecode
+    }
+}
+
+/// Generic shape color
+pub enum ShapeColor<T> {
+    /// Red / green / blue channels, in the 0-1 range
+    Rgb {
+        /// Red component
+        r: T,
+        /// Green component
+        g: T,
+        /// Blue component
+        b: T,
+    },
+    /// Hue / saturation / lightness channels, in the 0-1 range
+    Hsl {
+        /// Hue
+        h: T,
+        /// Saturation
+        s: T,
+        /// Lightness
+        l: T,
+    },
+}
+
+impl<T> ShapeColor<T> {
+    fn channels(&self) -> [&T; 3] {
+        match self {
+            ShapeColor::Rgb { r, g, b } => [r, g, b],
+            ShapeColor::Hsl { h, s, l } => [h, s, l],
+        }
+    }
+}
+
+impl ShapeColorBuffers {
+    /// Builds a new set of buffers for evaluating shape color
+    pub fn new(
+        colors: &[ShapeColor<VmShape>],
+    ) -> Result<Self, ShapeColorError> {
+        // Build a single unified variable map, used across all tapes
+        let mut var_map = VarMap::new();
+        for c in colors {
+            for channel in c.channels() {
+                let vars = channel.inner().vars();
+                for (v, _index) in vars.iter() {
+                    var_map.insert(v);
+                }
+            }
+        }
+        let mut reg_count = 0;
+        let mut shape_start = Vec::with_capacity(colors.len());
+        let mut bytecode_data: Vec<u32> = Vec::new();
+        let mut local_var_map = HashMap::new();
+        for c in colors {
+            // Divide by 2 to convert from `u32` to `TapeWord`
+            let kind = match c {
+                ShapeColor::Rgb { .. } => 0,
+                ShapeColor::Hsl { .. } => 1 << 31,
+            };
+            let index = u32::try_from(bytecode_data.len() / 2).unwrap();
+            assert!(
+                index & (1 << 31) == 0,
+                "you have built more than 2 GiB of shape tapes?!"
+            );
+            shape_start.push(index | kind);
+            for channel in c.channels() {
+                // Build a local variable remapping array, reusing allocations
+                local_var_map.clear();
+                local_var_map.extend(channel.inner().vars().iter().map(
+                    |(v, i)| {
+                        (
+                            u32::try_from(i).unwrap(),
+                            u32::try_from(var_map.get(&v).unwrap()).unwrap(),
+                        )
+                    },
+                ));
+
+                // Generate bytecode for the root tape
+                let bytecode = Bytecode::new_with_input_map(
+                    channel.inner().data(),
+                    &local_var_map,
+                )?;
+                bytecode_data.extend(bytecode.data());
+                reg_count = reg_count.max(bytecode.reg_count());
+            }
+        }
+
+        Ok(Self {
+            shape_count: colors.len(),
+            shape_start,
+            bytecode: bytecode_data,
+            var_map,
+            reg_count,
+        })
+    }
+
+    /// Helper function to return XYZ variable indices
+    pub(crate) fn axes(&self) -> [u32; 3] {
+        [Var::X, Var::Y, Var::Z]
+            .map(|a| self.var_map.get(&a).map(|v| v as u32).unwrap_or(u32::MAX))
+    }
+}

--- a/fidget-wgpu/src/lib.rs
+++ b/fidget-wgpu/src/lib.rs
@@ -11,10 +11,11 @@ use fidget_core::{
 use fidget_raster::RenderSize;
 
 use heck::ToShoutySnakeCase;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 pub mod buf;
+pub mod color;
 pub mod pixel;
 pub mod voxel;
 
@@ -180,14 +181,6 @@ impl Gpu {
         self.copy(buf, &mut scratch);
         let data = self.map(&mut scratch);
         data.to_vec()
-    }
-
-    /// Build a set of buffers for doing shape color evaluation
-    pub fn color_buffers(
-        &self,
-        colors: &[ShapeColor<VmShape>],
-    ) -> Result<ShapeColorBuffers, ShapeColorError> {
-        ShapeColorBuffers::new(colors, &self.device)
     }
 
     /// Copies from a GPU-resident buffer to a host-mappable buffer
@@ -357,14 +350,6 @@ pub enum RenderShapeError {
     RegisterError(#[from] ReservedRegister),
 }
 
-/// Error type when constructing a [`ShapeColorBuffers`]
-#[derive(Debug, thiserror::Error)]
-pub enum ShapeColorError {
-    /// The shape uses a reserved register
-    #[error(transparent)]
-    RegisterError(#[from] ReservedRegister),
-}
-
 impl RenderShape {
     /// Builds a new render shape
     pub fn new(shape: &VmShape) -> Result<Self, RenderShapeError> {
@@ -397,54 +382,61 @@ impl RenderShape {
         vars: &ShapeVars<f32>,
         buf: &mut buf::FlexBuffer<voxel::VarsBufferTag>,
     ) -> Result<CopyVarsChanged, CopyVarsError> {
-        // Copy vars (if present)
-        let vs = self.shape.inner().vars();
-        let mut changed = CopyVarsChanged::BufferUnchanged;
-        if vs.has_free_vars() {
-            // Do an initial pass to check for errors before resizing the buffer
-            for (v, _i) in vs.iter() {
-                match v {
-                    Var::X | Var::Y | Var::Z => (),
-                    Var::V(vi) => {
-                        if vars.get(vi).is_none() {
-                            return Err(MissingVar { var: vi }.into());
-                        };
-                    }
-                }
-            }
-            // If we have to change the vars buffer size, then we'll return
-            // `true` indicating that things have changed and bind groups should
-            // be invalidated.  TODO: only do this if we grow the buffer, since
-            // binding an overly-large buffer is fine?
-            let r = buf.grow_to_fit(&gpu.device, vs.len())?;
-            if !matches!(r, std::cmp::Ordering::Equal) {
-                changed = CopyVarsChanged::BufferChanged;
-            }
-            let mut writer = gpu
-                .queue
-                .write_buffer_with(
-                    buf.data(),
-                    0,
-                    ((vars.len() * std::mem::size_of::<f32>()) as u64)
-                        .try_into()
-                        .unwrap(),
-                )
-                .unwrap();
-            for (v, i) in vs.iter() {
-                match v {
-                    Var::X | Var::Y | Var::Z => (),
-                    Var::V(vi) => {
-                        let value = vars.get(vi).unwrap(); // checked above
-                        let offset = i * std::mem::size_of::<f32>();
-                        writer
-                            .slice(offset..offset + 4)
-                            .copy_from_slice(value.as_bytes());
-                    }
+        copy_vars(gpu, self.shape.inner().vars(), vars, buf)
+    }
+}
+
+pub(crate) fn copy_vars(
+    gpu: &Gpu,
+    vs: &VarMap,
+    vars: &ShapeVars<f32>,
+    buf: &mut buf::FlexBuffer<voxel::VarsBufferTag>,
+) -> Result<CopyVarsChanged, CopyVarsError> {
+    let mut changed = CopyVarsChanged::BufferUnchanged;
+    if vs.has_free_vars() {
+        // Do an initial pass to check for errors before resizing the buffer
+        for (v, _i) in vs.iter() {
+            match v {
+                Var::X | Var::Y | Var::Z => (),
+                Var::V(vi) => {
+                    if vars.get(vi).is_none() {
+                        return Err(MissingVar { var: vi }.into());
+                    };
                 }
             }
         }
-        Ok(changed)
+        // If we have to change the vars buffer size, then we'll return
+        // `true` indicating that things have changed and bind groups should
+        // be invalidated.  TODO: only do this if we grow the buffer, since
+        // binding an overly-large buffer is fine?
+        let r = buf.grow_to_fit(&gpu.device, vs.len())?;
+        if !matches!(r, std::cmp::Ordering::Equal) {
+            changed = CopyVarsChanged::BufferChanged;
+        }
+        let mut writer = gpu
+            .queue
+            .write_buffer_with(
+                buf.data(),
+                0,
+                ((vs.len() * std::mem::size_of::<f32>()) as u64)
+                    .try_into()
+                    .unwrap(),
+            )
+            .unwrap();
+        for (v, i) in vs.iter() {
+            match v {
+                Var::X | Var::Y | Var::Z => (),
+                Var::V(vi) => {
+                    let value = vars.get(vi).unwrap(); // checked above
+                    let offset = i * std::mem::size_of::<f32>();
+                    writer
+                        .slice(offset..offset + 4)
+                        .copy_from_slice(value.as_bytes());
+                }
+            }
+        }
     }
+    Ok(changed)
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -460,268 +452,6 @@ enum CopyVarsError {
 enum CopyVarsChanged {
     BufferChanged,
     BufferUnchanged,
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
-/// Color buffers for rendering a shape's diffuse color
-pub struct ShapeColorBuffers {
-    /// Unified [`VarMap`] object
-    var_map: VarMap,
-
-    /// Number of shapes available
-    shape_count: usize,
-
-    /// Maximum number of registers used by any tape
-    reg_count: u8,
-
-    /// Config and serialized tapes, all squished together
-    ///
-    /// The tape data is baked once (at construction); config data is edited
-    /// before each evaluation
-    config: wgpu::Buffer,
-
-    /// Start of the channel tapes for each shape
-    ///
-    /// The high bit indicates whether this is RGB (0) or HSL (1)
-    ///
-    /// This is baked once (at construction)
-    shape_start: wgpu::Buffer,
-
-    /// Lazily-constructed bind group for the config buffers
-    config_bind_group: std::cell::OnceCell<wgpu::BindGroup>,
-
-    /// GPU buffer to contain variables (passed in during evaluation)
-    ///
-    /// This doesn't live in a `Buffers` object because it's dynamically sized
-    /// based on the shape; everything in `Buffers` is based on image size.
-    vars: wgpu::Buffer,
-}
-
-/// Generic shape color
-pub enum ShapeColor<T> {
-    /// Red / green / blue channels, in the 0-1 range
-    Rgb {
-        /// Red component
-        r: T,
-        /// Green component
-        g: T,
-        /// Blue component
-        b: T,
-    },
-    /// Hue / saturation / lightness channels, in the 0-1 range
-    Hsl {
-        /// Hue
-        h: T,
-        /// Saturation
-        s: T,
-        /// Lightness
-        l: T,
-    },
-}
-
-impl<T> ShapeColor<T> {
-    fn channels(&self) -> [&T; 3] {
-        match self {
-            ShapeColor::Rgb { r, g, b } => [r, g, b],
-            ShapeColor::Hsl { h, s, l } => [h, s, l],
-        }
-    }
-}
-
-impl ShapeColorBuffers {
-    const fn expected_config_size() -> usize {
-        std::mem::size_of::<voxel::effects::ColorConfig>()
-    }
-
-    fn new(
-        colors: &[ShapeColor<VmShape>],
-        device: &wgpu::Device,
-    ) -> Result<Self, ShapeColorError> {
-        // Build a single unified variable map, used across all tapes
-        let mut var_map = VarMap::new();
-        for c in colors {
-            for channel in c.channels() {
-                let vars = channel.inner().vars();
-                for (v, _index) in vars.iter() {
-                    var_map.insert(v);
-                }
-            }
-        }
-        let mut reg_count = 0;
-        let mut shape_start = Vec::with_capacity(colors.len());
-        let mut bytecode_data: Vec<u32> = Vec::new();
-        let mut local_var_map = HashMap::new();
-        for c in colors {
-            // Divide by 2 to convert from `u32` to `TapeWord`
-            let kind = match c {
-                ShapeColor::Rgb { .. } => 0,
-                ShapeColor::Hsl { .. } => 1 << 31,
-            };
-            let index = u32::try_from(bytecode_data.len() / 2).unwrap();
-            assert!(
-                index & (1 << 31) == 0,
-                "you have built more than 2 GiB of shape tapes?!"
-            );
-            shape_start.push(index | kind);
-            for channel in c.channels() {
-                // Build a local variable remapping array, reusing allocations
-                local_var_map.clear();
-                local_var_map.extend(channel.inner().vars().iter().map(
-                    |(v, i)| {
-                        (
-                            u32::try_from(i).unwrap(),
-                            u32::try_from(var_map.get(&v).unwrap()).unwrap(),
-                        )
-                    },
-                ));
-
-                // Generate bytecode for the root tape
-                let bytecode = Bytecode::new_with_input_map(
-                    channel.inner().data(),
-                    &local_var_map,
-                )?;
-                bytecode_data.extend(bytecode.data());
-                reg_count = reg_count.max(bytecode.reg_count());
-            }
-        }
-
-        // Build a buffer for non-XYZ vars.  This buffer includes slots for XYZ
-        // as well, but we special-case them in evaluation.  If the tape has no
-        // variables, then we'll allocate 4 bytes (because empty buffers aren't
-        // allowed).
-        let vars = device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("vars"),
-            size: u64::try_from(std::mem::size_of::<f32>() * var_map.len())
-                .unwrap()
-                .max(4),
-            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
-            mapped_at_creation: false,
-        });
-
-        let shape_start_buf = device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("shape_start"),
-            size: u64::try_from(std::mem::size_of::<u32>() * shape_start.len())
-                .unwrap(),
-            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
-            mapped_at_creation: true,
-        });
-        shape_start_buf
-            .get_mapped_range_mut(0..)
-            .copy_from_slice(shape_start.as_bytes());
-        shape_start_buf.unmap();
-
-        let config_size = Self::expected_config_size();
-        let config_buf = device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("shape_start"),
-            size: u64::try_from(
-                std::mem::size_of::<u32>() * bytecode_data.len() + config_size,
-            )
-            .unwrap(),
-            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
-            mapped_at_creation: true,
-        });
-        config_buf
-            .get_mapped_range_mut(config_size as u64..)
-            .copy_from_slice(bytecode_data.as_bytes());
-        config_buf.unmap();
-
-        Ok(Self {
-            config: config_buf,
-            shape_count: colors.len(),
-            shape_start: shape_start_buf,
-            var_map,
-            vars,
-            config_bind_group: Default::default(),
-            reg_count,
-        })
-    }
-
-    /// Helper function to return XYZ variable indices
-    fn axes(&self) -> [u32; 3] {
-        [Var::X, Var::Y, Var::Z]
-            .map(|a| self.var_map.get(&a).map(|v| v as u32).unwrap_or(u32::MAX))
-    }
-
-    /// Writes a config value
-    ///
-    /// # Panics
-    /// If the config object is not the expected size
-    fn write_config<C: IntoBytes + Immutable>(
-        &self,
-        c: &C,
-        queue: &wgpu::Queue,
-    ) {
-        let config_len = std::mem::size_of::<C>();
-        assert_eq!(
-            config_len,
-            Self::expected_config_size(),
-            "wrong config object size"
-        );
-        let mut writer = queue
-            .write_buffer_with(
-                &self.config,
-                0,
-                (config_len as u64).try_into().unwrap(),
-            )
-            .unwrap();
-        writer.copy_from_slice(c.as_bytes());
-    }
-
-    fn write_vars(
-        &self,
-        vars: &ShapeVars<f32>,
-        queue: &wgpu::Queue,
-    ) -> Result<(), MissingVar> {
-        if self.var_map.has_free_vars() {
-            let var_size = self.vars.size();
-            let mut writer = queue
-                .write_buffer_with(&self.vars, 0, var_size.try_into().unwrap())
-                .unwrap();
-            for (v, i) in self.var_map.iter() {
-                match v {
-                    Var::X | Var::Y | Var::Z => (),
-                    Var::V(vi) => {
-                        let Some(value) = vars.get(vi) else {
-                            return Err(MissingVar { var: vi });
-                        };
-                        let offset = i * std::mem::size_of::<f32>();
-                        writer
-                            .slice(offset..offset + 4)
-                            .copy_from_slice(value.as_bytes());
-                    }
-                }
-            }
-        }
-        Ok(())
-    }
-
-    fn config_bind_group(
-        &self,
-        device: &wgpu::Device,
-        layout: &wgpu::BindGroupLayout,
-    ) -> &wgpu::BindGroup {
-        self.config_bind_group.get_or_init(|| {
-            device.create_bind_group(&wgpu::BindGroupDescriptor {
-                label: Some("config bind group"),
-                layout,
-                entries: &[
-                    wgpu::BindGroupEntry {
-                        binding: 0,
-                        resource: self.config.as_entire_binding(),
-                    },
-                    wgpu::BindGroupEntry {
-                        binding: 1,
-                        resource: self.shape_start.as_entire_binding(),
-                    },
-                    wgpu::BindGroupEntry {
-                        binding: 2,
-                        resource: self.vars.as_entire_binding(),
-                    },
-                ],
-            })
-        })
-    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/fidget-wgpu/src/pixel/effects/mod.rs
+++ b/fidget-wgpu/src/pixel/effects/mod.rs
@@ -17,8 +17,9 @@
 //! [`output_color`](MergeBuffers::output_color).
 //! Note that if color has not been computed, `output_color` will return `None`.
 use crate::{
-    Gpu, RegPipeline, ShapeColorBuffers,
+    CopyVarsError, Gpu, RegPipeline,
     buf::{BufferSizeError, FlexBuffer, buffer_ro, buffer_rw, buffer_uniform},
+    color::{ColorWorkspace as GenericColorWorkspace, ShapeColorBuffers},
     pixel::{PixelBufferTag, RawDistancePixel},
     shaders, tag,
 };
@@ -29,6 +30,9 @@ pub use crate::voxel::effects::ColorError;
 
 const MERGE_SHADER: &str = include_str!("shaders/merge.wgsl");
 const COLOR_SHADER: &str = include_str!("shaders/color.wgsl");
+
+/// Workspace for evaluating color expressions
+pub type ColorWorkspace = GenericColorWorkspace<ColorConfig>;
 
 /// Returns a shader for merging images
 fn merge_shader() -> String {
@@ -355,8 +359,15 @@ impl Context {
         merge: &mut MergeBuffers,
         settings: ColorSettings,
         shape: &ShapeColorBuffers,
+        bufs: &mut ColorWorkspace,
     ) -> Result<(), ColorError> {
-        self.submit_color_with_vars(merge, settings, shape, &Default::default())
+        self.submit_color_with_vars(
+            merge,
+            settings,
+            shape,
+            bufs,
+            &Default::default(),
+        )
     }
 
     /// Submits a color evaluation pass with auxiliary variables
@@ -369,20 +380,30 @@ impl Context {
         merge: &mut MergeBuffers,
         settings: ColorSettings,
         shape: &ShapeColorBuffers,
+        bufs: &mut ColorWorkspace,
         vars: &ShapeVars<f32>,
     ) -> Result<(), ColorError> {
         self.color_ctx
-            .submit(merge, settings, shape, vars, &self.gpu)
+            .submit(merge, settings, shape, bufs, vars, &self.gpu)
+    }
+
+    /// Returns a new workspace for color evaluation
+    pub fn color_workspace(&self) -> ColorWorkspace {
+        ColorWorkspace::new(&self.gpu.device)
     }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 /// Configuration for the color evaluation pass
+///
+/// This is quietly public because it's part of a public API, but is unlikely to
+/// be useful for end-users of the library.
 #[derive(Copy, Clone, FromBytes, Immutable, IntoBytes, KnownLayout)]
 #[cfg_attr(test, derive(facet::Facet))]
 #[repr(C)]
-pub(crate) struct ColorConfig {
+#[doc(hidden)]
+pub struct ColorConfig {
     /// Screen-to-model transform matrix (mat3x3)
     mat: [f32; 12],
 
@@ -486,13 +507,14 @@ impl ColorContext {
         image: &mut MergeBuffers,
         settings: ColorSettings,
         shape: &ShapeColorBuffers,
+        bufs: &mut ColorWorkspace,
         vars: &ShapeVars<f32>,
         gpu: &Gpu,
     ) -> Result<(), ColorError> {
-        if image.image_count != shape.shape_count {
+        if image.image_count != shape.shape_count() {
             return Err(ColorError::BadShapeCount {
                 merge_count: image.image_count,
-                shape_count: shape.shape_count,
+                shape_count: shape.shape_count(),
             });
         } else if image.has_color {
             return Err(ColorError::AlreadyHasColor);
@@ -503,9 +525,19 @@ impl ColorContext {
         let mut mat4 = nalgebra::Matrix4x3::<f32>::identity();
         mat4.fixed_view_mut::<3, 3>(0, 0).copy_from(&mat);
 
-        let config_bg = shape
-            .config_bind_group(&gpu.device, &self.config_bind_group_layout);
+        bufs.copy_vars(gpu, shape.var_map(), vars)
+            .map_err(|e| match e {
+                CopyVarsError::BufferSize(b) => ColorError::VarBufferSize(b),
+                CopyVarsError::MissingVar(v) => ColorError::MissingVar(v),
+            })?;
 
+        bufs.copy_tape(gpu, shape.bytecode())
+            .map_err(ColorError::ConfigBufferSize)?;
+        bufs.copy_shape_starts(gpu, shape.shape_start())
+            .expect("shape starts should always fit if shape bytecode fits");
+
+        // We'll write the config last, because writing the tape could have
+        // invalidated it.
         let config = ColorConfig {
             mat: mat4.data.as_slice().try_into().unwrap(),
             axes: shape.axes(),
@@ -514,8 +546,10 @@ impl ColorContext {
             _pad: [0; 3],
             z: settings.z,
         };
-        shape.write_config(&config, &gpu.queue);
-        shape.write_vars(vars, &gpu.queue)?;
+        bufs.copy_config(gpu, &config);
+
+        let config_bg =
+            bufs.config_bind_group(&gpu.device, &self.config_bind_group_layout);
 
         // Create a command encoder and dispatch the compute work
         let mut encoder = gpu.device.create_command_encoder(
@@ -549,7 +583,8 @@ impl ColorContext {
                     ],
                 });
             compute_pass.set_bind_group(1, &image_bg, &[]);
-            compute_pass.set_pipeline(self.color_pipeline.get(shape.reg_count));
+            compute_pass
+                .set_pipeline(self.color_pipeline.get(shape.reg_count()));
             compute_pass.dispatch_workgroups(
                 size.width().div_ceil(8),
                 size.height().div_ceil(8),
@@ -591,14 +626,6 @@ mod test {
         crate::test::compare_struct_layout::<ColorConfig>(
             &color_shader(16),
             "Config",
-        );
-    }
-
-    #[test]
-    fn color_config_size() {
-        assert_eq!(
-            std::mem::size_of::<ColorConfig>(),
-            ShapeColorBuffers::expected_config_size(),
         );
     }
 }

--- a/fidget-wgpu/src/pixel/mod.rs
+++ b/fidget-wgpu/src/pixel/mod.rs
@@ -1311,7 +1311,7 @@ impl ResetContext {
 mod test {
     use super::effects::ColorSettings;
     use super::*;
-    use crate::ShapeColor;
+    use crate::color::{ShapeColor, ShapeColorBuffers};
 
     use fidget_core::{context::Tree, vm::VmShape};
 
@@ -1343,6 +1343,7 @@ mod test {
     fn render(
         shapes: &[(Tree, ShapeColor<Tree>)],
         render_config: RenderConfig,
+        vars: &fidget_core::shape::ShapeVars<f32>,
     ) -> RenderOutput {
         let gpu = pollster::block_on(Gpu::init_basic()).unwrap();
         let pixel_ctx = Context::new(&gpu);
@@ -1355,7 +1356,9 @@ mod test {
         for (shape, _) in shapes {
             let shape =
                 RenderShape::new(&VmShape::from(shape.clone())).unwrap();
-            pixel_ctx.submit(&shape, &mut buf, &render_config).unwrap();
+            pixel_ctx
+                .submit_with_vars(&shape, vars, &mut buf, &render_config)
+                .unwrap();
             effects_ctx
                 .submit_merge(buf.output(), true, &mut merge_buf)
                 .unwrap();
@@ -1375,11 +1378,12 @@ mod test {
                 },
             })
             .collect::<Vec<_>>();
-        let shape_colors = gpu.color_buffers(&shape_colors).unwrap();
+        let shape_colors = ShapeColorBuffers::new(&shape_colors).unwrap();
+        let mut color_workspace = effects_ctx.color_workspace();
 
         // Compute per-pixel colors
         effects_ctx
-            .submit_color(
+            .submit_color_with_vars(
                 &mut merge_buf,
                 ColorSettings {
                     z: 0.0,
@@ -1387,6 +1391,8 @@ mod test {
                     world_to_model: render_config.world_to_model,
                 },
                 &shape_colors,
+                &mut color_workspace,
+                vars,
             )
             .unwrap();
 
@@ -1436,6 +1442,7 @@ mod test {
                     pixel_perfect: false,
                     z: 0.0,
                 },
+                &Default::default(),
             );
             assert_eq!(out.color.size(), image_size);
             assert_eq!(out.distance.size(), image_size);
@@ -1529,6 +1536,7 @@ mod test {
                 pixel_perfect: false,
                 z: 0.0,
             },
+            &Default::default(),
         );
         assert_eq!(out.color.size(), image_size);
         assert_eq!(out.distance.size(), image_size);
@@ -1622,6 +1630,149 @@ mod test {
     }
 
     #[test]
+    fn pixel_vars() {
+        // We only run in CI if we're on MacOS (because other runners don't have
+        // GPUs and will fail to build the context).
+        #[cfg(not(target_os = "macos"))]
+        if std::env::var("CI").is_ok() {
+            return;
+        }
+
+        let va = fidget_core::var::Var::new();
+        let vb = fidget_core::var::Var::new();
+        let vc = fidget_core::var::Var::new();
+        let vd = fidget_core::var::Var::new();
+        let circle_a = ((Tree::x() - 0.5).square() + Tree::y().square()).sqrt()
+            - Tree::from(va);
+        let circle_b = ((Tree::x() + va).square() + Tree::y().square()).sqrt()
+            - Tree::from(vb);
+
+        // Test a variety of image sizes for correctness
+        let image_size = RenderSize::new(64, 64);
+        let mut vars = fidget_core::shape::ShapeVars::new();
+        vars.insert(va.index().unwrap(), 0.25);
+        vars.insert(vb.index().unwrap(), 0.55);
+        vars.insert(vc.index().unwrap(), 0.75);
+        vars.insert(vd.index().unwrap(), 0.5);
+        let out = render(
+            &[
+                (
+                    circle_a,
+                    ShapeColor::Rgb {
+                        r: Tree::constant(0.0),
+                        g: Tree::constant(0.0),
+                        b: Tree::from(vc),
+                    },
+                ),
+                (
+                    circle_b,
+                    ShapeColor::Rgb {
+                        r: Tree::constant(0.0),
+                        g: Tree::from(vd),
+                        b: Tree::constant(0.0),
+                    },
+                ),
+            ],
+            RenderConfig {
+                image_size,
+                world_to_model: nalgebra::Matrix3::identity(),
+                pixel_perfect: false,
+                z: 0.0,
+            },
+            &vars,
+        );
+        assert_eq!(out.color.size(), image_size);
+        assert_eq!(out.distance.size(), image_size);
+
+        let mut pixels = String::new();
+        for j in 0..image_size.height() {
+            for i in 0..image_size.width() {
+                let p = out.color[(j as usize, i as usize)];
+                let c = match p.to_ne_bytes() {
+                    [0, 0, 191, 0] => "b",
+                    [0, 0, 191, 255] => "B",
+                    [0, 127, 0, 0] => "g",
+                    [0, 127, 0, 255] => "G",
+                    _ => panic!("invalid color {:?}", p.to_ne_bytes()),
+                };
+                pixels += c;
+            }
+            pixels += "\n";
+        }
+
+        assert_eq!(
+            pixels,
+            "\
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            ggggggggggggggggggggGGGGGGGGGggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggGGGGGGGGGGGGGGGgggggggggggggbbbbbbbbbbbbggggggg
+            gggggggggggggggGGGGGGGGGGGGGGGGGGGgggggggggggbbbbbbbbbbbbggggggg
+            ggggggggggggggGGGGGGGGGGGGGGGGGGGGGgggggggggbbbbbbbbbbbbbggggggg
+            gggggggggggggGGGGGGGGGGGGGGGGGGGGGGGggggggggbbbbbbbbbbbbbggggggg
+            ggggggggggggGGGGGGGGGGGGGGGGGGGGGGGGGgggggggbbbbbbbbbbbbbggggggg
+            gggggggggggGGGGGGGGGGGGGGGGGGGGGGGGGGGgggggbbbbbbbbbbbbbbggggggg
+            ggggggggggGGGGGGGGGGGGGGGGGGGGGGGGGGGGGggggbbbbbbbbbbbbbbggggggg
+            gggggggggGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGgggbbbbbbbbbbbbbbggggggg
+            gggggggggGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGggbbbbbbbbbbbbbbbbbbbbbb
+            ggggggggGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGgbbbBBBBBBBbbbbbbbbbbbb
+            ggggggggGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGgbBBBBBBBBBBBbbbbbbbbbb
+            ggggggggGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGgBBBBBBBBBBBBBbbbbbbbbb
+            gggggggGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGBBBBBBBBBBBBBbbbbbbbbb
+            gggggggGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGBBBBBBBBBBBBBBbbbbbbbb
+            gggggggGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGBBBBBBBBBBBBBBbbbbbbbb
+            gggggggGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGBBBBBBBBBBBBBBbbbbbbbb
+            gggggggGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGBBBBBBBBBBBBBBbbbbbbbb
+            gggggggGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGBBBBBBBBBBBBBBbbbbbbbb
+            gggggggGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGBBBBBBBBBBBBBBgggggggg
+            gggggggGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGBBBBBBBBBBBBBBbggggggg
+            gggggggGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGBBBBBBBBBBBBBbbggggggg
+            ggggggggGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGgBBBBBBBBBBBBBbbggggggg
+            ggggggggGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGgbBBBBBBBBBBBbbbggggggg
+            ggggggggGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGgbbbBBBBBBBbbbbbggggggg
+            gggggggggGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGggbbbbbbbbbbbbbbbggggggg
+            gggggggggGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGggbbbbbbbbbbbbbbbggggggg
+            ggggggggggGGGGGGGGGGGGGGGGGGGGGGGGGGGGGggggggggggggggggggggggggg
+            gggggggggggGGGGGGGGGGGGGGGGGGGGGGGGGGGgggggggggggggggggggggggggg
+            ggggggggggggGGGGGGGGGGGGGGGGGGGGGGGGGggggggggggggggggggggggggggg
+            gggggggggggggGGGGGGGGGGGGGGGGGGGGGGGgggggggggggggggggggggggggggg
+            ggggggggggggggGGGGGGGGGGGGGGGGGGGGGggggggggggggggggggggggggggggg
+            gggggggggggggggGGGGGGGGGGGGGGGGGGGgggggggggggggggggggggggggggggg
+            gggggggggggggggggGGGGGGGGGGGGGGGgggggggggggggggggggggggggggggggg
+            ggggggggggggggggggggGGGGGGGGGggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+            "
+            .replace(" ", "")
+        );
+    }
+
+    #[test]
     fn pixel_hsl() {
         // We only run in CI if we're on MacOS (because other runners don't have
         // GPUs and will fail to build the context).
@@ -1662,6 +1813,7 @@ mod test {
                 pixel_perfect: false,
                 z: 0.0,
             },
+            &Default::default(),
         );
         assert_eq!(out.color.size(), image_size);
         assert_eq!(out.distance.size(), image_size);

--- a/fidget-wgpu/src/voxel/effects/mod.rs
+++ b/fidget-wgpu/src/voxel/effects/mod.rs
@@ -10,8 +10,9 @@
 //! - Apply shading to a [`PackedVoxel`] buffer, producing an RGBA image buffer
 
 use crate::{
-    Gpu, RegPipeline, ShapeColorBuffers,
+    CopyVarsError, Gpu, RegPipeline,
     buf::{BufferSizeError, FlexBuffer, buffer_ro, buffer_rw, buffer_uniform},
+    color::{ColorWorkspace as GenericColorWorkspace, ShapeColorBuffers},
     shaders, tag,
     voxel::GeomBufferTag,
 };
@@ -38,6 +39,9 @@ pub struct Context {
 
     color_ctx: ColorContext,
 }
+
+/// Workspace for evaluating color expressions
+pub type ColorWorkspace = GenericColorWorkspace<ColorConfig>;
 
 const COMMON_SHADER: &str = include_str!("shaders/common.wgsl");
 const MERGE_SHADER: &str = include_str!("shaders/merge.wgsl");
@@ -101,10 +105,14 @@ pub struct PackedVoxel {
 }
 
 /// Configuration for the color evaluation pass
+///
+/// This is quietly public because it's part of a public API, but is unlikely to
+/// be useful for end-users of the library.
 #[derive(Copy, Clone, FromBytes, Immutable, IntoBytes, KnownLayout)]
 #[cfg_attr(test, derive(facet::Facet))]
 #[repr(C)]
-pub(crate) struct ColorConfig {
+#[doc(hidden)]
+pub struct ColorConfig {
     /// Screen-to-model transform matrix
     mat: [f32; 16],
 
@@ -296,8 +304,16 @@ pub enum SsaoError {
 #[derive(Debug, thiserror::Error)]
 pub enum ColorError {
     /// An error occurred while resizing the output buffer
-    #[error(transparent)]
-    OutputSize(BufferSizeError),
+    #[error("could not resize output buffer")]
+    OutputSize(#[source] BufferSizeError),
+
+    /// An error occurred while resizing the vars buffer
+    #[error("could not resize vars buffer")]
+    VarBufferSize(#[source] BufferSizeError),
+
+    /// An error occurred while resizing the config buffer
+    #[error("could not resize config buffer")]
+    ConfigBufferSize(#[source] BufferSizeError),
 
     /// A variable is missing from the map
     #[error(transparent)]
@@ -839,12 +855,14 @@ impl Context {
         merge: &MergeBuffers,
         world_to_model: &nalgebra::Matrix4<f32>,
         shape: &ShapeColorBuffers,
+        bufs: &mut ColorWorkspace,
         out: &mut ShadeBuffers,
     ) -> Result<(), ColorError> {
         self.submit_color_with_vars(
             merge,
             world_to_model,
             shape,
+            bufs,
             &Default::default(),
             out,
         )
@@ -860,6 +878,7 @@ impl Context {
         merge: &MergeBuffers,
         world_to_model: &nalgebra::Matrix4<f32>,
         shape: &ShapeColorBuffers,
+        bufs: &mut ColorWorkspace,
         vars: &ShapeVars<f32>,
         out: &mut ShadeBuffers,
     ) -> Result<(), ColorError> {
@@ -867,10 +886,16 @@ impl Context {
             merge,
             world_to_model,
             shape,
+            bufs,
             vars,
             out,
             &self.gpu,
         )
+    }
+
+    /// Returns a new workspace for color evaluation
+    pub fn color_workspace(&self) -> ColorWorkspace {
+        ColorWorkspace::new(&self.gpu.device)
     }
 }
 
@@ -1262,19 +1287,21 @@ impl ColorContext {
     }
 
     /// The output buffer is resized to fit `image`
+    #[allow(clippy::too_many_arguments)] // what are ya gonna do?
     fn submit(
         &self,
         image: &MergeBuffers,
         world_to_model: &nalgebra::Matrix4<f32>,
         shape: &ShapeColorBuffers,
+        bufs: &mut ColorWorkspace,
         vars: &ShapeVars<f32>,
         out: &mut ShadeBuffers,
         gpu: &Gpu,
     ) -> Result<(), ColorError> {
-        if image.image_count != shape.shape_count {
+        if image.image_count != shape.shape_count() {
             return Err(ColorError::BadShapeCount {
                 merge_count: image.image_count,
-                shape_count: shape.shape_count,
+                shape_count: shape.shape_count(),
             });
         }
         let size = image.out.size();
@@ -1285,17 +1312,28 @@ impl ColorContext {
 
         let mat = world_to_model * size.screen_to_world();
 
-        let config_bg = shape
-            .config_bind_group(&gpu.device, &self.config_bind_group_layout);
+        bufs.copy_vars(gpu, shape.var_map(), vars)
+            .map_err(|e| match e {
+                CopyVarsError::BufferSize(b) => ColorError::VarBufferSize(b),
+                CopyVarsError::MissingVar(v) => ColorError::MissingVar(v),
+            })?;
+        bufs.copy_tape(gpu, shape.bytecode())
+            .map_err(ColorError::ConfigBufferSize)?;
+        bufs.copy_shape_starts(gpu, shape.shape_start())
+            .expect("shape starts should always fit if shape bytecode fits");
 
+        // We'll write the config last, because writing the tape could have
+        // invalidated it.
         let config = ColorConfig {
             mat: mat.data.as_slice().try_into().unwrap(),
             axes: shape.axes(),
             image_size: [size.width(), size.height()],
             _pad: 0,
         };
-        shape.write_config(&config, &gpu.queue);
-        shape.write_vars(vars, &gpu.queue)?;
+        bufs.copy_config(gpu, &config);
+
+        let config_bg =
+            bufs.config_bind_group(&gpu.device, &self.config_bind_group_layout);
 
         // Create a command encoder and dispatch the compute work
         let mut encoder = gpu.device.create_command_encoder(
@@ -1329,7 +1367,8 @@ impl ColorContext {
                     ],
                 });
             compute_pass.set_bind_group(1, &image_bg, &[]);
-            compute_pass.set_pipeline(self.color_pipeline.get(shape.reg_count));
+            compute_pass
+                .set_pipeline(self.color_pipeline.get(shape.reg_count()));
             compute_pass.dispatch_workgroups(
                 size.width().div_ceil(8),
                 size.height().div_ceil(8),
@@ -1509,14 +1548,6 @@ mod test {
         crate::test::compare_struct_layout::<BlurConfig>(
             &blur_shader(),
             "BlurConfig",
-        );
-    }
-
-    #[test]
-    fn color_config_size() {
-        assert_eq!(
-            std::mem::size_of::<ColorConfig>(),
-            ShapeColorBuffers::expected_config_size(),
         );
     }
 }

--- a/fidget-wgpu/src/voxel/mod.rs
+++ b/fidget-wgpu/src/voxel/mod.rs
@@ -2401,7 +2401,7 @@ impl ResetContext {
 #[cfg(test)]
 mod test {
     use super::{effects::PackedVoxel, *};
-    use crate::ShapeColor;
+    use crate::color::{ShapeColor, ShapeColorBuffers};
     use fidget_core::{context::Tree, vm::VmShape};
     use std::collections::HashSet;
 
@@ -2509,7 +2509,8 @@ mod test {
                 },
             })
             .collect::<Vec<_>>();
-        let shape_colors = gpu.color_buffers(&shape_colors).unwrap();
+        let shape_colors = ShapeColorBuffers::new(&shape_colors).unwrap();
+        let mut color_workspace = effects_ctx.color_workspace();
 
         // Compute SSAO buffer
         let mut ssao_buf = effects_ctx.ssao_buffers();
@@ -2521,6 +2522,7 @@ mod test {
                 &merge_buf,
                 &render_config.world_to_model,
                 &shape_colors,
+                &mut color_workspace,
                 &mut shade_buf,
             )
             .unwrap();
@@ -2546,6 +2548,7 @@ mod test {
                 &merge_buf,
                 &render_config.world_to_model,
                 &shape_colors,
+                &mut color_workspace,
                 &mut shade_buf,
             )
             .unwrap();


### PR DESCRIPTION
This lets us easily cache and reuse them.

A bunch of other changes came along for the ride:

- A new helper type for "config buffer with trailing data"
- A new `ColorWorkspace` object
- Moving `ShapeColorBuffers` into `fidget_wgpu::color`