### PR TITLE
Allow `FlexBuffer` to accept an `AsRef<str>`

### DIFF
--- a/fidget-wgpu/src/buf.rs
+++ b/fidget-wgpu/src/buf.rs
@@ -168,14 +168,14 @@ where
 impl<T: BufferTag> FlexBuffer<T> {
     pub(crate) fn new(
         device: &wgpu::Device,
-        name: String,
+        name: impl AsRef<str>,
         size: T::S,
     ) -> Result<Self, BufferSizeError> {
         Self::check_size(size)?;
         let size_bytes = Self::calculate_buffer_size(size);
         let usage = wgpu::BufferUsages::from_bits(T::usage()).unwrap();
         let data = device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some(name.as_str()),
+            label: Some(name.as_ref()),
             size: size_bytes,
             usage,
             mapped_at_creation: false,
@@ -183,7 +183,7 @@ impl<T: BufferTag> FlexBuffer<T> {
         Ok(Self {
             data,
             size,
-            name,
+            name: name.as_ref().to_owned(),
             _t: std::marker::PhantomData,
         })
     }

--- a/fidget-wgpu/src/color.rs
+++ b/fidget-wgpu/src/color.rs
@@ -47,13 +47,10 @@ where
     C: zerocopy::IntoBytes + zerocopy::Immutable + Copy,
 {
     pub(crate) fn new(device: &wgpu::Device) -> Self {
-        let config =
-            FlexBuffer::new(device, "color config".to_owned(), 4.into())
-                .unwrap();
+        let config = FlexBuffer::new(device, "color config", 4.into()).unwrap();
         let shape_start =
-            FlexBuffer::new(device, "shape start".to_owned(), 4usize).unwrap();
-        let vars_buf =
-            FlexBuffer::new(device, "color vars".to_owned(), 4usize).unwrap();
+            FlexBuffer::new(device, "shape start", 4usize).unwrap();
+        let vars_buf = FlexBuffer::new(device, "color vars", 4usize).unwrap();
         Self {
             config,
             shape_start,

--- a/fidget-wgpu/src/lib.rs
+++ b/fidget-wgpu/src/lib.rs
@@ -155,7 +155,7 @@ impl Gpu {
         let Ok(size) = 64u32.try_into() else {
             panic!("could not build size");
         };
-        buf::ReadBuffer::new(&self.device, name.to_owned(), size)
+        buf::ReadBuffer::new(&self.device, name, size)
             .expect("64 should always be a valid size for ReadBuffer::new")
     }
 

--- a/fidget-wgpu/src/pixel/effects/mod.rs
+++ b/fidget-wgpu/src/pixel/effects/mod.rs
@@ -330,16 +330,13 @@ impl Context {
         });
         let distance = FlexBuffer::new(
             &self.gpu.device,
-            "pixel merge distance".to_owned(),
+            "pixel merge distance",
             64.into(),
         )
         .unwrap();
-        let color = FlexBuffer::new(
-            &self.gpu.device,
-            "pixel merge color".to_owned(),
-            64.into(),
-        )
-        .unwrap();
+        let color =
+            FlexBuffer::new(&self.gpu.device, "pixel merge color", 64.into())
+                .unwrap();
         MergeBuffers {
             config,
             distance,

--- a/fidget-wgpu/src/pixel/mod.rs
+++ b/fidget-wgpu/src/pixel/mod.rs
@@ -463,17 +463,16 @@ impl Buffers {
         let render_size = TileRenderSize::from(image_size);
         let tile_tapes = FlexBuffer::new(
             device,
-            "tile tape".to_string(),
+            "tile tape",
             Self::tile_tapes_buf_size(render_size),
         )
         .unwrap();
 
-        let pixels =
-            FlexBuffer::new(device, "pixels".to_string(), image_size).unwrap();
+        let pixels = FlexBuffer::new(device, "pixels", image_size).unwrap();
 
         let tile64 = TileBuffers::new(device, render_size).unwrap();
         let tile8 = TileBuffers::new(device, render_size).unwrap();
-        let vars_buf = FlexBuffer::new(device, "vars".to_string(), 4).unwrap();
+        let vars_buf = FlexBuffer::new(device, "vars", 4).unwrap();
 
         Self {
             config_buf,

--- a/fidget-wgpu/src/voxel/effects/mod.rs
+++ b/fidget-wgpu/src/voxel/effects/mod.rs
@@ -484,12 +484,8 @@ impl Context {
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
-        let out = FlexBuffer::new(
-            &self.gpu.device,
-            "merge output".to_owned(),
-            64.into(),
-        )
-        .expect("64 is always a valid size");
+        let out = FlexBuffer::new(&self.gpu.device, "merge output", 64.into())
+            .expect("64 is always a valid size");
         MergeBuffers {
             config,
             out,
@@ -509,12 +505,8 @@ impl Context {
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
-        let out = FlexBuffer::new(
-            &self.gpu.device,
-            "shade output".to_owned(),
-            64.into(),
-        )
-        .expect("64 is always a valid size");
+        let out = FlexBuffer::new(&self.gpu.device, "shade output", 64.into())
+            .expect("64 is always a valid size");
         ShadeBuffers {
             config,
             has_color: false,
@@ -536,12 +528,9 @@ impl Context {
                 mapped_at_creation: false,
             });
         let image_size = 64.into();
-        let raw_occlusion = FlexBuffer::new(
-            &self.gpu.device,
-            "ssao raw occlusion".to_owned(),
-            image_size,
-        )
-        .expect("64 is always a valid size");
+        let raw_occlusion =
+            FlexBuffer::new(&self.gpu.device, "ssao raw occlusion", image_size)
+                .expect("64 is always a valid size");
         let blur_config =
             self.gpu.device.create_buffer(&wgpu::BufferDescriptor {
                 label: Some("blur config"),
@@ -552,7 +541,7 @@ impl Context {
             });
         let blurred_occlusion = FlexBuffer::new(
             &self.gpu.device,
-            "ssao blurred occlusion".to_owned(),
+            "ssao blurred occlusion",
             image_size,
         )
         .expect("64 is always a valid size");

--- a/fidget-wgpu/src/voxel/mod.rs
+++ b/fidget-wgpu/src/voxel/mod.rs
@@ -1724,19 +1724,18 @@ impl Buffers {
         let render_size = TileRenderSize::from(image_size);
         let voxels = FlexBuffer::new(
             device,
-            "voxels".to_string(),
+            "voxels",
             Self::voxels_buf_size(render_size),
         )
         .unwrap();
         let tile_tapes = FlexBuffer::new(
             device,
-            "tile tape".to_string(),
+            "tile tape",
             Self::tile_tapes_buf_size(render_size),
         )
         .unwrap();
 
-        let geom =
-            FlexBuffer::new(device, "geom".to_string(), image_size).unwrap();
+        let geom = FlexBuffer::new(device, "geom", image_size).unwrap();
 
         let tile64 = RootTileBuffers::new(device, render_size).unwrap();
         let tile16 = TileBuffers::new(device, render_size).unwrap();
@@ -1754,7 +1753,7 @@ impl Buffers {
             mapped_at_creation: false,
         });
 
-        let vars_buf = FlexBuffer::new(device, "vars".to_string(), 4).unwrap();
+        let vars_buf = FlexBuffer::new(device, "vars", 4).unwrap();
 
         Self {
             config_buf,


### PR DESCRIPTION
This removes a bunch of `to_owned` spam